### PR TITLE
dev → main: real-UE clangd support — recommend clangd ≥22 (fixes 19.1.x deadlock), configurable LSP timeout, gamedev bundle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,16 +53,20 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   clangd indexes async → `afterInit` (`backends/index.js`) opens the compile_commands TUs + nearby
   headers (cap 100) and waits for `textDocument/publishDiagnostics` before the first query. CAVEAT: a
   compile DB without include dirs → system/3rd-party headers fail to resolve → only header-free symbols
-  index; UBT-generated DBs include the paths. **✅ real UE 5.x project checked (clang-cl-configured):**
-  `GenerateClangDatabase` needs **`-Compiler=VisualCpp`** override — targets set up to build with clang-cl
-  otherwise fail clang-toolchain validation (`Unable to find valid <ver> C++ toolchain for Clang x64`);
-  with the override → `Result: Succeeded`, ~26k-entry DB. `clangd --check` on a game TU (~19s) resolves
-  the **full engine include graph** (engine base types + `*.generated.h` land in the index cache) →
-  caveat confirmed on real source. KNOWN LIMIT: on a UE-scale **cold** index, LSP-server queries can
-  exceed the 30s `request()` timeout — `--background-index` saturates the AST worker indexing thousands
-  of engine headers and starves the first query; the engine parses fine (`--check` proves it), but a
-  one-shot CLI query needs a warm/persistent index or a higher timeout. Follow-up: make the LSP request
-  timeout env-configurable (`VTS_LSP_TIMEOUT_MS`) + optionally wait for index-ready on huge trees.
+  index; UBT-generated DBs include the paths. **✅ real UE 5.x project live-verified end-to-end**
+  (`search_symbol` returned the game `UCLASS` + its `*.generated.h` symbols as `file:line`):
+  - `GenerateClangDatabase` needs **`-Compiler=VisualCpp`** when the targets build with clang-cl — else
+    clang-toolchain validation fails (`Unable to find valid <ver> C++ toolchain for Clang x64`). Override
+    → `Result: Succeeded`, ~26k-entry DB.
+  - **CLANGD VERSION MATTERS (root cause of the long stall hunt).** VS-bundled clangd **19.1.5 DEADLOCKS**
+    on a real UE TU in LSP-server mode: `clangd --check` parses it in ~19s, but every async path (didOpen
+    *and* background-index) never finishes (>250s, 0 symbols). **Standalone clangd 22.1.6 parses the same
+    TU in ~13s and returns symbols.** So it's an upstream clangd 19.x bug, not a vts/glue bug. Fix: use
+    clangd ≥ `MIN_CLANGD` (22) — `backends/index.js` probes `clangd --version` and `core.js` prepends a
+    one-time advisory if it's older. Isolation proved engine headers (CoreMinimal, GameplayTagContainer)
+    parse fine; only the full game-TU header chain trips 19.x.
+  - Secondary tuning for cold/large indexes: `VTS_LSP_TIMEOUT_MS` (request timeout), `VTS_LSP_INDEX_WAIT_MS`
+    (afterInit waits for `$/progress` index-ready), `VTS_CLANGD_OPEN_CAP` (warm-up open cap).
 - **roslyn** (C#/.NET): `.sln/.csproj`. **✅ live-verified** against **Microsoft.CodeAnalysis.LanguageServer**
   (the real VS / C# Dev Kit engine), auto-detected from the VS Code C# extension bundle + its net10
   runtime; opens the workspace via `solution/open`/`project/open` then waits for

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ vs-token-safer drives an official engine; install the one(s) you need:
 
 | Backend | Language | Engine | Install | Needs |
 | --- | --- | --- | --- | --- |
-| `clangd` | C/C++ | clangd (LLVM) | [LLVM releases](https://github.com/clangd/clangd/releases) or your package manager | `compile_commands.json` |
+| `clangd` | C/C++ | clangd (LLVM) — **use clangd ≥ 22** ([clangd releases](https://github.com/clangd/clangd/releases)); the clangd 19.1.x bundled with Visual Studio can deadlock on Unreal | [clangd releases](https://github.com/clangd/clangd/releases) or your package manager | `compile_commands.json` |
 | `roslyn` | C#/.NET | **Microsoft.CodeAnalysis.LanguageServer** (the engine Visual Studio / the C# Dev Kit use), `csharp-ls` fallback | install the **VS Code C# extension** (`ms-dotnettools.csharp`) — bundles the engine + its runtime; or `dotnet tool install --global csharp-ls` | `.sln` / `.csproj` |
 
 **clangd needs a compile database** (`compile_commands.json`):
@@ -77,6 +77,10 @@ vs-token-safer drives an official engine; install the one(s) you need:
   - If your targets are configured to **build with clang-cl**, add **`-Compiler=VisualCpp`** — otherwise
     `GenerateClangDatabase` fails clang-toolchain validation (`Unable to find valid <ver> C++ toolchain for
     Clang x64`). The MSVC-compiler database still resolves the full engine include graph for clangd.
+  - **Use clangd ≥ 22.** The clangd 19.1.x bundled with Visual Studio (`…/VC/Tools/Llvm/bin/clangd.exe`)
+    **deadlocks** indexing real UE translation units in server mode (`clangd --check` parses them, but
+    queries never return). Standalone clangd 22.1.6 handles the same project in seconds and returns
+    symbols. Point `VTS_CLANGD_CMD` at a current clangd; vts warns if it detects an older one.
   - The database is large (a full editor target ≈ tens of thousands of entries). On a **cold** index the
     first query can be slow while clangd indexes the engine headers — see `VTS_LSP_TIMEOUT_MS` /
     `VTS_LSP_INDEX_WAIT_MS` below, or keep the MCP server running so the index stays warm.
@@ -156,7 +160,7 @@ unavailable, set `VTS_ENFORCE=0` so grep isn't blocked.
 
 | Backend | Status | Notes |
 | --- | --- | --- |
-| `clangd` (C/C++) | ✅ live-verified | `search_symbol` / `find_references` / `goto_definition` confirmed against real clangd on a `compile_commands.json` project. Needs a **correct** compile DB (with include dirs — Unreal: generate via UBT) so system/3rd-party headers resolve; otherwise only header-free symbols index. Checked on a real Unreal 5.x project: clangd resolves the full engine include graph (engine base types + `*.generated.h`). On a **cold** UE-scale index the first query may need a raised `VTS_LSP_TIMEOUT_MS`. VS ships clangd at `…/VC/Tools/Llvm/bin/clangd.exe`. |
+| `clangd` (C/C++) | ✅ live-verified (incl. real Unreal 5.x) | `search_symbol` / `find_references` / `goto_definition` confirmed against real clangd on a `compile_commands.json` project, **including a real Unreal 5.x game project end-to-end** (returned the game `UCLASS` + its `*.generated.h` symbols). Needs a **correct** compile DB (with include dirs — Unreal: generate via UBT, `-Compiler=VisualCpp` for clang-cl targets). **Use clangd ≥ 22** — the VS-bundled clangd 19.1.x (`…/VC/Tools/Llvm/bin/clangd.exe`) deadlocks on real UE TUs; vts warns if it detects an older one. Cold UE-scale indexes: raise `VTS_LSP_TIMEOUT_MS` / `VTS_LSP_INDEX_WAIT_MS`. |
 | `roslyn` (C#/.NET) | ✅ live-verified | `search_symbol` / `find_references` / `goto_definition` confirmed against **Microsoft.CodeAnalysis.LanguageServer** (the actual VS engine) on a real `.csproj`. Auto-detected; `csharp-ls` fallback. |
 
 ---

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ vs-token-safer drives an official engine; install the one(s) you need:
 
 **clangd needs a compile database** (`compile_commands.json`):
 - **Unreal Engine:** generate via UBT — `<UE>/Engine/Build/BatchFiles/RunUBT … -mode=GenerateClangDatabase`.
+  - If your targets are configured to **build with clang-cl**, add **`-Compiler=VisualCpp`** — otherwise
+    `GenerateClangDatabase` fails clang-toolchain validation (`Unable to find valid <ver> C++ toolchain for
+    Clang x64`). The MSVC-compiler database still resolves the full engine include graph for clangd.
+  - The database is large (a full editor target ≈ tens of thousands of entries). On a **cold** index the
+    first query can be slow while clangd indexes the engine headers — see `VTS_LSP_TIMEOUT_MS` /
+    `VTS_LSP_INDEX_WAIT_MS` below, or keep the MCP server running so the index stays warm.
 - **CMake:** configure with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.
 
 **C# uses the official Visual Studio Roslyn engine automatically.** vs-token-safer auto-detects
@@ -123,6 +129,9 @@ Precedence: **environment variable (`VTS_*`) > `~/.vs-token-safer/config.json` >
 | `backend` | `VTS_BACKEND` | auto | `clangd` \| `roslyn` (auto-detected from the root) |
 | `maxResults` | `VTS_MAX_RESULTS` | `60` | Cap on returned `file:line` locations |
 | — | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | Override the clangd executable / args |
+| — | `VTS_LSP_TIMEOUT_MS` | `30000` | Per-request LSP timeout. Raise for a cold, large (e.g. UE) index |
+| — | `VTS_LSP_INDEX_WAIT_MS` | `120000` | How long the clangd warm-up waits for background-index completion before the first query |
+| — | `VTS_CLANGD_OPEN_CAP` | `100` | Max files the warm-up opens to prime clangd's index |
 | — | `VTS_ROSLYN_DLL` | auto | Path to a specific `Microsoft.CodeAnalysis.LanguageServer.dll` |
 | — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto (MS engine) → `csharp-ls` | Override the C# LSP executable / args |
 | — | `VTS_ENFORCE` | `1` | Set `0`/`false`/`off` to let Bash code-grep through (escape hatch) |
@@ -147,7 +156,7 @@ unavailable, set `VTS_ENFORCE=0` so grep isn't blocked.
 
 | Backend | Status | Notes |
 | --- | --- | --- |
-| `clangd` (C/C++) | ✅ live-verified | `search_symbol` / `find_references` / `goto_definition` confirmed against real clangd on a `compile_commands.json` project. Needs a **correct** compile DB (with include dirs — Unreal: generate via UBT) so system/3rd-party headers resolve; otherwise only header-free symbols index. VS ships clangd at `…/VC/Tools/Llvm/bin/clangd.exe`. |
+| `clangd` (C/C++) | ✅ live-verified | `search_symbol` / `find_references` / `goto_definition` confirmed against real clangd on a `compile_commands.json` project. Needs a **correct** compile DB (with include dirs — Unreal: generate via UBT) so system/3rd-party headers resolve; otherwise only header-free symbols index. Checked on a real Unreal 5.x project: clangd resolves the full engine include graph (engine base types + `*.generated.h`). On a **cold** UE-scale index the first query may need a raised `VTS_LSP_TIMEOUT_MS`. VS ships clangd at `…/VC/Tools/Llvm/bin/clangd.exe`. |
 | `roslyn` (C#/.NET) | ✅ live-verified | `search_symbol` / `find_references` / `goto_definition` confirmed against **Microsoft.CodeAnalysis.LanguageServer** (the actual VS engine) on a real `.csproj`. Auto-detected; `csharp-ls` fallback. |
 
 ---

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -12,7 +12,8 @@ Steps:
 1. **Show current settings:** call `vts_config`.
 2. **Detect/confirm the backend.** Backend auto-detects from the project root:
    - C/C++ → needs `compile_commands.json` in (or under) the root → **clangd**. Unreal: generate via
-     UBT `-mode=GenerateClangDatabase`; CMake: `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.
+     UBT `-mode=GenerateClangDatabase` (add **`-Compiler=VisualCpp`** if the targets build with clang-cl,
+     else clang-toolchain validation fails); CMake: `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.
    - C#/.NET → a `.sln`/`.csproj` → **roslyn** (default engine `csharp-ls`; install with
      `dotnet tool install --global csharp-ls`, or point `VTS_ROSLYN_CMD` at MS C# LSP).
 3. **Gather values** (ask one at a time, or an `AskUserQuestion` for the common ones):
@@ -27,6 +28,9 @@ Notes:
 - Precedence is **environment variable (`VTS_*`) > config file > default**; a same-named env var wins.
 - Shell alternative: `vts setup --projectPath <root> --backend clangd`, then `vts config`.
 - Engine overrides: `VTS_CLANGD_CMD`/`VTS_CLANGD_ARGS`, `VTS_ROSLYN_CMD`/`VTS_ROSLYN_ARGS`.
+- Cold/large (e.g. UE) index: raise `VTS_LSP_TIMEOUT_MS` (default 30000) and `VTS_LSP_INDEX_WAIT_MS`
+  (default 120000) so the first query doesn't time out while clangd indexes engine headers; tune the
+  warm-up open set with `VTS_CLANGD_OPEN_CAP` (default 100).
 - Never write internal project paths or symbol names into any public/shared location.
 
 $ARGUMENTS

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -14,6 +14,8 @@ Steps:
    - C/C++ → needs `compile_commands.json` in (or under) the root → **clangd**. Unreal: generate via
      UBT `-mode=GenerateClangDatabase` (add **`-Compiler=VisualCpp`** if the targets build with clang-cl,
      else clang-toolchain validation fails); CMake: `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.
+     **Use clangd ≥ 22** — the VS-bundled clangd 19.1.x deadlocks indexing Unreal TUs; if vts prints a
+     clangd-version advisory, point `VTS_CLANGD_CMD` at a current clangd (https://github.com/clangd/clangd/releases).
    - C#/.NET → a `.sln`/`.csproj` → **roslyn** (default engine `csharp-ls`; install with
      `dotnet tool install --global csharp-ls`, or point `VTS_ROSLYN_CMD` at MS C# LSP).
 3. **Gather values** (ask one at a time, or an `AskUserQuestion` for the common ones):

--- a/eval/_mock-lsp.mjs
+++ b/eval/_mock-lsp.mjs
@@ -14,8 +14,15 @@ process.stdin.on("data", (d) => {
     const msg = JSON.parse(buf.slice(he + 4, he + 4 + len).toString("utf8"));
     buf = buf.slice(he + 4 + len);
     if (msg.method === "initialize") send({ jsonrpc: "2.0", id: msg.id, result: { capabilities: { workspaceSymbolProvider: true, referencesProvider: true } } });
-    else if (msg.method === "workspace/symbol") {
+    else if (msg.method === "initialized") {
+      // Simulate clangd's background-index work-done progress: a begin then an end notification.
+      // The clangd backend's afterInit waits for the kind:"end" before the first query.
+      send({ jsonrpc: "2.0", method: "$/progress", params: { token: "backgroundIndexProgress", value: { kind: "begin", title: "indexing" } } });
+      send({ jsonrpc: "2.0", method: "$/progress", params: { token: "backgroundIndexProgress", value: { kind: "end" } } });
+    } else if (msg.method === "workspace/symbol") {
       const q = (msg.params && msg.params.query) || "";
+      // "SLOW" delays past a short request timeout — exercises VTS_LSP_TIMEOUT_MS handling.
+      if (q === "SLOW") { setTimeout(() => send({ jsonrpc: "2.0", id: msg.id, result: [] }), 300); continue; }
       let result;
       if (q === "ALL") {
         // big result set with verbose container names — to exercise the token cap

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -35,6 +35,24 @@ const refOk = !r2.isError && /reference\(s\)/.test(r2.text);
 // 5) MCP=CLI parity: both go through runTool; the dispatch is the shared layer (smoke).
 const dispatchOk = lspOk && fmtOk && refOk;
 
+// 6) VTS_LSP_TIMEOUT_MS honored — a request slower than the configured timeout rejects (the cold
+// UE-scale fix: users can raise the ceiling instead of silently timing out at a hardcoded 30s).
+process.env.VTS_LSP_TIMEOUT_MS = "50";
+const ct = new LspClient(process.execPath, [process.env.VTS_CLANGD_ARGS], { cwd: process.cwd() });
+await ct.initialize(process.cwd());
+let timeoutHonored = false;
+try { await ct.symbol("SLOW"); } catch (e) { timeoutHonored = /timed out/.test(e.message); }
+await ct.shutdown();
+delete process.env.VTS_LSP_TIMEOUT_MS;
+
+// 7) index-ready signal — afterInit waits for clangd's background-index completion ($/progress
+// kind:end) before the first query, instead of racing the still-building index.
+const cp = new LspClient(process.execPath, [process.env.VTS_CLANGD_ARGS], { cwd: process.cwd() });
+await cp.initialize(process.cwd());
+const ready = await cp.waitForNotification("$/progress", 2000, (p) => p && p.value && p.value.kind === "end");
+await cp.shutdown();
+const indexReadyOk = !!ready;
+
 await disposeClients();
 
 const rows = [
@@ -44,6 +62,8 @@ const rows = [
   ["token reduction vs raw index", (capReduction * 100).toFixed(1) + "%", "≥ 70%", capReduction >= 0.7],
   ["references wiring", refOk, "true", refOk],
   ["runTool dispatch", dispatchOk, "true", dispatchOk],
+  ["VTS_LSP_TIMEOUT_MS honored", timeoutHonored, "true", timeoutHonored],
+  ["index-ready ($/progress end) wait", indexReadyOk, "true", indexReadyOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -37,13 +37,16 @@ const dispatchOk = lspOk && fmtOk && refOk;
 
 // 6) VTS_LSP_TIMEOUT_MS honored — a request slower than the configured timeout rejects (the cold
 // UE-scale fix: users can raise the ceiling instead of silently timing out at a hardcoded 30s).
-process.env.VTS_LSP_TIMEOUT_MS = "50";
+// Set the env only AROUND the slow request — not during initialize (the handshake would race a 50ms cap).
 const ct = new LspClient(process.execPath, [process.env.VTS_CLANGD_ARGS], { cwd: process.cwd() });
 await ct.initialize(process.cwd());
 let timeoutHonored = false;
-try { await ct.symbol("SLOW"); } catch (e) { timeoutHonored = /timed out/.test(e.message); }
+try {
+  process.env.VTS_LSP_TIMEOUT_MS = "50"; // mock delays "SLOW" 300ms → request() default timeout (50ms) rejects
+  await ct.symbol("SLOW");
+} catch (e) { timeoutHonored = /timed out/.test(e.message); }
+finally { delete process.env.VTS_LSP_TIMEOUT_MS; }
 await ct.shutdown();
-delete process.env.VTS_LSP_TIMEOUT_MS;
 
 // 7) index-ready signal — afterInit waits for clangd's background-index completion ($/progress
 // kind:end) before the first query, instead of racing the still-building index.

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -56,6 +56,17 @@ const ready = await cp.waitForNotification("$/progress", 2000, (p) => p && p.val
 await cp.shutdown();
 const indexReadyOk = !!ready;
 
+// 8) clangd version advisory — parse the major version and gate on the recommended floor (older
+// clangd deadlocks on large UE projects; ≥ MIN_CLANGD is the verified-good floor).
+// Dynamic import: static would load backends/index.js (capturing BACKENDS.clangd.cmd) before the
+// VTS_CLANGD_CMD env above is set; by here core.js has already loaded it with the mock cmd in place.
+const { parseClangdMajor, MIN_CLANGD } = await import("../server/backends/index.js");
+const verParseOk = parseClangdMajor("clangd version 19.1.5") === 19
+  && parseClangdMajor("clangd version 22.1.6 (https://github.com/llvm/llvm-project abc123)") === 22
+  && parseClangdMajor("not a version") === null;
+const verGateOk = MIN_CLANGD >= 22 && 19 < MIN_CLANGD && 22 >= MIN_CLANGD;
+const advisoryOk = verParseOk && verGateOk;
+
 await disposeClients();
 
 const rows = [
@@ -67,6 +78,7 @@ const rows = [
   ["runTool dispatch", dispatchOk, "true", dispatchOk],
   ["VTS_LSP_TIMEOUT_MS honored", timeoutHonored, "true", timeoutHonored],
   ["index-ready ($/progress end) wait", indexReadyOk, "true", indexReadyOk],
+  ["clangd version advisory + gate", advisoryOk, "true", advisoryOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -4,6 +4,7 @@
 //
 // Each backend is { cmd, args(root), detect(root) }. cmd/args are overridable via config/env
 // (VTS_<NAME>_CMD / VTS_<NAME>_ARGS) so users can point at their own clangd / csharp-ls / MS C# LSP.
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -11,6 +12,33 @@ import { toUri, envInt } from "../lsp.js";
 
 const env = (name, def) => { const v = process.env[name]; return v && v !== "" ? v : def; };
 const splitArgs = (s) => (s ? s.split(/\s+/).filter(Boolean) : null);
+
+// clangd ≥ this is recommended for large Unreal projects. Older clangd (notably the 19.1.x bundled with
+// Visual Studio) can DEADLOCK indexing real UE translation units in LSP-server mode — clangd --check
+// parses the same TU fine, but every async path (didOpen + background-index) never finishes. Verified:
+// VS-bundled clangd 19.1.5 deadlocks (>250s, 0 symbols); standalone clangd 22.1.6 parses it in ~13s and
+// returns symbols. See https://github.com/clangd/clangd/releases for a current build.
+export const MIN_CLANGD = 22;
+export function parseClangdMajor(versionText) {
+  const m = /clangd version (\d+)/i.exec(String(versionText || ""));
+  return m ? parseInt(m[1], 10) : null;
+}
+// Run `<cmd> --version` once and return the major version (or null if it can't be determined).
+let _clangdMajorCache;
+export function clangdMajor(cmd) {
+  if (_clangdMajorCache !== undefined) return _clangdMajorCache;
+  try { _clangdMajorCache = parseClangdMajor(execFileSync(cmd, ["--version"], { encoding: "utf8", timeout: 10000 })); }
+  catch { _clangdMajorCache = null; }
+  return _clangdMajorCache;
+}
+// One-line advisory if the resolved clangd is older than recommended; "" otherwise. Best-effort: a
+// clangd we can't version-probe (null) is left alone rather than nagged.
+export function clangdAdvisory(cmd) {
+  const major = clangdMajor(cmd);
+  if (major != null && major < MIN_CLANGD)
+    return `⚠ clangd ${major}.x detected — clangd ≥ ${MIN_CLANGD} is recommended for large Unreal/C++ projects. Older clangd (e.g. the 19.1.x bundled with Visual Studio) can hang indexing UE translation units. Point VTS_CLANGD_CMD at a newer clangd (https://github.com/clangd/clangd/releases).`;
+  return "";
+}
 
 // Collect every file (up to `depth`) whose name matches `re` — used to open all .csproj for Roslyn.
 function findAllShallow(root, re, depth = 2) {

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -7,7 +7,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { toUri } from "../lsp.js";
+import { toUri, envInt } from "../lsp.js";
 
 const env = (name, def) => { const v = process.env[name]; return v && v !== "" ? v : def; };
 const splitArgs = (s) => (s ? s.split(/\s+/).filter(Boolean) : null);
@@ -108,9 +108,18 @@ export const BACKENDS = {
         try { files = JSON.parse(fs.readFileSync(cc, "utf8")).map((e) => e.file).filter(Boolean); } catch { /* ignore */ }
       }
       const extra = findAllShallow(root, /\.(c|cc|cxx|cpp|h|hpp|hh|inl)$/i, 2);
-      const open = [...new Set([...files, ...extra])].slice(0, 100); // cap for huge trees
+      const open = [...new Set([...files, ...extra])].slice(0, envInt("VTS_CLANGD_OPEN_CAP", 100)); // cap for huge trees
       for (const f of open) client.didOpen(f, "cpp");
-      if (open.length) await client.waitForNotification("textDocument/publishDiagnostics", 30000);
+      if (open.length) {
+        // On a huge tree (e.g. a cold UE-scale index) the dynamic index isn't ready when the first
+        // file's diagnostics fire, so waiting on diagnostics alone races the still-building index and
+        // the first query times out. Prefer clangd's background-index completion ($/progress kind:end),
+        // bounded by VTS_LSP_INDEX_WAIT_MS; fall back to diagnostics if the server emits no work-done
+        // progress (older clangd / a server without that capability).
+        const idxWait = envInt("VTS_LSP_INDEX_WAIT_MS", 120000);
+        const indexed = await client.waitForNotification("$/progress", idxWait, (p) => p && p.value && p.value.kind === "end");
+        if (!indexed) await client.waitForNotification("textDocument/publishDiagnostics", Math.min(idxWait, 30000));
+      }
     },
   },
   // C#/.NET via a Roslyn-based LSP. Preferred engine: Microsoft.CodeAnalysis.LanguageServer (the exact

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -118,6 +118,8 @@ export const BACKENDS = {
         // progress (older clangd / a server without that capability).
         const idxWait = envInt("VTS_LSP_INDEX_WAIT_MS", 120000);
         const indexed = await client.waitForNotification("$/progress", idxWait, (p) => p && p.value && p.value.kind === "end");
+        // Fallback only for a server that emits no work-done progress (clangd always does). idxWait was
+        // already spent above, so this is a short "did the first file parse?" check, not a second full wait.
         if (!indexed) await client.waitForNotification("textDocument/publishDiagnostics", Math.min(idxWait, 30000));
       }
     },

--- a/server/core.js
+++ b/server/core.js
@@ -10,7 +10,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { LspClient, fromUri } from "./lsp.js";
-import { pickBackend, BACKENDS } from "./backends/index.js";
+import { pickBackend, BACKENDS, clangdAdvisory } from "./backends/index.js";
 
 const CONFIG_DIR = path.join(os.homedir(), ".vs-token-safer");
 export const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(CONFIG_DIR, "config.json");
@@ -84,6 +84,16 @@ export async function disposeClients() {
   clients.clear();
 }
 
+// Surface a one-time advisory if the resolved clangd is too old (older clangd deadlocks on large UE
+// projects — see backends/index.js MIN_CLANGD). Shown once per process, prepended to the first result.
+let _advisoryShown = false;
+function backendAdvisory(backendName) {
+  if (backendName !== "clangd" || _advisoryShown) return "";
+  const a = clangdAdvisory(BACKENDS.clangd.cmd);
+  if (a) _advisoryShown = true;
+  return a ? a + "\n\n" : "";
+}
+
 // ---- token-capping formatters: LSP results → compact file:line (no bodies) ----
 const locLine = (uri, range) => `${fromUri(uri).replace(/\\/g, "/")}:${(range.start.line + 1)}`;
 function fmtSymbols(syms, max) {
@@ -133,20 +143,21 @@ export async function runTool(name, a = {}) {
       if (!a.q) return err("search_symbol needs q (the symbol name/substring).");
       const c = await getClient(root, backendName);
       const syms = (await c.symbol(String(a.q))) || [];
-      if (!syms.length) return finishOut([], `No symbols matching "${a.q}" (backend: ${backendName}).`);
-      return finishOut(syms, `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root}):\n` + fmtSymbols(syms, max));
+      const adv = backendAdvisory(backendName);
+      if (!syms.length) return finishOut([], adv + `No symbols matching "${a.q}" (backend: ${backendName}).`);
+      return finishOut(syms, adv + `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root}):\n` + fmtSymbols(syms, max));
     }
     if (name === "find_references") {
       if (!a.path || a.line == null || a.character == null) return err("find_references needs path, line, character (0-based position of the symbol).");
       const c = await getClient(root, backendName);
       const locs = (await c.references(a.path, Number(a.line), Number(a.character), a.includeDeclaration === true)) || [];
-      return finishOut(locs, `references of ${a.path}:${Number(a.line) + 1} (backend: ${backendName}):\n` + fmtLocations(locs, max, "reference(s)"));
+      return finishOut(locs, backendAdvisory(backendName) + `references of ${a.path}:${Number(a.line) + 1} (backend: ${backendName}):\n` + fmtLocations(locs, max, "reference(s)"));
     }
     if (name === "goto_definition") {
       if (!a.path || a.line == null || a.character == null) return err("goto_definition needs path, line, character (0-based position).");
       const c = await getClient(root, backendName);
       const locs = (await c.definition(a.path, Number(a.line), Number(a.character))) || [];
-      return finishOut(locs, `definition of ${a.path}:${Number(a.line) + 1} (backend: ${backendName}):\n` + fmtLocations(locs, max, "definition(s)"));
+      return finishOut(locs, backendAdvisory(backendName) + `definition of ${a.path}:${Number(a.line) + 1} (backend: ${backendName}):\n` + fmtLocations(locs, max, "definition(s)"));
     }
     return err(`Unknown tool: ${name}`);
   } catch (e) {

--- a/server/lsp.js
+++ b/server/lsp.js
@@ -10,6 +10,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL, fileURLToPath } from "node:url";
 
+// Positive-integer env override, else default. Used so huge-project users (e.g. a cold UE-scale clangd
+// index) can raise the per-request timeout instead of hitting the hardcoded 30s ceiling.
+export const envInt = (name, def) => { const v = parseInt(process.env[name], 10); return Number.isFinite(v) && v > 0 ? v : def; };
+
 export const toUri = (p) => pathToFileURL(path.resolve(p)).href;
 export const fromUri = (u) => {
   try { return fileURLToPath(u); } catch { return u.replace(/^file:\/\//, ""); }
@@ -121,7 +125,7 @@ export class LspClient {
     });
   }
 
-  request(method, params, timeoutMs = 30000) {
+  request(method, params, timeoutMs = envInt("VTS_LSP_TIMEOUT_MS", 30000)) {
     const id = this.nextId++;
     this._send({ jsonrpc: "2.0", id, method, params });
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Integration PR from `dev`. Lands real-Unreal clangd support proven this session.

## Headline finding
The long cold-index stall on a real Unreal 5.x project was **an upstream clangd 19.x bug**, not a vts/glue bug:
- VS-bundled clangd **19.1.5 deadlocks** indexing a real UE TU in LSP-server mode — `clangd --check` parses it in ~19s, but didOpen **and** background-index never finish (>250s, 0 symbols).
- Standalone clangd **22.1.6 parses the same TU in ~13s**, and `search_symbol` returns the game UCLASS + its `*.generated.h` symbols as `file:line`. ✅ end-to-end on real UE.

## Changes
- **clangd ≥ 22 recommendation + advisory**: `backends/index.js` probes `clangd --version` (`parseClangdMajor`/`clangdMajor`, `MIN_CLANGD=22`); `core.js` prepends a one-time warning when an older clangd is resolved.
- **`-Compiler=VisualCpp`** documented for clang-cl UE targets (else `GenerateClangDatabase` fails clang-toolchain validation).
- **Configurable LSP knobs**: `VTS_LSP_TIMEOUT_MS`, `VTS_LSP_INDEX_WAIT_MS` (afterInit waits for `$/progress` index-ready), `VTS_CLANGD_OPEN_CAP`.
- **gamedev-log-analyzer** bundled as a 2nd marketplace plugin.
- **eval**: 9/9 (added timeout-honored, index-ready, clangd-version-gate guards); stable across runs.
- **docs**: README prerequisites/matrix, CLAUDE.md backends, setup.md.

## Verification
- eval 9/9; advisory warns on real clangd 19.1.5, silent on real 22.1.6.
- Isolation: engine headers (CoreMinimal, GameplayTagContainer) parse fine under 19.x; only the full game-TU chain trips it → upstream clangd bug.
- No proprietary data committed (synthetic descriptions only; eval uses the mock LSP).

## Follow-up (separate)
- Optional `ccls` secondary backend / `vts warmup` persistent index — not needed now that clangd ≥22 works.

Closes #3