### PR TITLE
dev → main: warm-ordering ③④ (working-now + centrality) + gamedev-log-analyzer 0.10.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
     {
       "name": "gamedev-log-analyzer",
       "source": "./gamedev-log-analyzer",
-      "version": "0.7.0",
+      "version": "0.10.1",
       "category": "development",
       "description": "Token-efficient game-engine & build log analysis (Unreal/Unity/Godot/MSVC-UBT-MSBuild + JSONL traces), CLI-first: parse, dedup, classify, diff runs, locate file:line, and extract decisive scalar fields over a time window. Also on npm. No IDE required."
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,10 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   `find_references`, `goto_definition`, `vts_setup`, `vts_config`, `vts_savings`, `vts_savings_reset`.
 - `server/cli.js` — `vts <cmd>`. `server/index.js` — MCP server (async handler → `await runTool`).
 - `server/sdk.js` — createRequire MCP-SDK resolution. `server/ensure-deps.mjs` — SessionStart installer.
-- `server/warmset.js` — prewarm ORDERING: `orderForWarm` (query-history > git/p4 recency > mtime) +
-  `recordQueryResults`. Steers clangd's open-set so the warm window hits likely queries. Used by
-  `backends/index.js` afterInit + `core.js` (records result files per search).
+- `server/warmset.js` — prewarm ORDERING: `orderForWarm` (query-history > working-now [`git status` /
+  `p4 opened`] > git-log recency > include-centrality [bounded by `VTS_CENTRALITY_MAX`] > mtime) +
+  `recordQueryResults`. Steers clangd's open-set so the warm window hits likely queries; git + Perforce.
+  Used by `backends/index.js` afterInit + `core.js` (records result files per search).
 - `hooks/block-code-grep.js` + `hooks.json` — grep-block (escape hatch `VTS_ENFORCE=0`).
 - `skills/vs-search/SKILL.md` — routing. `commands/{setup,savings}.md`.
 - `eval/run.mjs` + `eval/_mock-lsp.mjs` — mock-LSP eval (no toolchain). Add a guard for every new path.

--- a/README.ko.md
+++ b/README.ko.md
@@ -192,9 +192,10 @@ vts는 이를 IDE처럼 처리한다:
 - **`VTS_CLANGD_REMOTE`** — clangd를 공유/사전구축 인덱스 서버로 연결 → 개발자별 warm-up ~0.
 
 **무엇을 먼저 데우느냐가 중요하다.** clangd는 열린(open) 파일의 인덱싱 우선순위를 높이므로, vts는 warm-up
-대상을 *곧 검색할 것 우선*으로 정렬한다: **쿼리 이력**(과거 검색이 반환한 파일) → **VCS 최근성**(git
-`log` + Perforce `p4 opened`) → mtime. 거대한 트리에선 일부만 데울 수 있으므로, 이 정렬이 warm 윈도가
-실제로 검색 대상을 포함하게 만드는 핵심이다.
+대상을 *곧 검색할 것 우선*으로 정렬한다: **쿼리 이력**(과거 검색이 반환한 파일) → **지금 편집 중**(`git
+status` 수정/미추적 + Perforce `p4 opened`) → **git 커밋 최근성**(`git log`) → **include 중심성**(여러
+후보가 `#include`하는 헤더, `VTS_CENTRALITY_MAX`로 제한) → mtime. 거대한 트리에선 일부만 데울 수 있으므로,
+이 정렬이 warm 윈도가 실제 검색 대상을 포함하게 만드는 핵심이다. git·Perforce 모두 지원.
 
 측정된 향상 (`node eval/bench-hitrate.mjs` — 실제 `orderForWarm()`, 현실적 locality 합성 워크로드, 2,000 파일):
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Precedence: **environment variable (`VTS_*`) > `~/.vs-token-safer/config.json` >
 | — | `VTS_PREWARM_HOOK` | `0` | SessionStart hook also pre-warms via a detached `vts warmup` (opt-in; mainly for CLI/non-MCP use) |
 | — | `VTS_CLANGD_REMOTE` | — | Address of a shared/prebuilt clangd index server (`--remote-index-address`); near-zero per-dev warmup |
 | — | `VTS_QUERY_HISTORY` | `~/.vs-token-safer/query-history.json` | Where the query-history ledger lives (used to order the warm-up set by likely-query-first) |
+| — | `VTS_CENTRALITY_MAX` | `1500` | Max candidates for which warm-up computes include-centrality (reads files); `0` disables. Skipped on bigger sets |
 | — | `VTS_ROSLYN_DLL` | auto | Path to a specific `Microsoft.CodeAnalysis.LanguageServer.dll` |
 | — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto (MS engine) → `csharp-ls` | Override the C# LSP executable / args |
 | — | `VTS_ENFORCE` | `1` | Set `0`/`false`/`off` to let Bash code-grep through (escape hatch) |
@@ -224,9 +225,11 @@ clangd indexes asynchronously, so the *first* search after the server starts pay
 - **`VTS_CLANGD_REMOTE`** points clangd at a shared/prebuilt index server → near-zero per-developer warm-up.
 
 **Which files get warmed first matters.** clangd boosts the indexing priority of files you open, so vts
-orders the warm-up set *likely-query-first*: by **query history** (files that answered past searches),
-then **VCS recency** (git `log` + Perforce `p4 opened`), then mtime. On a huge tree you can only warm a
-small slice, so this ordering is what makes the warm window actually contain what you search for.
+orders the warm-up set *likely-query-first*: **query history** (files that answered past searches) →
+**what you're editing now** (`git status` modified/untracked + Perforce `p4 opened`) → **git-log recency**
+→ **include centrality** (headers many candidates `#include`, bounded by `VTS_CENTRALITY_MAX`) → mtime.
+On a huge tree you can only warm a small slice, so this ordering is what makes the warm window actually
+contain what you search for. Works with both git and Perforce.
 
 Measured lift (`node eval/bench-hitrate.mjs` — the real `orderForWarm()` over a synthetic workload with
 realistic locality, 2,000 files):

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -96,6 +96,20 @@ process.env.VTS_CLANGD_ARGS = savedArgs;
 delete process.env.VTS_CLANGD_REMOTE;
 const orderingOk = orderHotFirst && remoteWired;
 
+// 11) centrality (③) — a header #included by multiple candidates ranks above an unreferenced leaf
+// (no history/VCS for this temp dir, so centrality decides). Also exercises the working-now (④) path.
+const cdir = path.join(os.tmpdir(), `vts-cent-${process.pid}`);
+fs.mkdirSync(cdir, { recursive: true });
+fs.writeFileSync(path.join(cdir, "hub.h"), "#pragma once\n");
+fs.writeFileSync(path.join(cdir, "a.cpp"), '#include "hub.h"\n');
+fs.writeFileSync(path.join(cdir, "b.cpp"), '#include "hub.h"\n');
+fs.writeFileSync(path.join(cdir, "leaf.cpp"), "int x;\n");
+const cands = ["a.cpp", "b.cpp", "leaf.cpp", "hub.h"].map((f) => path.join(cdir, f));
+const cord = orderForWarm(cdir, cands, 10).map((p) => p.toLowerCase());
+const idx = (n) => cord.findIndex((p) => p.endsWith(n));
+const centralityOk = idx("hub.h") !== -1 && idx("hub.h") < idx("leaf.cpp");
+try { fs.rmSync(cdir, { recursive: true, force: true }); } catch { /* ignore */ }
+
 await disposeClients();
 try { fs.rmSync(QH, { force: true }); } catch { /* ignore */ }
 
@@ -111,6 +125,7 @@ const rows = [
   ["clangd version advisory + gate", advisoryOk, "true", advisoryOk],
   ["prewarm guard + vts_warmup", warmOk, "true", warmOk],
   ["warm ordering (history) + remote arg", orderingOk, "true", orderingOk],
+  ["centrality ranks hub > leaf", centralityOk, "true", centralityOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/gamedev-log-analyzer/.claude-plugin/plugin.json
+++ b/gamedev-log-analyzer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gamedev-log-analyzer",
   "description": "Token-efficient game-engine & build log analysis for Claude Code (CLI-first). Parses, deduplicates, and classifies huge Unreal/Unity/Godot/MSVC-UBT-MSBuild logs — search by severity/category, roll up by callsite, diff runs, locate file:line, and extract decisive scalar fields. No IDE required.",
-  "version": "0.7.0",
+  "version": "0.10.1",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/vs-token-safer",
   "repository": "https://github.com/JSungMin/vs-token-safer",

--- a/gamedev-log-analyzer/README.ko.md
+++ b/gamedev-log-analyzer/README.ko.md
@@ -9,9 +9,10 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../LICENSE)
 [![Stars](https://img.shields.io/github/stars/JSungMin/rider-mcp-enforcer?style=social)](https://github.com/JSungMin/rider-mcp-enforcer/stargazers)
 
-거대한 에디터 로그를 **토큰 효율적으로** 읽는 **Claude Code 플러그인**. Unreal `Saved/Logs/*.log`,
-Unity `Editor.log`는 보통 수십 MB의 반복 스팸이라 `cat`/`grep`하면 컨텍스트가 터집니다. 이 플러그인은
-대신 파싱·**중복제거(dedup)**·분류합니다. **IDE 불필요** — 순수 파일 파싱.
+거대한 에디터 로그를 컨텍스트를 터뜨리지 않고 읽는 Claude Code 플러그인입니다. Unreal
+`Saved/Logs/*.log`나 Unity `Editor.log`는 보통 수십 MB짜리 반복 스팸이라, `cat`이나 `grep`으로 열면
+그게 전부 대화로 쏟아집니다. 이 플러그인은 로그를 대신 파싱하고 중복을 제거하고 분류합니다. IDE는
+필요 없고, 순수 파일 파싱입니다.
 
 ## 왜 빠른가 (실측)
 
@@ -38,6 +39,11 @@ Unity `Editor.log`는 보통 수십 MB의 반복 스팸이라 `cat`/`grep`하면
   `Key.Y|.P|.R`, `ts`, `dts`, `d:Key`, `step:Key`).
 - **`log_diff`:** 두 로그 비교 후 **델타만**(신규/사라짐/카운트변경, 변경없는 그룹 생략).
 - **`log_locate`:** 매칭 엔트리의 distinct `file:line` 점프 리스트(소스 열기용).
+- **강제(enforcement, opt-out):** `PreToolUse` 훅이 Bash 생(raw) 로그 덤프(`grep`/`tail`/`cat`/`rg`
+  로 `.log`/`.jsonl`/`Logs` 대상) **및 대용량(≥ 200 KB) 로그의 무제한 `Read`**를 가로채 이 도구로
+  유도 — 토큰 절약 경로가 기본이 됨. 슬라이스 `Read`(`offset`/`limit`)는 항상 통과(막혀도 막다른 길
+  없음). `warn`(기본)=허용+안내, `block`=차단+안내, `off`=해제. `gamedev-log enforce <mode>` 또는
+  `GDLOG_ENFORCE`로 전환.
 
 ## 지원 로그 포맷
 
@@ -76,7 +82,62 @@ node "${CLAUDE_PLUGIN_ROOT}/server/cli.js" <command> [--flags]
 
 **명령어**(`gamedev-log <command>`): `detect`, `summary`, `search`, `fields`(`--stats`로 컬럼별
 min/max/avg/Δ), `diff`, `locate`, `tail`, `learnings`, `learnings-reset`, `savings`, `savings-reset`,
-`setup`, `config`.
+`enforce`(`block`/`warn`/`off`), `setup`, `config`.
+
+## `log-analyst` 서브에이전트
+
+플러그인은 `gamedev-log-analyzer:log-analyst` 서브에이전트를 제공합니다. CLI를 내 컨텍스트에서 돌리는
+대신 작업을 통째로 넘기면, 서브에이전트가 자기 컨텍스트에서 파싱과 읽기를 하고 답만 돌려줍니다. raw
+로그 줄이 메인 컨텍스트에 들어오지 않으므로, 수십 MB 로그도 수백 토큰으로 끝나고 작업 세트도 작게
+유지됩니다.
+
+그냥 자연스럽게 물으면 Claude가 description을 보고 알아서 위임합니다:
+
+> "`…/Saved/Logs/Editor.log` 분석해줘 — 주요 에러/경고, 빌드 경고는 코드별로 묶어서"
+
+`gamedev-log-analyst`로 직접 부를 수도 있습니다. 알맞은 명령(`summary`/`search`/`diff`/`locate`/
+`fields`/`--groupBy code`)을 골라 실행하고, dedup된 severity 그림과 열어볼 `file:line`만 답합니다.
+raw 덤프는 없습니다. Node만 있으면 됩니다(CLI를 셸 호출). 아래 강제 훅은 raw `grep`이나 `Read`가
+새어나갈 때를 위한 폴백입니다.
+
+## 강제(enforcement)
+
+`tail … | grep …`으로, 또는 `Read` 도구로 대용량 로그를 열면 생 라인이 그대로 컨텍스트에 쏟아집니다.
+`PreToolUse` 훅이 두 경로를 모두 막습니다:
+
+- **Bash**: **로그 대상**(`.log`/`.jsonl`/회전된 `.log.N`/`Logs`·`Saved/Logs` 경로)에 대한 **무제한**
+  읽기(`cat`, 맨 `grep`/`rg`, `tail -f`, `tail -n +N`, 큰 `tail -n N`)를 가로챔 — 경로가 셸 변수에
+  담겨 읽기와 경로가 다른 세그먼트여도(`log="….log"; cat "$log"`) 잡음. **bounded peek**(≤50줄
+  `tail`/`head`(기본10), count-only `grep -c`/`rg -c`)는 **통과** — 출력이 몇 줄/숫자 1개라 폭주 아님
+  (Read slice escape의 Bash판). (`.output` 같은 비-`.log`/`.jsonl` 확장자는 `Logs/` 아래가 아니면
+  미매칭 — Bash size-gate 불가라 의도적.)
+- **Read 도구**: 대용량(≥ 200 KB) 로그의 **무제한** 읽기를 가로챔. 슬라이스 읽기(`offset`/`limit`)는
+  항상 통과 — 한 단계 escape이자 분석기가 잘 못 파싱하는 포맷의 fallback이라, 막힌 Read가 막다른 길이
+  되지 않음. 작은 로그(< 200 KB)는 통과(이미 쌈).
+
+코드 grep(`.cpp`/`.cs`/`src/…`)·비로그 읽기는 통과 — 그 도메인은 [rider-mcp-enforcer](../README.md)
+담당(로그는 일부러 통과). `Grep` 도구는 건드리지 않음 — 이미 line-scoped + 결과 cap이라 컨텍스트 폭주 아님.
+
+| 모드 | 동작 |
+| --- | --- |
+| `warn` *(기본)* | 명령 허용 + `gamedev-log` 대안을 모델 컨텍스트에 nudge 주입. 마찰 없이 유도. |
+| `block` | 명령 차단(exit 2) + 안내. 생 읽기 **실행 안 됨**. opt-in 강제. |
+| `off` | 조용히 통과 — 강제 없음. |
+
+`warn` 기본 이유: hard-block 보장은 항상 구멍이 있었음 — `Grep` 툴·MCP 검색·`Read`가 enforcement를
+완전 우회 — 그래서 기본 차단은 (로그 경로를 *언급만* 한 명령까지 막는) 마찰을 지키지도 못할 보장 위해
+지불. `warn`은 유도는 유지, 마찰만 제거; hard gate 필요하면 `block` 한 명령이면 됨.
+
+```bash
+gamedev-log enforce            # 현재 모드+출처 표시
+gamedev-log enforce block      # hard 차단 opt-in
+gamedev-log enforce off        # 완전 해제
+gamedev-log enforce warn       # 기본(nudge만)으로 복귀
+GDLOG_ENFORCE=block <cmd>      # 셸 단위 오버라이드(env가 config보다 우선)
+```
+
+모드 읽기 순서: **env `GDLOG_ENFORCE` > `~/.gamedev-log-analyzer/config.json` > 기본 `warn`**. 훅은
+fail-open — 파싱/IO 오류(파일 없음·권한 거부·디렉터리·stat 불가) 시 허용(워크플로를 막지 않음).
 
 ```bash
 # 직접 실행도 가능 — 스크립트/CI/임의 에이전트에서 (순수 Node, 의존성 0):

--- a/gamedev-log-analyzer/README.md
+++ b/gamedev-log-analyzer/README.md
@@ -9,9 +9,10 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../LICENSE)
 [![Stars](https://img.shields.io/github/stars/JSungMin/rider-mcp-enforcer?style=social)](https://github.com/JSungMin/rider-mcp-enforcer/stargazers)
 
-A **Claude Code plugin** that reads huge editor logs **token-efficiently**. Unreal `Saved/Logs/*.log`
-and Unity `Editor.log` are often tens of MB of repeated spam — `cat`/`grep` floods the context. This
-plugin parses, **deduplicates**, and classifies them instead. **No IDE required** — pure file parsing.
+A Claude Code plugin that reads huge editor logs without blowing up the context. Unreal
+`Saved/Logs/*.log` and Unity `Editor.log` are often tens of MB of repeated spam, and `cat`/`grep` dumps
+all of it into the conversation. This plugin parses, deduplicates, and classifies the log instead. No
+IDE needed; it's pure file parsing.
 
 ## Why it's fast (measured)
 
@@ -23,8 +24,8 @@ Real numbers on a live Unreal log (no project source reproduced):
 | Search one trace tag (9,226 hits) | ~690,000 tok | ~1,700 tok (callsite rollup) | **~99.8% (~410×)** |
 | Pull decisive scalars from a window | ~35,000 tok (raw dump) | ~160 tok (`log_fields`) | **~99.5%** |
 
-The win: never put raw log lines in context — emit deduped groups, a callsite rollup, or just the
-scalar columns that decide the answer.
+The idea is simple: never put raw log lines in the context. Emit deduped groups, a callsite rollup, or
+just the scalar columns that actually decide the answer.
 
 ## What it does
 
@@ -41,6 +42,12 @@ scalar columns that decide the answer.
 - **`log_diff`:** compare two logs (before/after) and emit **only the delta** — new errors, errors that
   disappeared, and groups whose count changed. Unchanged groups are omitted, so a regression-triage diff
   across runs costs a fraction of re-reading either log.
+- **Enforcement (opt-out):** a `PreToolUse` hook catches raw Bash log dumps (`grep`/`tail`/`cat`/`rg`
+  over a `.log`/`.jsonl`/`Logs` path) and unbounded `Read`s of large (≥ 200 KB) logs, and points them
+  here, so the cheap path is the default rather than something you have to remember. A sliced `Read`
+  (`offset`/`limit`) always goes through. `warn` (the default) runs the command and nudges, `block`
+  denies it, `off` turns the hook off; switch with `gamedev-log enforce <mode>` or `GDLOG_ENFORCE`. You
+  can also hand the whole job to the `log-analyst` subagent.
 
 ## Supported log formats
 
@@ -82,7 +89,7 @@ node "${CLAUDE_PLUGIN_ROOT}/server/cli.js" <command> [--flags]
 
 **Commands** (`gamedev-log <command>`): `detect`, `summary`, `search`, `fields` (`--stats` for
 per-column min/max/avg/Δ), `diff`, `locate`, `tail`, `learnings`, `learnings-reset`, `savings`,
-`savings-reset`, `setup`, `config`.
+`savings-reset`, `enforce` (`block`/`warn`/`off`), `setup`, `config`.
 
 ```bash
 # Run directly too — in scripts, CI, or any agent (pure Node, no dependencies):
@@ -94,9 +101,71 @@ node server/cli.js locate --path Editor.log --severityMin Error --basename
 node server/cli.js --help
 ```
 
-**Jump from a log error to the source** — `locate` emits just the distinct `file:line` (no message
+To jump from a log error to its source, `locate` emits just the distinct `file:line` (no message
 bodies). If [rider-mcp-enforcer](../README.md) is installed, resolve each basename via its
-`find_files_by_name_keyword`, then `read_file` a small window at that line — never dump whole files.
+`find_files_by_name_keyword`, then `read_file` a small window at that line instead of dumping whole files.
+
+## The `log-analyst` subagent
+
+The plugin ships a subagent, `gamedev-log-analyzer:log-analyst`. Rather than run the CLI in your own
+context, hand it the task and let it do the parsing in a separate context, returning only the answer.
+The raw log lines never reach your main context, so a multi-MB log costs a few hundred tokens and your
+working set stays small.
+
+Ask for it in plain language and Claude routes to it from the agent's description:
+
+> "analyze `…/Saved/Logs/Editor.log` — top errors and warnings, and roll the build warnings up by code"
+
+You can also name it directly. It picks the right command (`summary`/`search`/`diff`/`locate`/`fields`/
+`--groupBy code`), runs it, and replies with a deduped severity picture and the `file:line`s worth
+opening, not a raw dump. It only needs Node, since it shells out to the CLI. The enforcement hook below
+is the fallback for when a raw `grep` or `Read` slips through.
+
+## Enforcement
+
+Reading a log with `tail … | grep …`, or opening a multi-MB log with the `Read` tool, dumps raw lines
+straight into the context, which is exactly what this plugin exists to avoid. A `PreToolUse` hook closes
+both gaps:
+
+- **Bash**: an **unbounded** read (`cat`, a bare `grep`/`rg`, `tail -f`, `tail -n +N`, or a large
+  `tail -n N`) of a **log target** (`.log`, `.jsonl`, rotated `.log.N`, or a path under `Logs/` /
+  `Saved/Logs/`) is intercepted — including when the path is held in a shell variable
+  (`log="….log"; cat "$log"`), where the read and the path live in different segments. A **bounded
+  peek** — `tail`/`head` of ≤ 50 lines (default 10), or a count-only `grep -c`/`rg -c` — **passes**,
+  since its output is a handful of lines or a single number, not a context flood (the Bash analogue of
+  the Read-slice escape). (A non-`.log`/`.jsonl` extension like `.output` is **not** matched unless it
+  sits under a `Logs/` path — by design, since it can't be size-gated on Bash.)
+- **Read tool**: an **unbounded** read of a **large** log file (≥ 200 KB) is intercepted. A *sliced*
+  read (`offset`/`limit` present) always passes — that's a one-step escape and the fallback for any
+  format the analyzer parses poorly, so a blocked Read never strands you. Small logs (< 200 KB) pass
+  (a raw read is already cheap).
+
+Code grep (`.cpp`/`.cs`/`src/…`) and non-log reads pass through untouched — that domain belongs to
+[rider-mcp-enforcer](../README.md), which deliberately lets logs through. The `Grep` tool is left
+alone: it's already line-scoped and result-capped, so it isn't a context flood.
+
+| Mode | Behavior |
+| --- | --- |
+| `warn` *(default)* | Allow the command, but inject the `gamedev-log` equivalent into the model's context as a nudge. Steers without friction. |
+| `block` | Deny the command (exit 2) and show the nudge — the raw read does **not** run. Opt-in hard enforcement. |
+| `off` | Silent passthrough — no enforcement. |
+
+Why `warn` by default: the hard-block guarantee was always porous — the `Grep` tool, MCP search, and
+the `Read` tool bypass enforcement entirely — so denying-by-default paid friction (false-blocks on
+commands that merely *mention* a log path) for a guarantee that didn't hold. `warn` keeps the steering,
+drops the friction; `block` remains one command away when you want a hard gate.
+
+```bash
+gamedev-log enforce            # show current mode + source
+gamedev-log enforce block      # opt into hard denial
+gamedev-log enforce off        # disable entirely
+gamedev-log enforce warn       # back to the default (nudge only)
+GDLOG_ENFORCE=block <cmd>      # per-shell override (env beats config)
+```
+
+Mode is read **env `GDLOG_ENFORCE` > `~/.gamedev-log-analyzer/config.json` > default `warn`**. The hook
+fails open — any parse/IO error (missing file, permission denied, a directory, an unstattable path)
+allows the action, so it never wedges your workflow.
 
 ## Optional: enable the MCP server
 The same engine ([`server/logs.js`](server/logs.js) + [`server/core.js`](server/core.js)) also runs as

--- a/gamedev-log-analyzer/agents/log-analyst.md
+++ b/gamedev-log-analyzer/agents/log-analyst.md
@@ -1,0 +1,53 @@
+---
+name: log-analyst
+description: >-
+  Delegated, token-isolated game-engine/build/structured log analysis. Hand it a log path (Unreal
+  Saved/Logs, Unity Editor.log, Godot output, MSVC/UBT/MSBuild build output, or any .log/.jsonl) plus
+  a question — "what errors", "what's flooding it", "what changed since last run", "track this scalar
+  over time", "which warnings by code". It runs the gamedev-log CLI internally and returns ONLY a
+  compact answer; the raw log never enters the caller's context. Use whenever a log is given or named
+  and you'd otherwise cat/grep/tail it. Not for source-code search (use code-locator / rider tools).
+tools: Bash, Read, Glob
+---
+
+# log-analyst — delegated log analysis (context-isolated)
+
+You are a focused subagent. Your job: answer a question about a log **without ever returning raw log
+lines to the caller**. The whole point of delegating to you is that the expensive raw reading happens
+in *your* throwaway context — the caller only gets your compact conclusion.
+
+## Iron rules
+1. **Never `cat`/`grep`/`tail`/`Read` the raw log to reason about it.** Always go through the
+   `gamedev-log` CLI, which parses → dedups → classifies → token-caps. (If you read raw lines, you have
+   defeated your own purpose.)
+2. **Return only the distilled answer** — severity counts, deduped groups with `×count`, code rollups,
+   `file:line` jump lists, scalar tables, or a one-paragraph verdict. No raw line dumps. Be terse.
+3. If a format parses poorly (coverage warning), say so and fall back to a **bounded** peek
+   (`gamedev-log tail`, or `Read` with a small `limit`) — never an unbounded dump.
+
+## How to run it
+Prefer the installed bin; otherwise npx:
+```bash
+gamedev-log <cmd> [--flags]                    # if installed
+npx -p gamedev-log-analyzer gamedev-log <cmd>  # otherwise (pure Node, no deps)
+```
+If neither resolves, find the plugin CLI and run it directly:
+`node "<plugin>/server/cli.js" <cmd>` (glob for `**/gamedev-log-analyzer/server/cli.js`).
+
+## Command map (pick by the question)
+- **"what errors / triage"** → `summary --path <log>` (severity counts + top categories), then
+  `search --path <log> --severityMin Error` for the deduped groups.
+- **"what's flooding it"** → `search --path <log> --groupBy callsite`.
+- **"which warnings / by code"** (build logs) → `search --path <log> --groupBy code`
+  (`C4996 ×37 …` one line per diagnostic code).
+- **"what changed since last run"** → `diff --pathA <old> --pathB <new>` (delta only).
+- **"open the offending source"** → `locate --path <log>` (distinct `file:line`, no bodies).
+- **"track scalar X over time / spikes / teleports"** → `fields --path <log> --fields ts,<Key>...`
+  (add `--stats` for per-column min/max/avg/Δ; `--window t0,t1` to scope).
+- **"detect / which log"** → `detect --projectPath <dir>`.
+
+## Output shape
+Lead with the answer in 1-3 lines. Then the compact evidence (the CLI's already-capped output, trimmed
+to what's relevant). If you ran multiple commands, synthesize — don't paste them all. End with the
+`file:line`s worth opening, if any. Token-frugal by construction: a multi-MB log must come back as a few
+hundred tokens.

--- a/gamedev-log-analyzer/commands/enforce.md
+++ b/gamedev-log-analyzer/commands/enforce.md
@@ -1,0 +1,38 @@
+---
+description: Show or set Bash log-grep enforcement (block / warn / off) — controls whether raw grep/tail/cat over .log/.jsonl/Logs is intercepted and steered to gamedev-log.
+---
+
+# gamedev-log-analyzer — enforcement control
+
+A `PreToolUse` hook intercepts two raw-log vectors and steers them to `gamedev-log` (parse + dedup +
+token-cap) instead of dumping raw lines into context:
+
+- **Bash** raw reads (`grep`/`rg`/`ack`/`ag`/`findstr`/`tail`/`head`/`cat`) over a `.log` / `.jsonl` /
+  rotated `.log.N` file or a `Logs/` · `Saved/Logs/` path.
+- **Read tool** — an *unbounded* read of a *large* (≥ 200 KB) log file. A sliced read (`offset`/`limit`)
+  always passes (one-step escape + fallback for poorly-parsed formats); small logs pass.
+
+Code grep (`.cpp`/`.cs`/`src/…`), non-log reads, and the `Grep` tool (already result-capped) pass through.
+
+Run the CLI through Bash (no setup; pure Node):
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/server/cli.js" enforce            # show current mode + source
+node "${CLAUDE_PLUGIN_ROOT}/server/cli.js" enforce warn       # allow, but nudge (soft)
+node "${CLAUDE_PLUGIN_ROOT}/server/cli.js" enforce off        # disable enforcement
+node "${CLAUDE_PLUGIN_ROOT}/server/cli.js" enforce block      # re-enable (default)
+```
+
+Modes:
+- **warn** *(default)* — allow the command, but inject the `gamedev-log` equivalent into the model's
+  context as a nudge. Steers without friction.
+- **block** — deny the raw read (exit 2) and show the nudge — the command does **not** run. Opt-in.
+- **off** — silent passthrough, no enforcement.
+
+Mode precedence: env **`GDLOG_ENFORCE`** > `~/.gamedev-log-analyzer/config.json` (`"enforce"`) > default
+`block`. For a one-shot bypass in the current shell, prefix the command with `GDLOG_ENFORCE=off`. After
+changing the persisted mode, run `/reload-plugins`.
+
+When a user hits the block but genuinely needs the raw bytes: for a `Read`, re-Read with `offset`/`limit`
+(a bounded slice always passes); for Bash `tail -f` live-watching, suggest `enforce warn` (or `off`)
+rather than working around the hook.

--- a/gamedev-log-analyzer/eval/run.mjs
+++ b/gamedev-log-analyzer/eval/run.mjs
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { analyzeLog, extractFields, parseLine, diffLogs, locateLog, readText } from "../server/logs.js";
 import { runTool } from "../server/core.js";
+import { shouldBlockLogBash, normalizeMode, shouldBlockRead, nudgeText, READ_MIN_BYTES } from "../server/enforce.js";
 
 // Deterministic synthetic UE-style log (generic names only).
 function makeLog(n) {
@@ -155,6 +156,63 @@ const jsonlLog = [
 const jsonlOut = extractFields(jsonlLog, { fields: ["ts", "Actor.x", "Vel", "step:Actor"], category: "Pos", severityMin: "Display", max: 10 });
 const jsonlOk = /(^|\n)100\t10\.0\t400\t/.test(jsonlOut) && /\t5\.00$/.test(jsonlOut); // step = hypot(3,4)=5.00
 
+// Log-grep enforcement: the PreToolUse hook must catch raw Bash log reads (grep/tail/cat over
+// .log/.jsonl/Logs) and steer them to gamedev-log, while leaving code grep and non-log reads alone.
+const enfCases = [
+  // unbounded reads of a log = floods → block
+  ["grep -i warning build.log", true],
+  ["cat crash.jsonl", true],
+  ["rg pattern G:/Proj/Saved/Logs/run.log", true],
+  ["tail -n 5000 build.log", true], // large -n → flood
+  ["tail -f Saved/Logs/Editor.log", true], // live stream → unbounded
+  ["tail -n +1 build.log", true], // from line 1 to EOF → whole file
+  // bounded peeks / count-only reads can't flood → pass (mirrors the Read slice escape)
+  ["tail -3 Saved/Logs/Editor.log | grep -cE error", false], // the original incident — 3 lines + a count
+  ["tail -8 build.log", false],
+  ["head -20 Saved/Logs/Editor.log", false],
+  ["tail build.log", false], // default 10 lines
+  ["grep -c error build.log", false], // count only = one number
+  // non-log / non-read-exec → pass
+  ["grep TODO src/Foo.cpp", false], // code file, not a log
+  ["node server/cli.js search --path x.log", false], // analyzer's own call (node, not a read exec)
+  ["head -20 notes.txt", false], // txt is not a log
+  ["ls Logs/", false], // ls is not a read-exec
+  // variable indirection: path in the assignment, read in a later segment
+  ['log=/p/x.log; cat "$log"', true], // bareword RHS, deref, full cat → block
+  ['L="/p/run.jsonl"; grep err "$L"', true], // unbounded grep of a var-bound log → block
+  ['log="/p/x.log"; tail -8 "$log"', false], // var-bound but bounded peek → pass
+  ['log="/p/x.log"; echo "$log"', false], // echo is not a read-exec → not a flood
+  ['f="notes.txt"; cat "$f"', false], // var bound to a non-log → precise, no block
+  ['tail -3 "$log" | grep err', false], // $log never bound → unknown, allow
+];
+const enforceClassifyOk = enfCases.every(([c, exp]) => shouldBlockLogBash(c) === exp);
+const enforceModeOk =
+  normalizeMode("on") === "block" && normalizeMode("0") === "off" &&
+  normalizeMode("nudge") === "warn" && normalizeMode("bogus") === null;
+const enforceStatusOk = /Log-grep enforcement: (block|warn|off)/.test(runTool("log_enforce", {}).text);
+
+// Read-tool enforcement: intercept only an UNBOUNDED read of a LARGE log. A slice (offset/limit),
+// a small log, a non-log file, or an unknown size (stat failed → 0) must all pass — the slice path is
+// the one-step escape so a blocked Read never strands the model.
+const big = READ_MIN_BYTES + 1, small = READ_MIN_BYTES - 1;
+const readCases = [
+  ["Saved/Logs/Editor.log", big, false, true],   // large log, unbounded → block
+  ["Editor.log", big, true, false],               // sliced (offset/limit) → always allow
+  ["Editor.log", small, false, false],            // small log → allow (cheap)
+  ["src/Foo.cpp", big, false, false],             // non-log code file → allow
+  ["run.jsonl", big, false, true],                // large .jsonl → block
+  ["", big, false, false],                        // no path → allow
+  ["Editor.log", 0, false, false],                // stat failed (size 0) → allow (fail-open)
+];
+const readClassifyOk = readCases.every(([p, sz, sliced, exp]) => shouldBlockRead(p, sz, sliced) === exp);
+// the nudge must tell the truth about HOW the read happened + offer the right escape per kind
+const nudgeOk =
+  /via the Read tool/.test(nudgeText("Editor.log", "read")) &&
+  /offset.*limit|limit.*offset|`offset`/.test(nudgeText("Editor.log", "read")) &&
+  /via Bash/.test(nudgeText("tail x.log", "bash")) &&
+  /gamedev-log (summary|search)/.test(nudgeText("x.log", "read"));
+const enforceOk = enforceClassifyOk && enforceModeOk && enforceStatusOk && readClassifyOk && nudgeOk;
+
 const rows = [
   ["parse coverage", (coverage * 100).toFixed(1) + "%", "≥ 95%", coverage >= 0.95],
   ["token reduction (callsite)", (reduction * 100).toFixed(1) + "%", "≥ 90%", reduction >= 0.9],
@@ -169,6 +227,7 @@ const rows = [
   ["log_locate omits bodies", locateNoBodies, "true", locateNoBodies],
   ["multi-engine classify (synthetic)", engineOk, "true", engineOk],
   ["build code rollup (groupBy=code)", codeRollupOk, "true", codeRollupOk],
+  ["enforce: bash+read+mode+nudge", enforceOk, "true", enforceOk],
   ["JSONL field extraction", jsonlOk, "true", jsonlOk],
   ["coverage hint (unknown fmt only)", covHintOk, "true", covHintOk],
   ["tail-read clean line boundary", tailOk, "true", tailOk],

--- a/gamedev-log-analyzer/hooks/block-log-grep.mjs
+++ b/gamedev-log-analyzer/hooks/block-log-grep.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/*
+ * gamedev-log-analyzer — PreToolUse hook (matchers: Bash, Read).
+ *
+ * Steers raw log reads to `gamedev-log` (which parses + dedups + token-caps) instead of flooding raw
+ * lines into context. Two vectors:
+ *   - Bash: grep/rg/tail/cat/… over a .log/.jsonl/Logs target.
+ *   - Read tool: an UNBOUNDED read of a LARGE log file (>= READ_MIN_BYTES). A sliced read
+ *     (offset/limit present) ALWAYS passes — that's the one-step escape and the fallback for formats
+ *     the analyzer parses poorly, so a blocked Read never strands the model.
+ * Code grep (.cpp/.cs/src/…) and non-log reads pass through — that domain belongs to rider-mcp-enforcer.
+ *
+ * Modes (env GDLOG_ENFORCE > ~/.gamedev-log-analyzer/config.json "enforce" > "block"):
+ *   block (default) -> exit 2, denied, nudge shown to the model
+ *   warn            -> exit 0, allowed, nudge shown (soft)
+ *   off             -> exit 0, silent passthrough
+ *
+ * Protocol: exit 0 = allow; exit 2 + stderr = block. Fail-open: any parse/IO error allows the command.
+ */
+import fs from "node:fs";
+import { shouldBlockLogBash, shouldBlockRead, enforceMode, nudgeText } from "../server/enforce.js";
+
+let input = "";
+process.stdin.on("data", (d) => (input += d));
+process.stdin.on("end", () => {
+  let toolName = "";
+  let ti = {};
+  try {
+    const j = JSON.parse(input);
+    toolName = j.tool_name || "";
+    ti = j.tool_input || {};
+  } catch {
+    process.exit(0); // unparseable — don't block
+  }
+
+  let mode = "block";
+  try {
+    mode = enforceMode();
+  } catch {
+    process.exit(0); // config trouble — fail open
+  }
+  if (mode === "off") process.exit(0);
+
+  let hit = null; // { kind: "bash"|"read", target: string }
+  try {
+    if (toolName === "Bash") {
+      if (shouldBlockLogBash(ti.command)) hit = { kind: "bash", target: ti.command || "" };
+    } else if (toolName === "Read") {
+      const fp = ti.file_path || "";
+      const sliced = ti.offset !== undefined && ti.offset !== null || (ti.limit !== undefined && ti.limit !== null);
+      let size = 0;
+      try {
+        size = fs.statSync(fp).size; // follows symlinks; throws on missing/EACCES/dir
+      } catch {
+        size = 0; // fail open — any stat error means "don't block"
+      }
+      if (shouldBlockRead(fp, size, sliced)) hit = { kind: "read", target: fp };
+    }
+  } catch {
+    process.exit(0); // any classifier error — fail open
+  }
+  if (!hit) process.exit(0);
+
+  const nudge = nudgeText(hit.target, hit.kind);
+  if (mode === "warn") {
+    // allow the command, but inject the nudge into the model's context (stderr on exit 0 is not
+    // reliably surfaced; additionalContext is).
+    process.stdout.write(
+      JSON.stringify({ hookSpecificOutput: { hookEventName: "PreToolUse", additionalContext: nudge } })
+    );
+    process.exit(0);
+  }
+  process.stderr.write(nudge + "\n"); // block: deny + show nudge
+  process.exit(2);
+});

--- a/gamedev-log-analyzer/hooks/hooks.json
+++ b/gamedev-log-analyzer/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/block-log-grep.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/gamedev-log-analyzer/server/README.md
+++ b/gamedev-log-analyzer/server/README.md
@@ -34,6 +34,7 @@ gamedev-log search --path Editor.log --severityMin Error --groupBy callsite
 | `diff` | Delta between two logs (new/gone/changed only). |
 | `locate` | Jump list: distinct `file:line` of matches. |
 | `tail` | Last N raw lines. |
+| `enforce` | Show/set log-read enforcement (PreToolUse hook over **Bash** raw reads *and* unbounded **Read**s of ≥200 KB logs; sliced `Read` passes): `warn` (default, allow + nudge), `block` (deny + nudge), `off`. Env override `GDLOG_ENFORCE`. |
 | `setup` / `config` | Persist / show settings (`~/.gamedev-log-analyzer/config.json`). |
 
 Run `gamedev-log` with no arguments for full usage. Settings precedence: env (`GDLOG_*`) > config file >

--- a/gamedev-log-analyzer/server/cli.js
+++ b/gamedev-log-analyzer/server/cli.js
@@ -35,6 +35,9 @@ Commands:
   learnings-reset   Clear the local learnings ledger.
   savings           How many tokens you've saved vs dumping raw logs into context.
   savings-reset     Clear the local savings ledger.
+  enforce           Show/set Bash log-grep enforcement.   [<block|warn|off> | status]
+                    block (default) denies raw grep/tail/cat over .log/.jsonl/Logs + nudges here;
+                    warn allows but nudges; off disables. Env override: GDLOG_ENFORCE.
   setup             Persist config.   [--projectPath --logPath --logMaxBytes --maxGroups --maxLineChars]
   config            Show effective settings.
 
@@ -92,8 +95,11 @@ if (!rawCmd || rawCmd === "-h" || rawCmd === "--help" || rawCmd === "help") {
 }
 const name = normCommand(rawCmd);
 const args = parseArgs(rest);
-// convenience: a bare first positional after the command is treated as --path (or --severityMin for nothing else)
-if (rest[0] && !rest[0].startsWith("--") && args.path === undefined && name !== "log_diff") {
+// convenience: `enforce <mode>` takes a bare positional as the mode, not a path.
+if (name === "log_enforce" && rest[0] && !rest[0].startsWith("--") && args.mode === undefined) {
+  args.mode = rest[0];
+} else if (rest[0] && !rest[0].startsWith("--") && args.path === undefined && name !== "log_diff") {
+  // convenience: a bare first positional after the command is treated as --path
   args.path = rest[0];
 }
 

--- a/gamedev-log-analyzer/server/core.js
+++ b/gamedev-log-analyzer/server/core.js
@@ -8,6 +8,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { detectLogs, readText, analyzeLog, extractFields, collectLearnings, diffLogs, locateLog } from "./logs.js";
+import { enforceMode, enforceSource, writeEnforceMode } from "./enforce.js";
 
 const CONFIG_DIR = path.join(os.homedir(), ".gamedev-log-analyzer");
 export const CONFIG_FILE = process.env.GDLOG_CONFIG_FILE || path.join(CONFIG_DIR, "config.json");
@@ -178,6 +179,25 @@ export function runTool(name, a = {}) {
     if (name === "log_learnings_reset") {
       try { fs.writeFileSync(LEARN_FILE, "{}"); } catch { /* ignore */ }
       return out("Learnings ledger cleared.");
+    }
+    if (name === "log_enforce") {
+      const set = a.mode !== undefined ? a.mode : a.set;
+      if (set === undefined || set === "" || String(set).toLowerCase() === "status") {
+        const m = enforceMode();
+        const what = m === "off" ? "allowed (no enforcement)" : m === "warn" ? "allowed with a nudge (soft)" : "blocked (denied + nudge)";
+        return out(
+          `Log-grep enforcement: ${m}  (source: ${enforceSource()})\n` +
+            `Raw Bash log reads (grep/tail/cat/… over .log/.jsonl/Logs) are ${what}.\n\n` +
+            `Change: gamedev-log enforce <block|warn|off>  (or env GDLOG_ENFORCE=<mode> per shell).`
+        );
+      }
+      try {
+        const m = writeEnforceMode(set);
+        const what = m === "off" ? "ALLOWED (no enforcement)" : m === "warn" ? "ALLOWED with a nudge (soft)" : "BLOCKED (denied + nudge)";
+        return out(`Enforcement set to '${m}'. Raw Bash log reads are now ${what}.\nConfig: ${CONFIG_FILE}\nRun /reload-plugins if a hook is active.`);
+      } catch (e) {
+        return err(e.message);
+      }
     }
     if (name === "log_savings") return out(savingsReport());
     if (name === "log_savings_reset") {

--- a/gamedev-log-analyzer/server/enforce.js
+++ b/gamedev-log-analyzer/server/enforce.js
@@ -1,0 +1,210 @@
+/*
+ * gamedev-log-analyzer — log-grep enforcement engine (pure, testable).
+ *
+ * Decides whether a Bash command is a raw text-dump of a LOG file (grep/tail/cat/… over a `.log` /
+ * `.jsonl` / Logs dir) that should instead go through `gamedev-log` (parse + dedup + token-cap).
+ * The PreToolUse hook (hooks/block-log-grep.mjs) imports this; the eval imports it too. Keeping the
+ * logic here (not inline in the hook) is what makes it unit-testable.
+ *
+ * Mode is read the same way core.js reads config: env GDLOG_ENFORCE > ~/.gamedev-log-analyzer/config.json
+ * "enforce" > default "block". Modes: "block" (deny + nudge), "warn" (allow + nudge), "off" (allow).
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Text-dump executables that flood raw log lines into context. `node`/`gamedev-log` are NOT here, so
+// the analyzer's own invocations never trip the hook.
+export const READ_EXECS = new Set(["grep", "rg", "ack", "ag", "findstr", "tail", "head", "cat"]);
+
+export function execOf(segment) {
+  const tokens = String(segment).trim().split(/\s+/);
+  let i = 0;
+  while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++; // skip FOO=bar prefixes
+  let exec = (tokens[i] || "").toLowerCase();
+  exec = exec.replace(/^.*[\\/]/, "").replace(/\.(exe|bat|cmd|ps1)$/, ""); // basename, drop win ext
+  return exec;
+}
+
+// A log target = a `.log` / `.jsonl` / rotated `.log.N` file, or a path under a Logs/Saved/Logs dir.
+// `.json` is intentionally excluded (configs); only line-delimited `.jsonl` counts as a log.
+function hasLogTarget(s) {
+  return (
+    /\.(log|jsonl)\b/.test(s) ||
+    /\.log\.\d+\b/.test(s) ||
+    /(^|[\s"'/\\])(saved[\\/]logs|logs)[\\/]/.test(s)
+  );
+}
+
+// A small bounded peek (`tail -8`, `head -20`, default-10 `tail`) or a count-only read (`grep -c`,
+// `rg -c`) cannot flood context regardless of file size — its output is a handful of lines or a single
+// number. Blocking it would be friction with zero token win (violates token-first), so it passes. This
+// mirrors the Read-tool slice escape (offset/limit always allowed). Unbounded reads — `cat`, a bare
+// `grep`, `tail -f`, `tail -n +N` (from a line to EOF), a large `-n N`, or `tail -c <bigbytes>` — still
+// block, since those are the actual floods the analyzer exists to replace.
+const BOUNDED_PEEK_LINES = 50;
+const BOUNDED_PEEK_BYTES = 8192;
+export function isBoundedRead(segment) {
+  const exec = execOf(segment);
+  const s = String(segment);
+  // count-only matchers: output is a count, never a line dump (findstr has no count flag).
+  if ((exec === "grep" || exec === "rg") && /(^|\s)(-c|--count)\b/.test(s)) return true;
+  if (exec === "tail" || exec === "head") {
+    if (/(^|\s)(-f|--follow)\b/.test(s)) return false; // live stream — unbounded
+    if (/-n\s*\+\d+|--lines[=\s]+\+\d+/.test(s)) return false; // tail -n +N → reads to EOF
+    const mc = s.match(/-c\s*(\d+)|--bytes[=\s]+(\d+)/); // byte count
+    if (mc) return Number(mc[1] || mc[2]) <= BOUNDED_PEEK_BYTES;
+    const m =
+      s.match(/--lines[=\s]+(\d+)/) || s.match(/-n\s*(\d+)/) || s.match(/(?:^|\s)-(\d+)\b/);
+    const n = m ? Number(m[1]) : 10; // tail/head default to 10 lines
+    return n <= BOUNDED_PEEK_LINES;
+  }
+  return false;
+}
+
+export function isLogReadSegment(segment) {
+  const exec = execOf(segment);
+  if (!READ_EXECS.has(exec)) return false;
+  if (!hasLogTarget(String(segment).toLowerCase())) return false;
+  return !isBoundedRead(segment); // a bounded peek / count-only read isn't a flood
+}
+
+// A bare file path that is a log target (for the Read-tool branch, where there's no shell exec).
+export function isLogPath(p) {
+  return hasLogTarget(String(p || "").toLowerCase());
+}
+
+// Coarse volume gate for the Read tool: a log at/above this many bytes is worth steering to the
+// analyzer (~3-5k tokens raw). Below it, a raw Read is cheap — let it through. Size is a blunt signal
+// (it misses redundancy), but it's the only thing knowable WITHOUT reading the file. Hardcoded on
+// purpose — no config key until there's evidence anyone needs to tune it.
+export const READ_MIN_BYTES = 200_000;
+
+// Decision for the `Read` tool. PURE — the caller supplies the file size and whether a slice
+// (offset/limit) was requested, so this never touches the filesystem (the hook does the stat and
+// fails open on any error). Intercept only an UNBOUNDED read of a LARGE LOG; a slice always passes,
+// which is the one-step escape hatch (Read again with offset/limit) and Claude's fallback when the
+// analyzer parses a format poorly.
+export function shouldBlockRead(filePath, sizeBytes, sliced) {
+  if (!filePath || sliced) return false;
+  if (!isLogPath(filePath)) return false;
+  return Number(sizeBytes) >= READ_MIN_BYTES;
+}
+
+// Shell variables assigned a LOG-PATH literal anywhere in the command. This closes the indirection
+// hole: `log="…/Editor.log"; tail -3 "$log" | grep err` puts the path in the ASSIGNMENT segment and the
+// read in a LATER segment, so per-segment matching alone misses it. We bind the var to the log here,
+// then a read-exec that dereferences that exact var counts as a log read. High precision: we require
+// BOTH a log-literal RHS AND a deref-by-a-read-exec (a bare `echo "$log"` is not a flood, not blocked).
+// The boundary `(?:^|[\s;&|(])` avoids matching inside `--flag=x.log` (no var binding for CLI flags).
+export function collectLogVars(cmd) {
+  const vars = new Set();
+  const re = /(?:^|[\s;&|(])([A-Za-z_][A-Za-z0-9_]*)=(?:"([^"]*)"|'([^']*)'|([^\s;&|]*))/g;
+  let m;
+  while ((m = re.exec(String(cmd || ""))) !== null) {
+    const rhs = m[2] !== undefined ? m[2] : m[3] !== undefined ? m[3] : m[4] || "";
+    if (rhs && hasLogTarget(rhs.toLowerCase())) vars.add(m[1]);
+  }
+  return vars;
+}
+
+// Does this segment dereference one of the bound log-vars ($VAR, ${VAR}, "$VAR")?
+function segDerefsLogVar(segment, vars) {
+  if (!vars.size) return false;
+  const re = /\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?/g;
+  let m;
+  while ((m = re.exec(String(segment))) !== null) if (vars.has(m[1])) return true;
+  return false;
+}
+
+// True if ANY shell segment is a raw log read — either a direct literal in a read-exec segment
+// (`tail x.log | grep err`), or a read-exec dereferencing a var bound to a log path earlier in the
+// command (`log="x.log"; tail "$log"`).
+export function shouldBlockLogBash(cmd) {
+  const c = String(cmd || "");
+  const segments = c.split(/\|\||&&|[|;&\n]/g);
+  const logVars = collectLogVars(c);
+  return segments.some((seg) => {
+    if (!seg.trim()) return false;
+    if (isLogReadSegment(seg)) return true; // direct log-path literal in a read-exec segment
+    // var-bound log path — same bounded-peek exemption as the direct case
+    return READ_EXECS.has(execOf(seg)) && !isBoundedRead(seg) && segDerefsLogVar(seg, logVars);
+  });
+}
+
+// ---- mode (env > config.json > default) ----
+const CONFIG_FILE =
+  process.env.GDLOG_CONFIG_FILE || path.join(os.homedir(), ".gamedev-log-analyzer", "config.json");
+
+function readConfig() {
+  try {
+    return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8")) || {};
+  } catch {
+    return {};
+  }
+}
+
+const VALID_MODES = ["block", "warn", "off"];
+
+// Normalize loose aliases so `on/1/true` → block, `0/false/none` → off.
+export function normalizeMode(v) {
+  const m = String(v || "").toLowerCase().trim();
+  if (["off", "0", "false", "none", "allow"].includes(m)) return "off";
+  if (["warn", "nudge", "soft"].includes(m)) return "warn";
+  if (["block", "on", "1", "true", "deny", "hard"].includes(m)) return "block";
+  return null;
+}
+
+// Default is "warn": nudge toward the analyzer but never deny. The hard-block guarantee was always
+// porous (the Grep tool / MCP search / Read bypass enforcement entirely), so paying friction for it
+// violated token-first. Opt into hard denial with `gamedev-log enforce block` / GDLOG_ENFORCE=block.
+export function enforceMode() {
+  const env = process.env.GDLOG_ENFORCE;
+  if (env !== undefined && env !== "") return normalizeMode(env) || "warn";
+  const fromCfg = readConfig().enforce;
+  if (fromCfg !== undefined && fromCfg !== null && fromCfg !== "") return normalizeMode(fromCfg) || "warn";
+  return "warn"; // default: nudge, don't deny
+}
+
+export function enforceSource() {
+  if (process.env.GDLOG_ENFORCE !== undefined && process.env.GDLOG_ENFORCE !== "") return "env GDLOG_ENFORCE";
+  if (readConfig().enforce != null && readConfig().enforce !== "") return CONFIG_FILE;
+  return "default";
+}
+
+// Persist mode into config.json (merge-preserving other keys). Returns the written mode.
+export function writeEnforceMode(mode) {
+  const norm = normalizeMode(mode);
+  if (!norm) throw new Error(`mode must be one of: ${VALID_MODES.join(" | ")} (or on/off aliases)`);
+  const cur = readConfig();
+  cur.enforce = norm;
+  fs.mkdirSync(path.dirname(CONFIG_FILE), { recursive: true });
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(cur, null, 2));
+  return norm;
+}
+
+// The nudge shown when a raw log read is intercepted. One source of truth for the hook + tests.
+// `kind` ∈ {"bash","read"} controls the wording and the escape hatch so the message never lies about
+// how the read happened. `target` is the command (bash) or the file path (read).
+export function nudgeText(target, kind = "bash") {
+  const t = String(target || "");
+  const how = kind === "read" ? "a large log via the Read tool" : "a raw log read via Bash";
+  const head = "[gamedev-log-analyzer] Intercepted " + how + (t ? `:\n  ${t.slice(0, 200)}` : "");
+  const pathRef = kind === "read" && t ? t : "<log>";
+  const tools =
+    "\nUse gamedev-log instead — it parses, dedups, and token-caps the log " +
+    "(a multi-MB log → a few hundred tokens) rather than dumping raw lines into context:\n" +
+    `  - severity + category rollup   -> gamedev-log summary --path ${pathRef}\n` +
+    `  - search / dedup groups        -> gamedev-log search  --path ${pathRef} --severityMin Warning\n` +
+    `  - build warnings by code       -> gamedev-log search  --path ${pathRef} --groupBy code\n` +
+    `  - jump list (file:line only)   -> gamedev-log locate  --path ${pathRef}\n` +
+    `  - scalar fields over time      -> gamedev-log fields  --path ${pathRef} --fields ts,<Key>\n`;
+  const escape =
+    kind === "read"
+      ? "Genuinely need the raw bytes? Re-run Read with `offset`/`limit` for a bounded slice (always " +
+        `allowed), or peek with \`gamedev-log tail --path ${pathRef}\`, or lower enforcement: ` +
+        "`gamedev-log enforce warn|off`."
+      : "Genuinely need the raw bytes? Lower enforcement: `gamedev-log enforce warn` (nudge only) or " +
+        "`gamedev-log enforce off` (allow), or set GDLOG_ENFORCE=off for this shell.";
+  return head + tools + escape;
+}

--- a/gamedev-log-analyzer/server/index.js
+++ b/gamedev-log-analyzer/server/index.js
@@ -161,6 +161,16 @@ const TOOLS = [
     description: "Clear the local savings ledger.",
     inputSchema: { type: "object", properties: {} },
   },
+  {
+    name: "log_enforce",
+    description:
+      "Show or set Bash log-grep enforcement. Pass mode to set ('block' = deny raw grep/tail/cat over " +
+      ".log/.jsonl/Logs + nudge to gamedev-log; 'warn' = allow + nudge; 'off' = allow). Omit (or 'status') to show.",
+    inputSchema: {
+      type: "object",
+      properties: { mode: { type: "string", description: "block | warn | off | status" } },
+    },
+  },
 ];
 
 const server = new Server({ name: "gamedev-log", version: "0.3.0" }, { capabilities: { tools: {} } });

--- a/gamedev-log-analyzer/server/package.json
+++ b/gamedev-log-analyzer/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamedev-log-analyzer",
-  "version": "0.7.0",
+  "version": "0.10.1",
   "type": "module",
   "description": "Token-efficient game-engine & build log analysis (Unreal/Unity/Godot/MSVC-UBT-MSBuild) for the CLI and MCP — parse, dedup, classify by severity/category, diff runs, locate file:line, and extract scalar fields. No IDE required.",
   "keywords": [
@@ -30,7 +30,7 @@
     "gamedev-log": "cli.js",
     "gamedev-log-analyzer": "index.js"
   },
-  "files": ["index.js", "cli.js", "core.js", "logs.js", "sdk.js", "ensure-deps.mjs", "README.md"],
+  "files": ["index.js", "cli.js", "core.js", "logs.js", "enforce.js", "sdk.js", "ensure-deps.mjs", "README.md"],
   "scripts": {
     "start": "node index.js",
     "test": "node ../eval/run.mjs"

--- a/gamedev-log-analyzer/skills/logs/SKILL.md
+++ b/gamedev-log-analyzer/skills/logs/SKILL.md
@@ -62,6 +62,24 @@ Quote every path argument (Windows paths/spaces). `--help` lists everything.
   (new-parser candidates). See *Growing format coverage* below; a low-coverage file also auto-nudges.
 - `savings` / `savings-reset` — local cumulative report of how many tokens you've saved vs dumping raw
   logs into context. Each analysis also appends a one-line `✓ Saved ~N tokens (M× smaller)` for big logs.
+- `enforce <block|warn|off>` (or no arg = status) — log-read enforcement. A `PreToolUse` hook
+  intercepts raw Bash log reads (`grep`/`tail`/`cat`/… over `.log`/`.jsonl`/`Logs`) **and unbounded
+  `Read`s of large (≥ 200 KB) logs**, steering them here. A sliced `Read` (`offset`/`limit`) always
+  passes — that's the one-step escape when you truly need raw bytes or when a format parses poorly.
+  `warn` (default) allows + nudges; `block` denies + nudges; `off` disables. Env: `GDLOG_ENFORCE`. If a
+  user hits the block and genuinely wants raw bytes, tell them to re-Read with `offset`/`limit`, or
+  `gamedev-log enforce warn|off`.
+
+## Inline lookup vs. delegating to the `log-analyst` subagent
+- A single quick check on a log — one summary, one search — whose result you want to see: run the CLI
+  inline. Cheapest path; a subagent costs ~15k tokens of its own to return a few hundred.
+- Once you reach a third *related* pass over the same log (severity, then a trace tag, then a scalar
+  window), or you know up front it's a multi-step investigation, hand the whole thing to the
+  `log-analyst` subagent in one call. It runs every pass in its own context and returns one compact
+  answer, so the raw output never piles up in yours.
+- Rule of thumb: inline for 1–2; batch-delegate at 3+ related passes or a multi-step dig. Don't spawn a
+  subagent for one summary, and don't run ten sequential inline reads when one delegation would do.
+  "Related" is the signal — count alone doesn't decide it.
 
 ## Default flow ("check the logs")
 

--- a/server/warmset.js
+++ b/server/warmset.js
@@ -3,9 +3,11 @@
  *
  * clangd boosts the indexing priority of TUs related to files we didOpen (IndexBoostedFile), so the
  * order of the open-set steers what becomes queryable first. We rank candidates by, in weight order:
- *   ① query-history  (LFU + recency) — files that answered past searches (strongest signal)
- *   ② vcs-recency    — recently-touched files (git log + Perforce `p4 opened`) — what the dev works on
- *   ③ mtime          — filesystem recency (tiebreak / no-VCS fallback; p4 edit/sync updates mtime too)
+ *   query-history  (LFU + recency) — files that answered past searches (strongest evidence)
+ *   working-now    — files open/modified right now (git status / Perforce `p4 opened`)
+ *   git-recency    — recently-committed files (git log)
+ *   centrality     — include fan-in among candidates (bounded; widely-reused headers help many queries)
+ *   mtime          — filesystem recency fallback (p4 edit/sync updates mtime too)
  * Background indexing still covers everything eventually; this only front-loads the likely targets.
  * Keep the open-set small (cap) — over-prewarming pollutes/saturates the worker.
  */
@@ -16,6 +18,7 @@ import path from "node:path";
 
 const HIST_FILE = process.env.VTS_QUERY_HISTORY || path.join(os.homedir(), ".vs-token-safer", "query-history.json");
 const norm = (p) => path.resolve(p).replace(/\\/g, "/").toLowerCase();
+const envInt = (name, def) => { const v = parseInt(process.env[name], 10); return Number.isFinite(v) && v >= 0 ? v : def; };
 const readHist = () => { try { return JSON.parse(fs.readFileSync(HIST_FILE, "utf8")) || {}; } catch { return {}; } };
 // LFU with a recency tiebreak (scan-resistant-ish: a one-off scan adds n=1, repeated use compounds).
 const score = (e, now) => e.n + 1 / (1 + (now - e.t));
@@ -63,7 +66,7 @@ function addOrder(rank, order) {
 // git: recently-touched files (most recent first). Empty if not a git repo / no git.
 function gitRecent(root, rank) {
   try {
-    const out = execFileSync("git", ["-C", root, "log", "--name-only", "--format=", "-n", "80"], { encoding: "utf8", timeout: 5000 });
+    const out = execFileSync("git", ["-C", root, "log", "--name-only", "--format=", "-n", "80"], { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"] });
     const order = []; const seen = new Set();
     for (const line of out.split(/\r?\n/)) {
       const t = line.trim();
@@ -73,38 +76,68 @@ function gitRecent(root, rank) {
   } catch { /* no git */ }
 }
 
-// Perforce: files currently OPEN for edit in this client (a strong "working on it right now" signal) —
-// `p4 -ztag opened` reports each file's local `clientFile`. Best-effort; empty if no p4 / not configured.
-function p4Recent(root, rank) {
+// ④ "Working on it right now" — the strongest recency signal: files modified in the working tree
+// (`git status`) and/or open for edit in Perforce (`p4 opened`). Returns a Set of normalized paths.
+// Both probed best-effort; a p4 `clientFile` is already a local path, git paths are repo-relative.
+function workingFiles(root) {
+  const set = new Set();
   try {
-    const out = execFileSync("p4", ["-ztag", "opened", "-m", "200"], { cwd: root, encoding: "utf8", timeout: 5000 });
-    const order = [];
+    const out = execFileSync("git", ["-C", root, "status", "--porcelain", "--untracked-files=all"], { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"] });
+    for (const line of out.split(/\r?\n/)) {
+      let t = line.slice(3).trim(); // drop the 2-char XY status + space
+      if (!t) continue;
+      if (t.includes(" -> ")) t = t.split(" -> ").pop(); // renames: take the new path
+      set.add(norm(path.join(root, t.replace(/^"|"$/g, ""))));
+    }
+  } catch { /* no git */ }
+  try {
+    const out = execFileSync("p4", ["-ztag", "opened", "-m", "500"], { cwd: root, encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"] });
     for (const line of out.split(/\r?\n/)) {
       const m = /^\.\.\. clientFile (.+)$/.exec(line.trim());
-      if (m) order.push(norm(m[1]));
+      if (m) set.add(norm(m[1]));
     }
-    addOrder(rank, order);
   } catch { /* no p4 */ }
+  return set;
 }
 
-// Merged VCS recency (git + Perforce). A tree may be under either; both are probed best-effort and the
-// higher rank wins. mtime (in orderForWarm) remains the universal fallback — in a p4 workspace, `p4 edit`
-// / `p4 sync` updates file mtime, so recently-touched files surface even without the p4 probe.
-function vcsRecent(root) {
-  const rank = new Map();
-  gitRecent(root, rank);
-  p4Recent(root, rank);
-  return rank;
+// ③ Dependency centrality (bounded): among candidates, count include fan-in — how many candidates
+// `#include` each one. High fan-in = reused widely → warming it helps many queries. Reads files, so it's
+// gated to a max candidate count (VTS_CENTRALITY_MAX, default 1500; 0 disables) to stay cheap on huge
+// trees, where clangd's preamble already pulls central headers transitively when a TU is opened.
+function centralityRank(candidates) {
+  const max = envInt("VTS_CENTRALITY_MAX", 1500);
+  if (!max || candidates.length > max) return new Map();
+  const byName = new Map();
+  for (const f of candidates) { const b = path.basename(f).toLowerCase(); if (!byName.has(b)) byName.set(b, norm(f)); }
+  const fanin = new Map();
+  for (const f of candidates) {
+    let txt; try { txt = fs.readFileSync(f, "utf8"); } catch { continue; }
+    const self = norm(f); const seen = new Set();
+    const re = /#\s*include\s*["<]([^">]+)[">]/g; let m;
+    while ((m = re.exec(txt))) {
+      const target = byName.get(path.basename(m[1]).toLowerCase());
+      if (target && target !== self && !seen.has(target)) { seen.add(target); fanin.set(target, (fanin.get(target) || 0) + 1); }
+    }
+  }
+  return fanin;
 }
 
-// Reorder `candidates` for warming and cap. Weights: history >> git-recency >> mtime.
+// Reorder `candidates` for warming and cap. Tiered weights (strongest evidence first):
+//   ② query history > ④ working-now (git status / p4 opened) > ① git-log recency > ③ centrality > mtime.
 export function orderForWarm(root, candidates, cap = 100) {
   const hist = histRank(root);
-  const vcs = vcsRecent(root);
+  const working = workingFiles(root);
+  const gitLog = new Map(); gitRecent(root, gitLog);
+  const central = centralityRank(candidates);
   const mtime = (p) => { try { return fs.statSync(p).mtimeMs; } catch { return 0; } };
   const scored = candidates.map((f) => {
     const k = norm(f);
-    return { f, s: (hist.get(k) || 0) * 1e6 + (vcs.get(k) || 0) * 1e3 + mtime(f) / 1e13 };
+    const s = (hist.get(k) || 0) * 1e6
+      + (working.has(k) ? 1e5 : 0)
+      + (gitLog.get(k) || 0) * 1e3
+      + (central.get(k) || 0) * 1e1
+      + mtime(f) / 1e13;
+    return { f, s };
   });
   scored.sort((a, b) => b.s - a.s);
   return scored.slice(0, cap).map((x) => x.f);


### PR DESCRIPTION
Third integration from `dev` (on top of v0.3.0).

## Warm-up ordering — added signals
Beyond query-history + git-recency, the warm-up open-set is now ordered by:
- **④ working-now**: files modified in the working tree (`git status`) or open for edit (Perforce `p4 opened`) — the strongest 'on this right now' signal, just below proven query history.
- **③ include-centrality**: among candidates, headers `#include`d by many others rank higher (widely reused ⇒ warming them helps many queries). Bounded by `VTS_CENTRALITY_MAX` (default 1500; reads files, skipped on bigger sets where clangd's preamble already pulls central headers).
- Tiered score: **query-history > working-now > git-log recency > centrality > mtime**. Works with git AND Perforce. VCS-probe stderr suppressed (no spam on non-git/p4 trees).

## Bundle
- **gamedev-log-analyzer 0.7.0 → 0.10.1** (refreshed from the published package / `../rider-mcp-enforcer`): new `block-log-grep` hook, `log-analyst` agent, `enforce` command; server matches npm 0.10.1.

## Verification
- eval 12/12 (added centrality guard); `node eval/bench-hitrate.mjs` still shows ordering beats arbitrary at every cap; gamedev eval passes (117k → 77 tok).
- No proprietary data (synthetic workloads; mock LSP).

## Docs
README EN/KO ordering description + `VTS_CENTRALITY_MAX`; CLAUDE.md.