### PR TITLE
feat(clangd): configurable LSP timeout + index-ready warm-up for cold UE-scale projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ vs-token-safer drives an official engine; install the one(s) you need:
 
 **clangd needs a compile database** (`compile_commands.json`):
 - **Unreal Engine:** generate via UBT — `<UE>/Engine/Build/BatchFiles/RunUBT … -mode=GenerateClangDatabase`.
+  - If your targets are configured to **build with clang-cl**, add **`-Compiler=VisualCpp`** — otherwise
+    `GenerateClangDatabase` fails clang-toolchain validation (`Unable to find valid <ver> C++ toolchain for
+    Clang x64`). The MSVC-compiler database still resolves the full engine include graph for clangd.
+  - The database is large (a full editor target ≈ tens of thousands of entries). On a **cold** index the
+    first query can be slow while clangd indexes the engine headers — see `VTS_LSP_TIMEOUT_MS` /
+    `VTS_LSP_INDEX_WAIT_MS` below, or keep the MCP server running so the index stays warm.
 - **CMake:** configure with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.
 
 **C# uses the official Visual Studio Roslyn engine automatically.** vs-token-safer auto-detects
@@ -123,6 +129,9 @@ Precedence: **environment variable (`VTS_*`) > `~/.vs-token-safer/config.json` >
 | `backend` | `VTS_BACKEND` | auto | `clangd` \| `roslyn` (auto-detected from the root) |
 | `maxResults` | `VTS_MAX_RESULTS` | `60` | Cap on returned `file:line` locations |
 | — | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | Override the clangd executable / args |
+| — | `VTS_LSP_TIMEOUT_MS` | `30000` | Per-request LSP timeout. Raise for a cold, large (e.g. UE) index |
+| — | `VTS_LSP_INDEX_WAIT_MS` | `120000` | How long the clangd warm-up waits for background-index completion before the first query |
+| — | `VTS_CLANGD_OPEN_CAP` | `100` | Max files the warm-up opens to prime clangd's index |
 | — | `VTS_ROSLYN_DLL` | auto | Path to a specific `Microsoft.CodeAnalysis.LanguageServer.dll` |
 | — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto (MS engine) → `csharp-ls` | Override the C# LSP executable / args |
 | — | `VTS_ENFORCE` | `1` | Set `0`/`false`/`off` to let Bash code-grep through (escape hatch) |
@@ -147,7 +156,7 @@ unavailable, set `VTS_ENFORCE=0` so grep isn't blocked.
 
 | Backend | Status | Notes |
 | --- | --- | --- |
-| `clangd` (C/C++) | ✅ live-verified | `search_symbol` / `find_references` / `goto_definition` confirmed against real clangd on a `compile_commands.json` project. Needs a **correct** compile DB (with include dirs — Unreal: generate via UBT) so system/3rd-party headers resolve; otherwise only header-free symbols index. VS ships clangd at `…/VC/Tools/Llvm/bin/clangd.exe`. |
+| `clangd` (C/C++) | ✅ live-verified | `search_symbol` / `find_references` / `goto_definition` confirmed against real clangd on a `compile_commands.json` project. Needs a **correct** compile DB (with include dirs — Unreal: generate via UBT) so system/3rd-party headers resolve; otherwise only header-free symbols index. Checked on a real Unreal 5.x project: clangd resolves the full engine include graph (engine base types + `*.generated.h`). On a **cold** UE-scale index the first query may need a raised `VTS_LSP_TIMEOUT_MS`. VS ships clangd at `…/VC/Tools/Llvm/bin/clangd.exe`. |
 | `roslyn` (C#/.NET) | ✅ live-verified | `search_symbol` / `find_references` / `goto_definition` confirmed against **Microsoft.CodeAnalysis.LanguageServer** (the actual VS engine) on a real `.csproj`. Auto-detected; `csharp-ls` fallback. |
 
 ---

--- a/eval/_mock-lsp.mjs
+++ b/eval/_mock-lsp.mjs
@@ -14,8 +14,15 @@ process.stdin.on("data", (d) => {
     const msg = JSON.parse(buf.slice(he + 4, he + 4 + len).toString("utf8"));
     buf = buf.slice(he + 4 + len);
     if (msg.method === "initialize") send({ jsonrpc: "2.0", id: msg.id, result: { capabilities: { workspaceSymbolProvider: true, referencesProvider: true } } });
-    else if (msg.method === "workspace/symbol") {
+    else if (msg.method === "initialized") {
+      // Simulate clangd's background-index work-done progress: a begin then an end notification.
+      // The clangd backend's afterInit waits for the kind:"end" before the first query.
+      send({ jsonrpc: "2.0", method: "$/progress", params: { token: "backgroundIndexProgress", value: { kind: "begin", title: "indexing" } } });
+      send({ jsonrpc: "2.0", method: "$/progress", params: { token: "backgroundIndexProgress", value: { kind: "end" } } });
+    } else if (msg.method === "workspace/symbol") {
       const q = (msg.params && msg.params.query) || "";
+      // "SLOW" delays past a short request timeout — exercises VTS_LSP_TIMEOUT_MS handling.
+      if (q === "SLOW") { setTimeout(() => send({ jsonrpc: "2.0", id: msg.id, result: [] }), 300); continue; }
       let result;
       if (q === "ALL") {
         // big result set with verbose container names — to exercise the token cap

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -35,6 +35,24 @@ const refOk = !r2.isError && /reference\(s\)/.test(r2.text);
 // 5) MCP=CLI parity: both go through runTool; the dispatch is the shared layer (smoke).
 const dispatchOk = lspOk && fmtOk && refOk;
 
+// 6) VTS_LSP_TIMEOUT_MS honored — a request slower than the configured timeout rejects (the cold
+// UE-scale fix: users can raise the ceiling instead of silently timing out at a hardcoded 30s).
+process.env.VTS_LSP_TIMEOUT_MS = "50";
+const ct = new LspClient(process.execPath, [process.env.VTS_CLANGD_ARGS], { cwd: process.cwd() });
+await ct.initialize(process.cwd());
+let timeoutHonored = false;
+try { await ct.symbol("SLOW"); } catch (e) { timeoutHonored = /timed out/.test(e.message); }
+await ct.shutdown();
+delete process.env.VTS_LSP_TIMEOUT_MS;
+
+// 7) index-ready signal — afterInit waits for clangd's background-index completion ($/progress
+// kind:end) before the first query, instead of racing the still-building index.
+const cp = new LspClient(process.execPath, [process.env.VTS_CLANGD_ARGS], { cwd: process.cwd() });
+await cp.initialize(process.cwd());
+const ready = await cp.waitForNotification("$/progress", 2000, (p) => p && p.value && p.value.kind === "end");
+await cp.shutdown();
+const indexReadyOk = !!ready;
+
 await disposeClients();
 
 const rows = [
@@ -44,6 +62,8 @@ const rows = [
   ["token reduction vs raw index", (capReduction * 100).toFixed(1) + "%", "≥ 70%", capReduction >= 0.7],
   ["references wiring", refOk, "true", refOk],
   ["runTool dispatch", dispatchOk, "true", dispatchOk],
+  ["VTS_LSP_TIMEOUT_MS honored", timeoutHonored, "true", timeoutHonored],
+  ["index-ready ($/progress end) wait", indexReadyOk, "true", indexReadyOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -37,13 +37,16 @@ const dispatchOk = lspOk && fmtOk && refOk;
 
 // 6) VTS_LSP_TIMEOUT_MS honored — a request slower than the configured timeout rejects (the cold
 // UE-scale fix: users can raise the ceiling instead of silently timing out at a hardcoded 30s).
-process.env.VTS_LSP_TIMEOUT_MS = "50";
+// Set the env only AROUND the slow request — not during initialize (the handshake would race a 50ms cap).
 const ct = new LspClient(process.execPath, [process.env.VTS_CLANGD_ARGS], { cwd: process.cwd() });
 await ct.initialize(process.cwd());
 let timeoutHonored = false;
-try { await ct.symbol("SLOW"); } catch (e) { timeoutHonored = /timed out/.test(e.message); }
+try {
+  process.env.VTS_LSP_TIMEOUT_MS = "50"; // mock delays "SLOW" 300ms → request() default timeout (50ms) rejects
+  await ct.symbol("SLOW");
+} catch (e) { timeoutHonored = /timed out/.test(e.message); }
+finally { delete process.env.VTS_LSP_TIMEOUT_MS; }
 await ct.shutdown();
-delete process.env.VTS_LSP_TIMEOUT_MS;
 
 // 7) index-ready signal — afterInit waits for clangd's background-index completion ($/progress
 // kind:end) before the first query, instead of racing the still-building index.

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -7,7 +7,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { toUri } from "../lsp.js";
+import { toUri, envInt } from "../lsp.js";
 
 const env = (name, def) => { const v = process.env[name]; return v && v !== "" ? v : def; };
 const splitArgs = (s) => (s ? s.split(/\s+/).filter(Boolean) : null);
@@ -108,9 +108,18 @@ export const BACKENDS = {
         try { files = JSON.parse(fs.readFileSync(cc, "utf8")).map((e) => e.file).filter(Boolean); } catch { /* ignore */ }
       }
       const extra = findAllShallow(root, /\.(c|cc|cxx|cpp|h|hpp|hh|inl)$/i, 2);
-      const open = [...new Set([...files, ...extra])].slice(0, 100); // cap for huge trees
+      const open = [...new Set([...files, ...extra])].slice(0, envInt("VTS_CLANGD_OPEN_CAP", 100)); // cap for huge trees
       for (const f of open) client.didOpen(f, "cpp");
-      if (open.length) await client.waitForNotification("textDocument/publishDiagnostics", 30000);
+      if (open.length) {
+        // On a huge tree (e.g. a cold UE-scale index) the dynamic index isn't ready when the first
+        // file's diagnostics fire, so waiting on diagnostics alone races the still-building index and
+        // the first query times out. Prefer clangd's background-index completion ($/progress kind:end),
+        // bounded by VTS_LSP_INDEX_WAIT_MS; fall back to diagnostics if the server emits no work-done
+        // progress (older clangd / a server without that capability).
+        const idxWait = envInt("VTS_LSP_INDEX_WAIT_MS", 120000);
+        const indexed = await client.waitForNotification("$/progress", idxWait, (p) => p && p.value && p.value.kind === "end");
+        if (!indexed) await client.waitForNotification("textDocument/publishDiagnostics", Math.min(idxWait, 30000));
+      }
     },
   },
   // C#/.NET via a Roslyn-based LSP. Preferred engine: Microsoft.CodeAnalysis.LanguageServer (the exact

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -118,6 +118,8 @@ export const BACKENDS = {
         // progress (older clangd / a server without that capability).
         const idxWait = envInt("VTS_LSP_INDEX_WAIT_MS", 120000);
         const indexed = await client.waitForNotification("$/progress", idxWait, (p) => p && p.value && p.value.kind === "end");
+        // Fallback only for a server that emits no work-done progress (clangd always does). idxWait was
+        // already spent above, so this is a short "did the first file parse?" check, not a second full wait.
         if (!indexed) await client.waitForNotification("textDocument/publishDiagnostics", Math.min(idxWait, 30000));
       }
     },

--- a/server/lsp.js
+++ b/server/lsp.js
@@ -10,6 +10,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL, fileURLToPath } from "node:url";
 
+// Positive-integer env override, else default. Used so huge-project users (e.g. a cold UE-scale clangd
+// index) can raise the per-request timeout instead of hitting the hardcoded 30s ceiling.
+export const envInt = (name, def) => { const v = parseInt(process.env[name], 10); return Number.isFinite(v) && v > 0 ? v : def; };
+
 export const toUri = (p) => pathToFileURL(path.resolve(p)).href;
 export const fromUri = (u) => {
   try { return fileURLToPath(u); } catch { return u.replace(/^file:\/\//, ""); }
@@ -121,7 +125,7 @@ export class LspClient {
     });
   }
 
-  request(method, params, timeoutMs = 30000) {
+  request(method, params, timeoutMs = envInt("VTS_LSP_TIMEOUT_MS", 30000)) {
     const id = this.nextId++;
     this._send({ jsonrpc: "2.0", id, method, params });
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## What
Make the clangd backend usable on a **cold, UE-scale** `compile_commands.json` index.

## Why (from real-project verification)
Against a real Unreal 5.x project: clangd parses a game TU fine (`clangd --check` ~19s, resolves the full engine include graph — engine base types + `*.generated.h`). But in LSP-server mode the cold `--background-index` saturates the AST worker indexing thousands of engine headers, so the first `workspace/symbol` / `definition` exceeded the **hardcoded 30s** `request()` timeout and the one-shot CLI returned nothing. The engine works; the glue's fixed timeout + warm-up were the gap.

## Changes
- **`VTS_LSP_TIMEOUT_MS`** — per-request LSP timeout now env-configurable (default 30000).
- **clangd `afterInit`** waits for background-index completion (`$/progress` kind:end), bounded by **`VTS_LSP_INDEX_WAIT_MS`** (default 120000), with a `publishDiagnostics` fallback for servers without work-done progress.
- **`VTS_CLANGD_OPEN_CAP`** — warm-up open-file cap now configurable (default 100).
- **eval**: mock LSP emits `$/progress` + a slow path; two new guards assert the timeout is honored and the index-ready wait resolves (now 8/8).
- **docs**: README env table + Unreal **`-Compiler=VisualCpp`** requirement (clang-cl targets) and cold-index note.

## Review points
- `afterInit` prefers `$/progress` end over racing first-diagnostics — correct readiness signal on huge trees; fallback path for older clangd.
- No company/proprietary data: verification used synthetic descriptions only; eval uses the mock LSP.

## Follow-up (separate)
- `vts warmup` command to build a **persistent** on-disk clangd index so later one-shot CLI queries are warm/instant — the proper UX for huge trees.

Closes #3