### PR TITLE
dev → main: README/community polish to rider-mcp-enforcer level (v0.5.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vs-token-safer",
-  "description": "Force Claude Code to search C++/C# code through an official language server's index (clangd / Roslyn) instead of Bash grep, token-capped to a compact file:line list. No IDE required. Faster and far fewer tokens on large Unreal C++/.NET codebases.",
+  "description": "Force Claude Code to search C++/C# code through an official language server's index (clangd / Roslyn) instead of Bash grep, token-capped to a compact file:line list. No IDE required. Faster and far fewer tokens on large Unreal C++/.NET codebases. Auto-installs gamedev-log-analyzer.",
   "version": "0.4.0",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/vs-token-safer",
@@ -19,5 +19,6 @@
     "code-search",
     "token-efficiency",
     "claude-code"
-  ]
+  ],
+  "dependencies": ["gamedev-log-analyzer"]
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
   - package-ecosystem: npm
+    directory: /gamedev-log-analyzer/server
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1,8 +1,14 @@
-# Benchmark
+# Benchmark: vs-token-safer (clangd / Roslyn index) vs Bash grep
 
 vs-token-safer's whole point is **token efficiency**: return the answer to a code-search question as a
 compact `file:line` list instead of dumping raw source (or a raw language-server index response) into
-the model's context. This file documents how that's measured and how to reproduce it.
+the model's context. Benchmarks here are **A/B**: the same query **without the plugin** (Arm A — raw
+`grep`/`rg`, i.e. what the model receives when it greps) versus **with the plugin** (Arm B — the
+clangd/Roslyn index, formatted and token-capped).
+
+> No source code, file paths, or project symbol names are reproduced here — only aggregate counts,
+> sizes, and timings. The query below is a **public Unreal Engine framework symbol** (`FGameplayTag`),
+> not a symbol from any private project.
 
 ## The gate (runs on every commit)
 
@@ -15,8 +21,10 @@ toolchain needed, so it runs in CI on Windows + Linux across Node 18/20/22). It 
 | symbol → `file:line` (no bodies) | The formatter emits `kind name @ file:line` and **never** ranges/kinds/source. |
 | token cap (1,000 syms → capped) | A large index response collapses to a capped list with a `… N more` footer. |
 | **token reduction vs raw index ≥ 70%** | The core promise — the response is dramatically smaller. |
-| references wiring | `find_references` resolves and formats locations. |
+| references + goto wiring | `find_references` / `goto_definition` resolve and format locations. |
 | `runTool` dispatch | MCP and CLI share one implementation. |
+| LSP timeout / index-ready wait / clangd advisory | Cold-index handling, `$/progress` end wait, old-clangd gate. |
+| prewarm + `vts_warmup` + warm ordering + centrality | The IDE-style warm-up path and its hit-rate ordering. |
 
 Run it:
 
@@ -27,36 +35,116 @@ node eval/run.mjs
 Representative output:
 
 ```
-✓ LSP client handshake + symbol          true   true
-✓ symbol → file:line (no bodies)         true   true
-✓ token cap (1000 syms → capped)         true   true
 ✓ token reduction vs raw index          97.4%   ≥ 70%
-✓ references wiring                       true   true
-✓ runTool dispatch                        true   true
-
+…
 raw index ~57,308 tok → capped output ~1,515 tok
 EVAL PASSED.
 ```
 
-## What the number means
-
 - **Raw index response** = the JSON the language server returns for a broad `workspace/symbol` query
   (1,000 symbols, each with name, kind, container, and a full URI + range). ~57k tokens.
-- **Capped output** = what vs-token-safer actually hands the model: `maxResults` lines of
+- **Capped output** = what vs-token-safer hands the model: `maxResults` lines of
   `kind name (in container) @ file:line`, plus a `… N more` footer. ~1.5k tokens.
-- The reduction is **~97%** on this synthetic-but-realistic shape. The threshold is set at **70%** so
+- The reduction is **~97.4%** on this synthetic-but-realistic shape. The threshold is set at **70%** so
   the gate fails loudly if a change ever starts leaking bodies or stops capping.
 
-## vs Bash grep
+## Token savings (the dominant, always-on win)
 
-The eval measures the *response-shaping* win (raw index → capped list). Against pasting `grep`/`rg`
-output into context, the saving is typically **larger** still, because grep returns the full text of
-every matching line (and matches by text, so it returns more lines — comments, strings, unrelated
-identifiers). vs-token-safer returns one `file:line` per semantic hit, capped.
+Real A/B on a large **Unreal Engine 5** project, finding one public engine symbol (`FGameplayTag`):
 
-## Live numbers
+| | Bash grep-and-paste (whole repo) | **Plugin (clangd index, capped)** |
+| --- | ---: | ---: |
+| What the model receives | 5,654 lines / 1,010 files | 47 semantic declarations (`file:line`) |
+| Tokens to the model | **~282,194** | **~2,048** |
 
-clangd / Roslyn live runs on real projects are tracked in the
-[Status & TODO](#) wiki and will be added here once the live-verification pass (P2) lands. Until then
-the mock-LSP eval is the committed, reproducible figure. Keep all benchmark inputs **synthetic** — no
-real paths, symbols, or project identifiers (see [CONTRIBUTING.md](CONTRIBUTING.md)).
+- vs whole-repo grep-and-paste: `~2,048` vs `~282,194` → **~99.3% fewer (~138×)**.
+- The win has two sources: grep returns the **full text** of every matching line, and grep matches by
+  **text**, so it returns far more lines (comments, strings, unrelated identifiers, generated headers).
+  The plugin returns one `file:line` per **semantic** hit, capped at `maxResults`.
+
+Even against a *line-capped* grep (Claude Code's built-in Grep tool truncates output at ≈250 lines), the
+capped semantic list is still dramatically smaller — and every line is a real `file:line`, not raw
+bytes.
+
+## Search time — depends on scope (honest)
+
+- vs **whole-repo** grep (the common case: Claude doesn't know where a symbol lives and scans the repo
+  root, Engine included): indexed lookup beats scanning the UE Engine tree once the index is warm.
+- vs a **narrow** grep over a small, known directory: ripgrep is very fast on a small scope; a cold
+  clangd index pays a one-time warm-up (it indexes the engine headers) on the first query. After that,
+  queries in the same session are sub-second because the client + index are cached.
+
+vts hides the warm-up cost the way an IDE does: the MCP server **pre-warms at boot** (`VTS_PREWARM`) and
+keeps the client warm for its lifetime, so you pay it **once per session, not per query**. `vts warmup`
+builds the on-disk index up front, and `VTS_CLANGD_REMOTE` lets a team share one prebuilt index. See the
+hit-rate table in the [README](README.md#pre-warming--hit-rate) for how the warm-up set is ordered
+likely-query-first.
+
+**Takeaway:** tokens win massively and unconditionally (~97–99%). Wall-clock wins when the scope is
+large/unknown (Engine included) and the index is warm; a cold first query is the price you pay once.
+
+## Accuracy difference (and why)
+
+The two paths optimize differently — it is a **precision/recall trade**, not "one is simply correct":
+
+| Aspect | Bash grep | clangd / Roslyn index (this plugin) |
+| --- | --- | --- |
+| Match basis | Literal substring | Symbol index (`search_symbol`) / position resolve (`find_references`, `goto_definition`) |
+| Recall (completeness) | 100% of literal hits | **Capped at `maxResults`** — top N only |
+| Precision (relevance) | Low — matches comments, includes, substrings (`Foo` also hits `FooBar`) | Higher — distinct **semantic** declarations, no substring false positives |
+| Result shape | Raw lines, undeduped | `kind name (in container) @ file:line`, capped, no bodies |
+
+**Degree of difference, measured here:** grep's 5,654 matching lines across 1,010 files collapse to 47
+distinct semantic declarations from the index — grep over-reports heavily because most lines are
+comments, `#include`s, generated-header references, and substring noise, not declarations.
+
+- **Recall:** with the default cap (60), the plugin surfaces the top semantic hits, not every textual
+  occurrence. If you need an exhaustive list, raise `maxResults` / `VTS_MAX_RESULTS` or use grep
+  deliberately.
+- **Precision:** the index never returns a substring false positive, and `goto_definition` /
+  `find_references` resolve the symbol at a position — they answer "where is *this* symbol", not "what
+  text looks like this".
+
+Net: for **navigation** (jump to the definition / see representative usages), the plugin is more
+accurate *and* far cheaper. For an **exhaustive audit** of every textual occurrence, raise the cap or
+use grep on purpose.
+
+# Logs: A/B (gamedev-log-analyzer)
+
+Same A/B framing for the bundled log analyzer: **Arm A** = paste the raw editor log into context;
+**Arm B** = the `gamedev-log` CLI (summary / search / locate / diff). Token ≈ bytes ÷ 4. No log lines
+are reproduced — only sizes.
+
+| Operation (Arm B) | Editor log ~1 MB (~267,000 tok raw) |
+| --- | ---: |
+| `summary` (severity counts + top categories) | ~130 tok · **~99.95%** fewer |
+| `search` Error+ (dedup groups by callsite) | a few hundred tok · ~99.8% fewer |
+| `locate` Error+ (`file:line` jump list) | ~77 tok · ~99.97% fewer |
+
+**The win grows with log size** — raw logs scale linearly (a 1 MB log is ~267k tokens), while the
+`summary` stays flat (~130 tokens) because it reports counts, not bodies. `search`/`locate` stay small
+by deduping repeated lines into templated groups and capping. `diff` reads two runs and returns only
+what changed, instead of pasting both logs to compare. The bundled plugin's own eval reduces a
+representative log from ~117k tokens to ~77 tokens.
+
+# Reproduce
+
+```bash
+# Code search — the committed, toolchain-free gate (mock LSP):
+node eval/run.mjs           # → EVAL PASSED, 97.4% reduction
+
+# Warm-up hit-rate (synthetic workload, real orderForWarm()):
+node eval/bench-hitrate.mjs # → OK — ordering beats arbitrary at every cap
+
+# Live A/B against your own project (counts only, never source):
+#   grep side
+rg -n "<Symbol>" "<project>"                     # whole repo (incl. Engine)
+#   index side (clangd needs compile_commands.json; Roslyn needs a .sln/.csproj)
+vts symbol --q "<Symbol>" --projectPath "<project>"
+
+# Logs A/B (bundled gamedev-log-analyzer) — counts only, never log content:
+node gamedev-log-analyzer/eval/bench-ab.mjs
+```
+
+Keep all benchmark inputs **synthetic** or **public** (Unreal Engine framework symbols) — no real
+paths, symbols, or project identifiers (see [CONTRIBUTING.md](CONTRIBUTING.md)).

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,30 +1,119 @@
-# vs-token-safer
+# vs-token-safer · gamedev-log-analyzer
 
-**Claude Code가 C++/C# 코드를 Bash `grep` 대신 공식 언어 서버 인덱스로 검색하도록 강제한다** —
-C/C++은 clangd(LLVM), C#/.NET은 Roslyn 기반 LSP. 결과는 간결한 `file:line` 목록으로 **토큰 캡**한다.
-대규모 Unreal C++ / .NET 코드베이스에서 더 빠르고 토큰을 훨씬 적게 쓴다. **로컬 전용, IDE 불필요.**
-Claude Code 플러그인(MCP 서버 + 훅 + 스킬)과 클론해서 쓰는 독립 CLI(`vts`)로 제공된다.
+[English](README.md) · **한국어**
 
-> 🇺🇸 English: [README.md](README.md)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-7C3AED)](https://code.claude.com/docs/en/plugins)
+[![MCP](https://img.shields.io/badge/MCP-server-1f6feb)](https://modelcontextprotocol.io)
+[![release](https://img.shields.io/github/v/release/JSungMin/vs-token-safer)](https://github.com/JSungMin/vs-token-safer/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/JSungMin/vs-token-safer/pulls)
+[![Stars](https://img.shields.io/github/stars/JSungMin/vs-token-safer?style=social)](https://github.com/JSungMin/vs-token-safer/stargazers)
 
-[rider-mcp-enforcer](https://github.com/JSungMin/rider-mcp-enforcer)의 IDE 비종속 형제 프로젝트다.
-토큰 효율 목표는 같지만, 실행 중인 IDE의 MCP 서버를 프록시하는 대신 **공식 언어 서버를 헤드리스로
-직접 실행**한다 — 그래서 에디터를 열지 않아도 Visual Studio / 임의의 C++·C# 프로젝트에서 동작한다.
+> 대형 Unreal C++ · Visual Studio · .NET 프로젝트를 위한 Claude Code 플러그인 두 개. 코드베이스는
+> `grep` 대신 **공식 언어 서버 인덱스**(clangd / Roslyn)로 검색하고, 수십 MB짜리 에디터 로그는 대화에
+> 통째로 쏟지 않고 읽습니다. 둘 다 토큰을 약 99% 적게 씁니다. **로컬 전용, IDE 불필요.**
+
+### 실제 모습
+```text
+# Claude가 코드를 grep 시도 → 훅이 차단하고 인덱스 도구로 안내:
+$ grep -rn "SpawnActor" Source/**/*.cpp
+🛑 [vs-token-safer] Bash 코드 심볼 검색 감지. search_symbol / find_references 사용
+   (clangd/Roslyn 인덱스 — 의미 기반, 토큰 캡).   # grep 허용하려면 VTS_ENFORCE=0
+
+▶ search_symbol "SpawnActor"
+  func SpawnActor (in AGameMode)   @ Source/GameMode.cpp:142   (+2 more)
+  → ~120 토큰   (grep이면 수천 줄 덤프)
+
+# 1MB 에디터 로그 → 파싱·dedup·분류 (동봉된 gamedev-log-analyzer):
+▶ /gamedev-log-analyzer:logs
+  41,233줄 · 에러 7 · 경고 312
+  ERROR   [LogStreaming] Failed to load asset <addr>         (×128)   @ AssetManager.cpp:210
+  WARNING [LogPhysics]   Penetration depth <n> exceeds limit (×4,051) @ MyComponent.cpp:88
+  → ~130 토큰   (raw 로그 ≈ 267,000)
+```
+<sub>공개 Unreal Engine 심볼을 쓴 예시 출력.</sub>
+
+### 이런 경험 있나요?
+- 🔍 거대 Unreal C++ / .NET repo에서 `grep`이 컨텍스트를 폭발 → clangd/Roslyn 인덱스로 검색, 토큰 상한 (**~97–99% 절감** — [벤치마크](#성능-실측)).
+- 🪵 50MB 에디터 로그를 읽을 수 없음 → 파싱·dedup·분류해서 수백 토큰으로.
+- 🤖 Claude가 자꾸 코드를 `grep` → 훅이 잡아서 인덱스 도구로 안내.
+- 🖥️ IDE 프록시 방식과 달리 언어 서버를 **헤드리스**로 실행 — 에디터를 열 필요 없음.
+
+### 목차
+- [마켓플레이스 — 2개 플러그인](#마켓플레이스--2개-플러그인) · [합산 절감](#합산-토큰-절감-실측) · [두 플러그인 함께 쓰기](#두-플러그인-함께-쓰기)
+- [무엇을 하나](#무엇을-하나) · [성능](#성능-실측) · [사전 인덱싱과 hit-rate](#사전-인덱싱pre-warm과-hit-rate)
+- [사전 요구사항](#사전-요구사항) · [설치](#설치) · [설정](#설정-명령어) · [업데이트](#새-버전으로-업데이트)
+- [설정 항목](#설정-항목-env) · [문제 해결](#문제-해결) · [상태 / 주의](#상태--주의) · [기여](#기여) · [Releases](https://github.com/JSungMin/vs-token-safer/releases)
 
 ---
 
-## 왜 필요한가
+Claude가 Bash `grep` 대신 **공식 언어 서버 인덱스**로 심볼 검색 · 참조(references) 찾기 · 정의로 이동을
+하도록 만들고(C/C++은 **clangd**(LLVM), C#/.NET은 **Roslyn 기반 LSP** —
+`Microsoft.CodeAnalysis.LanguageServer`, Visual Studio / C# Dev Kit가 쓰는 엔진), 검색이 폭발할 때
+간결한 `file:line` 목록(소스 본문 없음)만 반환해 토큰을 상한선으로 막아주는 **Claude Code
+플러그인**입니다. `grep`이 느리고 컨텍스트를 잡아먹는 대형 Unreal C++ 및 .NET/C# 코드베이스를 위해
+만들었습니다.
 
-큰 게임/.NET 코드베이스에서 `grep`/`rg`는 **수천 줄**을 모델 컨텍스트에 쏟아붓는다 — 대부분 무관하고,
-심볼 의미 없는 단순 텍스트 매치다. vs-token-safer는 대신:
+[rider-mcp-enforcer](https://github.com/JSungMin/rider-mcp-enforcer)의 IDE 비종속 형제 프로젝트입니다.
+토큰 효율 목표는 같지만, 실행 중인 IDE의 MCP 서버를 프록시하는 대신 공식 언어 서버를 **헤드리스로**
+실행합니다 — 그래서 에디터를 열지 않아도 Visual Studio / 임의의 C++·C# 프로젝트에서 동작합니다.
 
-- **언어 서버 인덱스**에 심볼/참조/정의를 묻고(텍스트가 아닌 의미 기반),
-- **토큰 캡된 `file:line` 목록**만 반환한다 — 소스 본문은 절대 포함하지 않는다.
+## 마켓플레이스 — 2개 플러그인
 
-1,000개 심볼 인덱스 응답 기준 **약 97% 토큰 절감**이다([벤치마크](#벤치마크)). `PreToolUse` 훅이
-Bash의 코드 심볼 `grep`을 **차단**하고 인덱스 도구로 안내하므로 절감이 자동으로 일어난다.
+이 repo는 **"큰 것을 싸게 읽는다"** 는 한 아이디어를 공유하는 2개 플러그인이 든 Claude Code
+**플러그인 마켓플레이스**입니다:
 
-## 동작 예시
+| 플러그인 | 기능 | 필요 |
+| --- | --- | --- |
+| **vs-token-safer** (이 페이지) | 코드 검색을 grep 대신 clangd/Roslyn 인덱스로 강제(기본 하드 차단, 탈출구 opt-out), `file:line`으로 토큰 캡 | Node + 언어 서버(clangd / Roslyn). IDE 불필요. |
+| **[gamedev-log-analyzer](gamedev-log-analyzer/README.ko.md)** | 거대 Unreal/Unity/Godot/MSVC-UBT-MSBuild 로그 파싱·dedup·분류·검색·diff·locate·스칼라 추출 (CLI 우선) | Node만 (IDE 불필요) |
+
+**한 번에 설치** — `vs-token-safer`가 `gamedev-log-analyzer`를 의존성으로 선언해서 한 번 설치하면 둘
+다 깔리고, 각 서버의 `npm install`은 첫 세션에 자동 실행됩니다(수동 설정 0):
+```bash
+/plugin marketplace add JSungMin/vs-token-safer
+/plugin install vs-token-safer@vs-token-safer        # gamedev-log-analyzer도 자동 설치
+/reload-plugins                                       # 첫 실행 시 둘 다 의존성 자동 설치
+```
+로그 분석기만 원하면 단독 설치: `/plugin install gamedev-log-analyzer@vs-token-safer`.
+
+### 합산 토큰 절감 (실측)
+| 작업 | Bash / raw | 플러그인 | 절감 |
+| --- | ---: | ---: | ---: |
+| 실제 UE5 repo 심볼 검색 (`FGameplayTag`) | ~282,194 tok | ~2,048 tok | **~99.3% (~138×)** |
+| raw 인덱스 응답 → 캡된 목록 (eval, 심볼 1,000개) | ~57,308 tok | ~1,515 tok | **~97.4%** |
+| ~1MB 에디터 로그 읽기 (`summary`) | ~267,000 tok | ~130 tok | **~99.95%** |
+
+### 두 플러그인 함께 쓰기
+로그 분석기는 각 항목의 `file:line`을 출력하고, vs-token-safer는 그 `file:line`을 실제 심볼/소스로
+바꿉니다. 전형적 흐름:
+1. `/gamedev-log-analyzer:logs` → 에러/경고와 그 `file:line` 찾기.
+2. 그 위치를 vs-token-safer의 `goto_definition`/`find_references`(또는 `search_symbol`)에 넘겨 코드를
+   열고 이해 — raw 로그를 grep하거나 덤프하지 않고.
+
+## 무엇을 하나
+
+clangd와 Roslyn은 그 자체로 이미 의미 기반 심볼/참조 분석을 합니다. 이 플러그인이 그 위에 더하는 건
+**강제**, **토큰 캡**, **헤드리스 실행 + warm-up** 으로, Claude가 grep 대신 인덱스를 실제로 쓰게
+만듭니다:
+
+| 레이어 | 파일 | 효과 |
+| --- | --- | --- |
+| **강제 훅(hook)** | `hooks/block-code-grep.js` | 소스 파일(`.c/.cc/.cpp/.h/.hpp/.cs`, 또는 `src/`·`source/`·`engine/`·`plugins/`) 대상 Bash `grep`/`rg`/`ack`/`ag`/`findstr` 및 `find -name`을 가로채 인덱스 도구로 유도. **정밀함**: 명령 세그먼트의 실제 실행 파일이 검색 도구일 때만 발동하고, 원시 텍스트 검색(로그, `.md`, `.json`, 설정, build/intermediate 디렉터리)은 그대로 통과. 탈출구 `VTS_ENFORCE=0`. |
+| **라우팅 스킬** | `skills/vs-search/SKILL.md` | Claude가 인덱스 도구를 먼저 쓰도록 유도하는 규칙: 심볼/참조/정의 검색은 `search_symbol`/`find_references`/`goto_definition`, grep은 최후수단. |
+| **토큰 캡 코어** | `server/core.js` | 두 어댑터가 공유하는 `runTool()`: LSP 결과를 `kind name (in container) @ file:line`으로 바꾸고 `maxResults`로 상한, `… N more` 푸터를 붙임 — range/kind/소스 본문은 절대 없음. 로컬 절감 원장 기록. |
+| **헤드리스 LSP 클라이언트** | `server/lsp.js` + `server/backends/index.js` | 완전 자체 구현 LSP 클라이언트(JSON-RPC 2.0, `Content-Length` 프레이밍)가 공식 엔진을 stdio로 실행, 실행 설정 + `pickBackend(root)` 자동 감지 + IDE식 pre-warm(`afterInit`) 포함. |
+
+> **엔진은 공식, 글루는 우리 것.** 분석은 clangd(LLVM)·Roslyn(Microsoft)이 하고, 이 저장소는
+> LSP↔MCP 글루만 작성합니다. 소스 위에서 서드파티 MCP 서버가 돌지 않습니다.
+
+### 명령어 & 도구
+- `/vs-token-safer:setup` — 플러그인 설정 ([설정](#설정-명령어) 참고).
+- `/vs-token-safer:savings` — 누적 토큰 절감량 표시.
+- MCP 도구(서버 `vs-search`): `search_symbol`, `find_references`, `goto_definition`, `vts_warmup`,
+  `vts_setup`, `vts_config`, `vts_savings`, `vts_savings_reset`.
+- CLI (`vts`): `symbol`, `references`, `definition`, `warmup`, `setup`, `config`, `savings`,
+  `savings-reset`.
 
 ```
 $ vts symbol --q SpawnActor --projectPath ./MyGame
@@ -36,166 +125,51 @@ func SpawnActorFromClass  @ MyGame/Source/SpawnLib.cpp:31
 ✓ Saved ~4,200 tokens here (96.8% / 31× smaller than the raw index response).
 ```
 
----
+## 성능 (실측)
 
-## 설치
+대형 Unreal Engine 5 프로젝트에서 공개 엔진 심볼 한 개(`FGameplayTag`)를 Bash grep-and-paste vs 이
+플러그인으로 찾은 실측 A/B. 프로젝트 소스는 공개하지 않음(집계 수치만) — 방법은
+[BENCHMARK.md](BENCHMARK.md) 참고.
 
-### Claude Code 플러그인으로
+| | Bash grep-and-paste (전체 repo) | **플러그인 (clangd 인덱스, 캡)** |
+| --- | ---: | ---: |
+| 모델이 받는 것 | 5,654줄 / 1,010 파일 | 47개 의미 기반 선언 (`file:line`) |
+| 모델로 가는 토큰 | ~282,194 | **~2,048** |
 
-```
-/plugin marketplace add JSungMin/vs-token-safer
-/plugin install vs-token-safer
-/reload-plugins
-```
+- **토큰: ~99.3% 절감 (~138×).** grep은 매칭 줄 전체 텍스트(텍스트 매치라 더 많은 줄 — 주석/문자열/
+  무관한 식별자)를 반환; 플러그인은 의미 기반 히트당 `file:line` 하나만, 캡됨.
+- 목-LSP eval(`node eval/run.mjs`, 툴체인 불필요)이 매 커밋 응답 정형화 절감을 게이트: raw 인덱스
+  `~57,308 tok` → 캡된 출력 `~1,515 tok` = **97.4%** (체크 12/12).
 
-`vs-search` MCP 서버, grep 차단 훅, 라우팅 스킬이 연결된다. 첫 실행 시 MCP 서버가 의존성
-(`@modelcontextprotocol/sdk`) 하나를 플러그인 데이터 디렉터리에 설치한다.
+### 정확도 차이 (와 그 이유)
+"누가 더 맞다"가 아니라 **정밀도/재현율 트레이드오프**입니다:
+- **재현율:** 플러그인은 상위 `N`개(cap)만 반환, 모든 텍스트 occurrence가 아님. 빠진 꼬리는 대부분
+  주석/include/부분문자열 노이즈. 전수가 필요하면 `maxResults`를 올리거나 grep 사용.
+- **정밀도:** grep은 모든 부분문자열 매칭(`Foo` 검색이 `FooBar`도 매칭)으로 과다보고; 인덱스는
+  distinct **의미 기반** 선언을 반환 — `search_symbol`은 심볼 인덱스 질의이고,
+  `find_references`/`goto_definition`은 위치의 심볼을 해석(텍스트 매치 아님).
 
-### 독립 CLI로 (IDE·Claude Code 불필요)
-
-npm 미배포 — 클론해서 설치한다:
-
-```
-git clone https://github.com/JSungMin/vs-token-safer
-cd vs-token-safer/server && npm install && npm link   # `vts` 제공
-# 또는 link 없이 직접 실행:
-node /path/to/vs-token-safer/server/cli.js symbol --q SpawnActor --projectPath /path/to/proj
-```
-
-### 사전 준비 — 언어 서버
-
-vs-token-safer는 공식 엔진을 구동한다. 필요한 것을 설치한다:
-
-| 백엔드 | 언어 | 엔진 | 설치 | 필요 조건 |
-| --- | --- | --- | --- | --- |
-| `clangd` | C/C++ | clangd (LLVM) | [LLVM 릴리스](https://github.com/clangd/clangd/releases) 또는 패키지 매니저 | `compile_commands.json` |
-| `roslyn` | C#/.NET | **Microsoft.CodeAnalysis.LanguageServer** (Visual Studio / C# Dev Kit가 쓰는 엔진), `csharp-ls` 폴백 | **VS Code C# 확장**(`ms-dotnettools.csharp`) 설치 — 엔진+런타임 동봉; 또는 `dotnet tool install --global csharp-ls` | `.sln` / `.csproj` |
-
-**clangd는 컴파일 DB(`compile_commands.json`)가 필요하다:**
-- **Unreal Engine:** UBT로 생성 — `<UE>/Engine/Build/BatchFiles/RunUBT … -mode=GenerateClangDatabase`.
-- **CMake:** `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`로 구성.
-
-**C#은 공식 Visual Studio Roslyn 엔진을 자동 사용한다.** vs-token-safer가 VS Code C# 확장 번들에서
-`Microsoft.CodeAnalysis.LanguageServer`(와 맞는 .NET 런타임)를 자동 감지하고, `.sln`/`.csproj`를 열어
-프로젝트 로드를 기다린 뒤 질의한다 — 플래그 불필요. 특정 엔진을 쓰려면 `VTS_ROSLYN_DLL`(dll 경로),
-또는 다른 Roslyn LSP면 `VTS_ROSLYN_CMD`/`VTS_ROSLYN_ARGS`로 재정의한다. MS 엔진도 재정의도 없으면
-`csharp-ls`로 폴백한다.
-
----
-
-## 사용법
-
-### MCP 도구 (서버 이름: `vs-search`)
-
-| 도구 | 용도 | 주요 인자 |
-| --- | --- | --- |
-| `search_symbol` | 이름/부분문자열로 심볼 선언 검색 | `q`, `projectPath`, `backend`, `maxResults` |
-| `find_references` | 위치의 심볼에 대한 참조/사용처 | `path`, `line`, `character` (0-based), `includeDeclaration` |
-| `goto_definition` | 위치의 심볼 정의 | `path`, `line`, `character` (0-based) |
-| `vts_setup` | 설정 저장(`~/.vs-token-safer/config.json`) | `projectPath`, `backend`, `maxResults` |
-| `vts_config` | 현재 유효 설정 표시 | — |
-| `vts_savings` / `vts_savings_reset` | 토큰 절감 원장 | — |
-
-### CLI (`vts`)
-
-```
-vts symbol      --q <name> --projectPath <dir> [--backend clangd|roslyn] [--maxResults N]
-vts references  --path <file> --line N --character N [--includeDeclaration]
-vts definition  --path <file> --line N --character N
-vts setup       [--projectPath <dir>] [--backend …] [--maxResults N]
-vts config
-vts savings | vts savings-reset
-```
-
-슬래시 명령(플러그인): `/vs-token-safer:setup`, `/vs-token-safer:savings`.
-
----
-
-## 설정
-
-우선순위: **환경 변수(`VTS_*`) > `~/.vs-token-safer/config.json` > 기본값.**
-
-| 설정 키 | 환경 변수 | 기본값 | 의미 |
-| --- | --- | --- | --- |
-| `projectPath` | `VTS_PROJECT_PATH` | cwd | 프로젝트 루트(컴파일 DB / `.sln` 위치) |
-| `backend` | `VTS_BACKEND` | auto | `clangd` \| `roslyn` (루트에서 자동 감지) |
-| `maxResults` | `VTS_MAX_RESULTS` | `60` | 반환 `file:line` 개수 상한 |
-| — | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | clangd 실행 파일/인자 재정의 |
-| — | `VTS_ROSLYN_DLL` | auto | 특정 `Microsoft.CodeAnalysis.LanguageServer.dll` 경로 |
-| — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto(MS 엔진) → `csharp-ls` | C# LSP 실행 파일/인자 재정의 |
-| — | `VTS_ENFORCE` | `1` | `0`/`false`/`off`이면 Bash 코드 grep 허용(탈출구) |
-
-자동 감지: `compile_commands.json`(또는 `.uproject`) → **clangd**; `.sln`/`.csproj` → **roslyn**.
-
----
-
-## grep 차단 훅
-
-`PreToolUse`(Bash) 훅이 소스 파일(`.c/.cc/.cpp/.h/.hpp/.cs`, 또는 `src/`·`source/`·`engine/`·
-`plugins/`)에 대한 코드 심볼 검색(`grep`/`rg`/`ack`/`ag`/`findstr`, 또는 `find -name`)을 차단하고
-인덱스 도구를 쓰도록 안내한다. **정밀하다**: 명령 세그먼트의 실제 실행 파일이 검색 도구일 때만
-발동하며, **원시 텍스트** 검색(로그, `.md`, `.json`, 설정, build/intermediate 디렉터리)은 그대로
-통과시킨다. 언어 서버를 못 쓰면 `VTS_ENFORCE=0`으로 grep 차단을 끈다.
-
----
-
-## 백엔드 지원 현황
-
-| 백엔드 | 상태 | 비고 |
-| --- | --- | --- |
-| `clangd` (C/C++) | ✅ 라이브 검증됨 | `compile_commands.json` 프로젝트 대상 실제 clangd로 `search_symbol`/`find_references`/`goto_definition` 확인. **정확한** 컴파일 DB(include 경로 포함 — Unreal은 UBT 생성) 필요(그래야 시스템/서드파티 헤더 해석; 없으면 헤더 없는 심볼만 인덱싱). VS는 `…/VC/Tools/Llvm/bin/clangd.exe`에 clangd 동봉. |
-| `roslyn` (C#/.NET) | ✅ 라이브 검증됨 | 실제 `.csproj` 대상 **Microsoft.CodeAnalysis.LanguageServer**(VS 실제 엔진)로 `search_symbol`/`find_references`/`goto_definition` 확인. 자동 감지, `csharp-ls` 폴백. |
-
----
-
-## 동작 원리 (아키텍처)
-
-```
-Claude Code ──(MCP / CLI)──▶ vs-token-safer  ──(stdio LSP)──▶ clangd / csharp-ls ──▶ 소스
-                              └ runTool(): LSP 결과 토큰 캡 → file:line, 본문 없음
-```
-
-- `server/lsp.js` — 완전 자체 구현 **LSP 클라이언트**(JSON-RPC 2.0, `Content-Length` 프레이밍).
-  유일하게 새로 만든 핵심.
-- `server/backends/index.js` — 각 공식 엔진 실행 방법 + `pickBackend(root)` 자동 감지.
-- `server/core.js` — async `runTool()` 디스패치, 토큰 캡 포매터, 절감 원장. 두 어댑터가 공유 →
-  도구당 구현은 정확히 하나.
-- `server/index.js` — MCP 서버(얇은 어댑터). `server/cli.js` — `vts` CLI(얇은 어댑터).
-
-**엔진은 공식, 글루는 우리 것.** 분석은 clangd(LLVM)·Roslyn(Microsoft)이 하고, 이 저장소는
-LSP↔MCP 글루만 작성한다. 소스 위에서 서드파티 MCP 서버가 돌지 않는다.
-
----
-
-## 벤치마크
-
-eval(`node eval/run.mjs`, 목 LSP — 툴체인 불필요)이 매 커밋 토큰 절감을 게이트한다:
-
-```
-raw index ~57,308 tok → capped output ~1,515 tok      = 97.4% 절감 (심볼 1,000개)
-```
-
-이는 응답 정형화 절감(원시 인덱스 응답 → 캡된 목록)이다. `grep` 출력을 컨텍스트에 붙이는 것 대비
-절감은 보통 더 크다 — grep은 매칭 줄 전체를 반환하기 때문이다.
-
----
+> 정리: **탐색(정의 + 대표 사용처)** 용도면 플러그인이 더 정확하고 훨씬 저렴. **전수 감사**면 cap을
+> 올리거나 일부러 grep을 쓰세요.
 
 ## 사전 인덱싱(pre-warm)과 hit-rate
 
-clangd는 비동기로 인덱싱하므로 서버 기동 후 *첫* 검색은 1회 warm-up 비용(엔진 헤더 인덱싱)을 치른다.
-vts는 이를 IDE처럼 처리한다:
+clangd는 비동기로 인덱싱하므로 서버 기동 후 *첫* 검색은 1회 warm-up 비용(엔진 헤더 인덱싱)을 치릅니다.
+vts는 이를 IDE처럼 처리합니다:
 
 - **MCP 서버가 기동 시 pre-warm** (`VTS_PREWARM`, `projectPath` 설정 시 기본 on) — 첫 검색 시점엔 이미
-  인덱스가 데워지는 중이고, 클라이언트는 서버 수명 동안 캐시된다. 따라서 warm-up은 **세션당 1회이지
-  쿼리마다가 아니다**(이후 검색은 sub-초).
+  인덱스가 데워지는 중이고, 클라이언트는 서버 수명 동안 캐시됩니다. 따라서 warm-up은 **세션당 1회이지
+  쿼리마다가 아닙니다**(이후 검색은 sub-초).
 - **`vts warmup`** — CLI/CI용으로 clangd 온디스크 인덱스(`.cache/clangd`)를 미리 구축.
-- **`VTS_CLANGD_REMOTE`** — clangd를 공유/사전구축 인덱스 서버로 연결 → 개발자별 warm-up ~0.
+- **`VTS_CLANGD_REMOTE`** — clangd를 공유/사전구축 clangd-index-server로 연결 → 개발자별 warm-up ~0
+  (팀/CI가 사전구축 인덱스 하나를 질의).
 
-**무엇을 먼저 데우느냐가 중요하다.** clangd는 열린(open) 파일의 인덱싱 우선순위를 높이므로, vts는 warm-up
-대상을 *곧 검색할 것 우선*으로 정렬한다: **쿼리 이력**(과거 검색이 반환한 파일) → **지금 편집 중**(`git
-status` 수정/미추적 + Perforce `p4 opened`) → **git 커밋 최근성**(`git log`) → **include 중심성**(여러
-후보가 `#include`하는 헤더, `VTS_CENTRALITY_MAX`로 제한) → mtime. 거대한 트리에선 일부만 데울 수 있으므로,
-이 정렬이 warm 윈도가 실제 검색 대상을 포함하게 만드는 핵심이다. git·Perforce 모두 지원.
+**무엇을 먼저 데우느냐가 중요합니다.** clangd는 열린 파일의 인덱싱 우선순위를 높이므로, vts는 warm-up
+대상을 *곧 검색할 것 우선*으로 정렬합니다: **쿼리 이력**(과거 검색이 반환한 파일) → **지금 편집
+중**(`git status` 수정/미추적 + Perforce `p4 opened`) → **git 커밋 최근성** → **include 중심성**(여러
+후보가 `#include`하는 헤더, `VTS_CENTRALITY_MAX`로 제한) → mtime. 거대한 트리에선 일부(언리얼의 수만
+TU 중 수백 개)만 데울 수 있으므로, 이 정렬이 warm 윈도가 실제 검색 대상을 포함하게 만드는 핵심입니다.
+git·Perforce 모두 지원.
 
 측정된 향상 (`node eval/bench-hitrate.mjs` — 실제 `orderForWarm()`, 현실적 locality 합성 워크로드, 2,000 파일):
 
@@ -207,28 +181,218 @@ status` 수정/미추적 + Perforce `p4 opened`) → **git 커밋 최근성**(`g
 | 20% | 24.8% | **68.5%** | 2.8× |
 | 50% | 46.3% | **80.5%** | 1.7× |
 
-데울 수 있는 비율이 작을수록(예: 언리얼의 수만 TU 중 수백 개) 효과가 크다 — 임의 순서는 거의 못 맞히고,
-정렬은 대부분을 맞힌다.
+데울 수 있는 비율이 작을수록 효과가 큽니다 — 임의 순서는 거의 못 맞히고, 정렬은 대부분을 맞힙니다.
 
----
+## 얼마나 절약했나? (토큰 절감 명령어)
 
-## 개인정보 & 보안
+코어는 검색마다 언어 서버 raw 인덱스 응답 대비 절약한 토큰을 기록합니다. 누적 합계 확인 방법:
 
-**로컬 전용, 전송 제로.** 언어 서버는 stdio로 로컬 실행되며, 유일한 외부 네트워크 호출은 첫 실행 시
-MCP SDK의 `npm install`뿐이다. 텔레메트리·소스·쿼리가 기기를 떠나지 않는다.
-[PRIVACY.md](PRIVACY.md), [SECURITY.md](SECURITY.md) 참고.
+- **Claude Code에서:** `/vs-token-safer:savings` 실행 (또는 "플러그인이 얼마나 아꼈어?"라고 질문).
+  `vts_savings` MCP 도구를 호출합니다.
+- **셸에서:** `vts savings`
+- **리셋:** `vts_savings_reset` 도구 호출 (또는 `vts savings-reset`).
 
-## 개발
-
+출력 예시:
 ```
-npm install            # 루트 개발 도구(eslint, prettier)
-npm test               # node eval/run.mjs → EVAL PASSED
-npm run lint
-cd server && npm install   # MCP 서버 의존성, 이후 `node index.js`로 서버 시작
+vs-token-safer savings (local, 1 search(es))
+  total saved: ~4,200 tokens vs forwarding raw index responses
+  raw → output: 4,340 → 140 tok (~31× smaller)
+  biggest single run: 4,340 → 140 tok
+```
+> 여기서 "saved"는 언어 서버의 *raw* 인덱스 응답 대비입니다. **Bash grep** 대비 절감은 보통 훨씬
+> 큽니다 — [BENCHMARK.md](BENCHMARK.md) 참고.
+
+## 사전 요구사항
+
+- PATH에 **Node.js ≥ 18**.
+- 검색할 언어의 언어 서버:
+  - **C/C++ → clangd ≥ 22** ([clangd 릴리스](https://github.com/clangd/clangd/releases)). Visual
+    Studio에 동봉된 clangd 19.1.x(`…/VC/Tools/Llvm/bin/clangd.exe`)는 실제 Unreal TU를 서버 모드에서
+    인덱싱할 때 **데드락**합니다 — vts가 오래된 버전을 감지하면 경고합니다. `compile_commands.json`
+    컴파일 DB 필요.
+  - **C#/.NET → Roslyn LSP.** **VS Code C# 확장**(`ms-dotnettools.csharp`) 설치 — vts가 번들에서
+    `Microsoft.CodeAnalysis.LanguageServer`와 그 전용 .NET 런타임을 자동 감지합니다. 폴백:
+    `dotnet tool install --global csharp-ls`. `.sln`/`.csproj` 필요.
+- IDE는 실행 중이지 않아도 됩니다.
+
+**clangd는 컴파일 DB(`compile_commands.json`)가 필요합니다:**
+- **Unreal Engine:** UBT로 생성 — `<UE>/Engine/Build/BatchFiles/RunUBT … -mode=GenerateClangDatabase`.
+  타겟이 **clang-cl**로 빌드되면 **`-Compiler=VisualCpp`**를 추가하세요 — 아니면
+  `GenerateClangDatabase`가 clang 툴체인 검증에 실패합니다(`Unable to find valid C++ toolchain for
+  Clang x64`); MSVC-컴파일러 DB도 clangd용 전체 엔진 include 그래프를 해석합니다.
+- **CMake:** `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`로 구성.
+
+## 설치
+
+```bash
+# 1) 마켓플레이스 추가 + 설치 (gamedev-log-analyzer도 자동 설치)
+/plugin marketplace add JSungMin/vs-token-safer
+/plugin install vs-token-safer@vs-token-safer
+/reload-plugins        # 첫 실행 시 서버 의존성 자동 설치 (수동 npm 불필요)
+
+# 2) 설정 — Claude Code 안에서 그냥 실행:
+/vs-token-safer:setup
+#   백엔드를 감지하고, 프로젝트 경로를 물어본 뒤 config를 기록합니다.
 ```
 
-새 코드 경로에는 `eval/run.mjs`에 eval 가드를 추가한다. [CONTRIBUTING.md](CONTRIBUTING.md) 참고.
+`vs-search` MCP 서버와 도구들이 보이는지, `grep src/**/*.cpp`이 인덱스 도구 유도와 함께 차단되는지
+(또는 `VTS_ENFORCE=0`이면 자유롭게 실행) 확인하세요. MCP 서버의 의존성 하나
+(`@modelcontextprotocol/sdk`)는 첫 세션에 플러그인 데이터 디렉터리에 자동 설치됩니다.
+
+### 독립 CLI로 (IDE·Claude Code 불필요)
+
+vs-token-safer는 **npm 미배포** — `vts` CLI를 클론해서 설치합니다:
+
+```bash
+git clone https://github.com/JSungMin/vs-token-safer
+cd vs-token-safer/server && npm install && npm link   # `vts` 제공
+# 또는 link 없이 직접 실행:
+node /path/to/vs-token-safer/server/cli.js symbol --q SpawnActor --projectPath /path/to/proj
+```
+
+## 설정 명령어
+
+OS 환경변수를 직접 편집하지 않습니다. 설정은 CLI와 MCP 서버가 시작 시 읽는 config 파일
+(`~/.vs-token-safer/config.json`)에 저장됩니다. 설정 방법:
+
+- **Claude Code에서 (권장):** `/vs-token-safer:setup` — 가이드 진행: 현재 설정 표시(`vts_config`),
+  백엔드 감지, `projectPath` 질문, `vts_setup` 도구로 적용. 그 후 `/reload-plugins`.
+- **도구 직접 호출:** Claude에게 `vts_setup { "projectPath": "…", "backend": "clangd" }`,
+  `vts_config`(유효 설정 표시) 호출 요청.
+- **셸에서:**
+  ```bash
+  vts setup --projectPath <root> --backend clangd
+  vts config
+  ```
+
+백엔드는 루트에서 자동 감지: `compile_commands.json`(또는 `.uproject`) → **clangd**; `.sln`/`.csproj`
+→ **roslyn**. 설정은 시작 시 읽힘 → **변경 후 `/reload-plugins` 실행**. 우선순위:
+**환경변수(`VTS_*`) > config 파일 > 기본값** (같은 이름 환경변수가 있으면 그게 이김).
+
+## 새 버전으로 업데이트
+
+Claude Code는 마켓플레이스 repo를 캐시하므로 새 커밋이 **자동으로 받아지지 않습니다**. 새 버전을
+받으려면:
+
+```bash
+# 1) 캐시된 마켓플레이스 카탈로그 갱신
+/plugin marketplace update vs-token-safer
+
+# 2) 설치된 플러그인 업데이트 (확실히 하려면 uninstall 후 install)
+/plugin update vs-token-safer
+#   안 되면: /plugin uninstall vs-token-safer  그 다음  /plugin install vs-token-safer@vs-token-safer
+
+# 3) 새 훅/명령어/MCP 서버 적용 (의존성은 세션 시작 시 자동 재설치)
+/reload-plugins        # 또는 Claude Code 재시작
+```
+
+`/plugin`으로 설치 상태/버전 확인 가능. `/vs-token-safer:setup` 같은 명령이 안 보이면 설치본이
+구버전 — 위 절차로 업데이트하세요.
+
+> 유지보수 참고: `.claude-plugin/plugin.json`(과 마켓플레이스 엔트리)의 `version` 필드가 업데이트
+> 게이트 — 클라이언트가 변경을 받게 하려면 버전을 올리세요. 변경이 동봉된 `gamedev-log-analyzer`(자체
+> 독립 semver 유지)에만 있더라도 헤드라인 플러그인을 올려야 합니다(아니면 "already at latest"). 버전
+> 히스토리는 [Releases](https://github.com/JSungMin/vs-token-safer/releases)에 있습니다(각 `v*` 태그
+> 자동 생성) — README가 아님.
+
+## 설정 항목 (env)
+
+우선순위: **환경변수(`VTS_*`) > `~/.vs-token-safer/config.json` > 기본값.**
+
+| 설정 키 | 환경변수 | 기본값 | 의미 |
+| --- | --- | --- | --- |
+| `projectPath` | `VTS_PROJECT_PATH` | cwd | 프로젝트 루트(컴파일 DB / `.sln` 위치). |
+| `backend` | `VTS_BACKEND` | auto | `clangd` \| `roslyn` (루트에서 자동 감지). |
+| `maxResults` | `VTS_MAX_RESULTS` | `60` | 반환 `file:line` 개수 상한. |
+| — | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | clangd 실행 파일/인자 재정의. |
+| — | `VTS_ROSLYN_DLL` | auto | 특정 `Microsoft.CodeAnalysis.LanguageServer.dll` 경로. |
+| — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto(MS 엔진) → `csharp-ls` | C# LSP 실행 파일/인자 재정의. |
+| — | `VTS_LSP_TIMEOUT_MS` | `30000` | 요청당 LSP 타임아웃. 차갑고 큰(예: UE) 인덱스면 올림. |
+| — | `VTS_LSP_INDEX_WAIT_MS` | `120000` | clangd warm-up이 첫 쿼리 전 백그라운드 인덱싱 완료를 기다리는 시간. |
+| — | `VTS_CLANGD_OPEN_CAP` | `100` | warm-up이 clangd 인덱스를 데우려 여는 파일 최대 수. |
+| — | `VTS_PREWARM` | on (`projectPath` 설정 시) | MCP 서버가 기동 시 인덱스 pre-warm(IDE식); `0`이면 비활성. |
+| — | `VTS_PREWARM_HOOK` | `0` | SessionStart 훅도 detached `vts warmup`으로 pre-warm(opt-in; 주로 CLI/비-MCP). |
+| — | `VTS_CLANGD_REMOTE` | — | 공유/사전구축 clangd 인덱스 서버 주소(`--remote-index-address`); 개발자별 warmup ~0. |
+| — | `VTS_QUERY_HISTORY` | `~/.vs-token-safer/query-history.json` | 쿼리 이력 원장 위치(warm-up 세트를 곧-검색-우선으로 정렬하는 데 사용). |
+| — | `VTS_CENTRALITY_MAX` | `1500` | warm-up이 include 중심성을 계산할 후보 최대 수(파일을 읽음); `0`이면 비활성. 더 큰 세트는 건너뜀. |
+| — | `VTS_ENFORCE` | `1` | `0`/`false`/`off`이면 Bash 코드 grep 허용(언어 서버 불가 시 탈출구). |
+
+## 강제(enforcement) 동작 방식
+
+- **훅**은 모든 Bash 호출 전에 실행됩니다. 명령이 코드-심볼 검색(grep/rg/ack/ag/findstr 또는
+  `*.c/.cc/.cpp/.h/.hpp/.cs`·`src|source|engine|plugins/` 대상 `find -name`)이고 로그/md/json/빌드
+  경로가 *아니면* 명령을 차단하고 Claude에게 인덱스 도구를 쓰라고 알립니다. 그 외엔 통과. `VTS_ENFORCE=0`
+  이면 완전 비활성.
+- **스킬**은 Claude가 인덱스 도구를 선제적으로 쓰도록 유도합니다.
+- **코어**는 Claude가 도구를 어떻게 호출하든 토큰 상한을 보장합니다.
+
+## 문제 해결
+
+| 증상 | 원인 | 해결 |
+| --- | --- | --- |
+| `/vs-token-safer:setup`가 자동완성에 안 뜸 | 플러그인 미설치(마켓플레이스만 add) 또는 구버전 | `/plugin install vs-token-safer@vs-token-safer` → `/reload-plugins`. `/plugin`에서 버전 확인. |
+| 첫 clangd 쿼리가 매우 느리거나 타임아웃 | 차가운 UE-스케일 인덱스 — clangd가 엔진 헤더 인덱싱 중 | pre-warm(`VTS_PREWARM` on, 또는 `vts warmup`); `VTS_LSP_TIMEOUT_MS`/`VTS_LSP_INDEX_WAIT_MS` 올림. MCP 서버를 띄워둬 인덱스를 warm 유지. |
+| 실제 UE 프로젝트에서 clangd 쿼리가 영영 안 돌아옴(hang) | VS 동봉 clangd 19.1.x가 UE TU에서 **데드락** | **clangd ≥ 22** 설치 후 `VTS_CLANGD_CMD`로 지정. 오래된 clangd 감지 시 vts가 버전 경고 출력. |
+| `GenerateClangDatabase` 실패: "Unable to find valid C++ toolchain for Clang x64" | 타겟이 clang-cl 빌드; UBT가 Clang 툴체인 검증 | UBT 명령에 **`-Compiler=VisualCpp`** 추가 — MSVC DB도 include 그래프를 해석함. |
+| clangd가 헤더 없는 심볼만 해석 | 컴파일 DB에 include 경로 없음 → 시스템/서드파티 헤더 미해석 | UBT 생성 DB 사용(경로 포함); 수작업 `compile_commands.json`은 include 경로를 명시해야 함. |
+| C# 결과 없음 / "No backend resolved" | Roslyn 엔진 미발견 | VS Code C# 확장(`ms-dotnettools.csharp`) 설치, 또는 `dotnet tool install --global csharp-ls`; 또는 `VTS_ROSLYN_DLL`/`VTS_ROSLYN_CMD` 설정. |
+| 원하던 grep인데 코드 검색이 차단됨 | 훅이 인덱스로 유도 중 | `VTS_ENFORCE=0`으로 grep 허용(예: 언어 서버 불가 시). |
+| 잘못된 백엔드 선택됨 | 루트 아래 프로젝트 파일이 여럿 | 고정: `VTS_BACKEND=clangd`(또는 `roslyn`), 또는 호출마다 `backend` 전달. |
+
+## 상태 / 주의
+
+- **clangd 라이브 검증됨** — `compile_commands.json` 프로젝트 대상 실제 clangd로
+  `search_symbol`/`find_references`/`goto_definition` 확인, **실제 Unreal 5.x 게임 프로젝트
+  end-to-end 포함**(게임 `UCLASS` + 그 `*.generated.h` 심볼 반환). **정확한** 컴파일 DB(include 경로
+  포함)와 **clangd ≥ 22** 필요 — 오래된 clangd는 실제 UE TU에서 데드락.
+- **Roslyn 라이브 검증됨** — 실제 `.csproj` 대상 **Microsoft.CodeAnalysis.LanguageServer**(VS 실제
+  엔진)로 확인. VS Code C# 확장 번들에서 자동 감지, `csharp-ls` 폴백.
+- 차가운 UE-스케일 인덱스는 첫 쿼리가 느림 — pre-warm하거나 LSP wait/timeout 환경변수를 올리세요.
+- 절감 원장·벤치마크 수치는 응답 정형화(raw 인덱스 → 캡). grep 대비 절감은 더 큼;
+  [BENCHMARK.md](BENCHMARK.md) 참고.
+
+## 권한 & 안전
+
+전부 **로컬**에서 동작하고 아무것도 업로드하지 않습니다:
+
+- **훅**(`PreToolUse` Bash)은 명령 문자열만 검사해 code-grep을 인덱스로 리다이렉트할지 결정 — 파일
+  내용을 읽거나 무언가 실행하지 않음. `VTS_ENFORCE=0` 존중.
+- **언어 서버**는 기기에서 stdio로 실행됩니다. 유일한 외부 네트워크 호출은 첫 실행 시 MCP SDK의
+  `npm install`뿐. 텔레메트리·소스·쿼리가 기기를 떠나지 않음 — `~/.vs-token-safer/`에 설정 + 로컬
+  토큰절감 원장만 기록.
+- **gamedev-log-analyzer**는 지정한 로컬 로그 파일을 읽어 요약만 출력.
+
+[SECURITY.md](SECURITY.md), [PRIVACY.md](PRIVACY.md) 참고.
+
+## 버전 히스토리
+
+**[Releases](https://github.com/JSungMin/vs-token-safer/releases)** 페이지 참고 — 버전 태그마다
+카테고리·PR 링크된 노트(🚀 Features / 🐛 Bug Fixes / 📝 Documentation / 🔧 Maintenance)가 자동
+생성됩니다. 상단 배지는 항상 최신을 가리킵니다. 지금까지의 하이라이트:
+
+- **v0.1.0** — 초기 vs-token-safer: clangd/Roslyn 기반 `search_symbol`/`find_references`/
+  `goto_definition`, 토큰 캡 코어, grep 차단 훅, 라우팅 스킬, MCP 서버 + `vts` CLI.
+- **v0.2.0** — clangd ≥ 22 권고(오래된 clangd는 UE에서 데드락), 설정 가능한 LSP 타임아웃, 동봉된
+  gamedev-log-analyzer 마켓플레이스 플러그인.
+- **v0.3.0** — 기동 시 IDE식 pre-warm + hit-rate 정렬 warm-up 세트(git/Perforce), 공유/사전구축 원격
+  인덱스(`VTS_CLANGD_REMOTE`).
+- **v0.4.0** — warm-up 정렬에 working-now(`git status` / `p4 opened`)와 include 중심성 추가;
+  gamedev-log-analyzer 0.10.1.
+
+## 기여
+
+이슈·PR 환영 — 버그 리포트, 새 백엔드/엔진, 언어 매핑 추가, 문서 등.
+
+이 repo는 **AI 보조 리뷰**로 유지보수됩니다. 즉 PR은 diff + 설명 + 증거로 판단되니 **작고, 명확히
+설명되고, 증거가 있고, 사내정보(실제 경로·심볼·프로젝트 식별자)가 없게** 올려주세요. 새 코드 경로에는
+`eval/run.mjs`에 eval 가드를 추가하세요. PR 전 **[CONTRIBUTING.md](CONTRIBUTING.md)**를 읽어주세요.
+
+**⭐ 토큰이나 디버깅 시간을 아꼈다면, star가 다른 사람들의 발견을 돕습니다.**
+
+## 개인정보
+
+이 플러그인들은 개인정보를 수집하지 않고 모든 처리를 로컬에서 합니다 — [PRIVACY.md](PRIVACY.md) 참고.
 
 ## 라이선스
 
-[MIT](LICENSE) © JSungMin
+MIT © 2026 JSungMin

--- a/README.md
+++ b/README.md
@@ -1,33 +1,121 @@
-# vs-token-safer
+# vs-token-safer · gamedev-log-analyzer
 
-**Force Claude Code to search C++/C# code through an official language server's index — clangd (LLVM)
-for C/C++, a Roslyn-based LSP for C#/.NET — instead of Bash `grep`, and token-cap the result to a
-compact `file:line` list.** Faster and far fewer tokens on large Unreal C++ / .NET codebases.
-**Local-only. No IDE required.** Ships as a Claude Code plugin (MCP server + hook + skill) and as a
-standalone CLI (`vts`) you run from a clone.
+**English** · [한국어](README.ko.md)
 
-> 🇰🇷 한국어 문서: [README.ko.md](README.ko.md)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-7C3AED)](https://code.claude.com/docs/en/plugins)
+[![MCP](https://img.shields.io/badge/MCP-server-1f6feb)](https://modelcontextprotocol.io)
+[![release](https://img.shields.io/github/v/release/JSungMin/vs-token-safer)](https://github.com/JSungMin/vs-token-safer/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/JSungMin/vs-token-safer/pulls)
+[![Stars](https://img.shields.io/github/stars/JSungMin/vs-token-safer?style=social)](https://github.com/JSungMin/vs-token-safer/stargazers)
 
-The IDE-agnostic sibling of [rider-mcp-enforcer](https://github.com/JSungMin/rider-mcp-enforcer):
-same token-efficiency goal, but instead of proxying a running IDE's MCP server, it spawns the
-**official language server headlessly** — so it works with Visual Studio / any C++/C# project without
-an editor open.
+> Two Claude Code plugins for large Unreal C++, Visual Studio, and .NET projects. Search the codebase
+> through an **official language server's index** (clangd / Roslyn) instead of `grep`, and read
+> tens-of-MB editor logs without dumping them into the conversation. Both cost about 99% fewer tokens
+> than the naive approach. **Local-only. No IDE required.**
+
+### What it looks like
+```text
+# Claude tries to grep code → the hook blocks it and points at the indexed tools:
+$ grep -rn "SpawnActor" Source/**/*.cpp
+🛑 [vs-token-safer] Code-symbol search via Bash. Use search_symbol / find_references
+   instead (clangd/Roslyn index — semantic, token-capped).   # VTS_ENFORCE=0 to allow grep
+
+▶ search_symbol "SpawnActor"
+  func SpawnActor (in AGameMode)   @ Source/GameMode.cpp:142   (+2 more)
+  → ~120 tokens   (grep would have dumped thousands of lines)
+
+# A 1 MB editor log → parsed, deduped, classified (bundled gamedev-log-analyzer):
+▶ /gamedev-log-analyzer:logs
+  41,233 lines · 7 errors · 312 warnings
+  ERROR   [LogStreaming] Failed to load asset <addr>         (×128)   @ AssetManager.cpp:210
+  WARNING [LogPhysics]   Penetration depth <n> exceeds limit (×4,051) @ MyComponent.cpp:88
+  → ~130 tokens   (raw log ≈ 267,000)
+```
+<sub>Illustrative output with public Unreal Engine symbols.</sub>
+
+### Sound familiar?
+- `grep` on a giant Unreal C++ or .NET repo floods the context. Searching through clangd/Roslyn's index instead stays token-capped, around 97–99% smaller ([benchmarks](#performance-measured)).
+- A 50 MB editor log is unreadable as-is. Parsing, deduplicating, and classifying it brings it down to a few hundred tokens.
+- Claude keeps reaching for `grep` on code. A hook catches that and points it at the indexed tools.
+- Unlike an IDE-proxy approach, the language server runs **headlessly** — no editor needs to be open.
+
+### Contents
+- [Marketplace — two plugins](#marketplace--two-plugins) · [Combined savings](#combined-token-savings-measured) · [Using both together](#using-both-together)
+- [What it does](#what-it-does) · [Performance](#performance-measured) · [Pre-warming & hit-rate](#pre-warming--hit-rate)
+- [Prerequisites](#prerequisites) · [Install](#install) · [Setup](#setup--configuration-command) · [Updating](#updating-to-a-new-version)
+- [Configuration](#configuration-env) · [Troubleshooting](#troubleshooting) · [Status / caveats](#status--caveats) · [Contributing](#contributing) · [Releases](https://github.com/JSungMin/vs-token-safer/releases)
 
 ---
 
-## Why
+A Claude Code plugin that routes symbol search, find-references, and go-to-definition through an
+**official language server's index** — **clangd** (LLVM) for C/C++, a **Roslyn-based LSP**
+(`Microsoft.CodeAnalysis.LanguageServer`, the engine Visual Studio / the C# Dev Kit use) for C#/.NET —
+instead of Bash `grep`, and caps the tokens a search flood can spend by returning a compact `file:line`
+list (never source bodies). It's built for large Unreal C++ and .NET/C# codebases, where `grep` is slow
+and burns context.
 
-`grep`/`rg` over a big game or .NET codebase dumps **thousands of lines** into the model's context —
-most of it irrelevant, and it's a raw text match (no symbol semantics). vs-token-safer instead:
+It is the IDE-agnostic sibling of
+[rider-mcp-enforcer](https://github.com/JSungMin/rider-mcp-enforcer): same token-efficiency goal, but
+instead of proxying a running IDE's MCP server, it spawns the official language server **headlessly** —
+so it works with Visual Studio / any C++/C# project without an editor open.
 
-- asks the **language server's index** for the symbol/references/definition (semantic, not text), and
-- returns only a **token-capped `file:line` list** — never source bodies.
+## Marketplace — two plugins
 
-On a 1,000-symbol index response that's a **~97% token reduction** (see [Benchmark](#benchmark)).
-A `PreToolUse` hook **blocks code-symbol `grep` in Bash** and points Claude at the indexed tools, so
-the win happens automatically.
+This repo is a Claude Code plugin marketplace. It holds two plugins built around the same goal: read
+big things without paying for all of it in tokens.
 
-## What it looks like
+| Plugin | Does | Needs |
+| --- | --- | --- |
+| **vs-token-safer** (this page) | Force code search through clangd/Roslyn's index over Bash grep (hard-block by default, escape hatch opt-out), token-capped to `file:line` | Node + a language server (clangd / Roslyn). No IDE. |
+| **[gamedev-log-analyzer](gamedev-log-analyzer/README.md)** | Parse/dedup/classify huge Unreal/Unity/Godot/MSVC-UBT-MSBuild logs (CLI-first), search + diff + locate + extract scalars | Node only (no IDE) |
+
+One-step install: `vs-token-safer` declares `gamedev-log-analyzer` as a dependency, so installing it
+pulls in both. Each server's `npm install` runs on the first session, so there's no manual setup:
+```bash
+/plugin marketplace add JSungMin/vs-token-safer
+/plugin install vs-token-safer@vs-token-safer        # also auto-installs gamedev-log-analyzer
+/reload-plugins                                       # first run auto-installs deps for both
+```
+Want only the log analyzer? Install it alone: `/plugin install gamedev-log-analyzer@vs-token-safer`.
+
+### Combined token savings (measured)
+| Task | Bash / raw | Plugin | Reduction |
+| --- | ---: | ---: | ---: |
+| Symbol search on a real UE5 repo (`FGameplayTag`) | ~282,194 tok | ~2,048 tok | **~99.3% (~138×)** |
+| Raw index response → capped list (eval, 1,000 symbols) | ~57,308 tok | ~1,515 tok | **~97.4%** |
+| Read a ~1 MB editor log (`summary`) | ~267,000 tok | ~130 tok | **~99.95%** |
+
+### Using both together
+The log analyzer emits `file:line` for each entry; vs-token-safer turns a `file:line` into the actual
+symbol/source. A typical loop:
+1. `/gamedev-log-analyzer:logs` → find the error/warning and its `file:line`.
+2. Hand that location to vs-token-safer's `goto_definition` / `find_references` (or `search_symbol`) to
+   open and understand the code — without ever grepping or dumping the raw log.
+
+## What it does
+
+clangd and Roslyn already do semantic symbol/reference analysis on their own. What this plugin adds on
+top is the **enforcement**, the **token cap**, and the **headless spawn + warm-up** so Claude actually
+uses the index instead of grep:
+
+| Layer | File | Effect |
+| --- | --- | --- |
+| **Enforcement hook** | `hooks/block-code-grep.js` | Intercepts Bash `grep`/`rg`/`ack`/`ag`/`findstr` and `find -name` over source files (`.c/.cc/.cpp/.h/.hpp/.cs`, or `src/`, `source/`, `engine/`, `plugins/`) and steers Claude to the indexed tools. **Surgical**: only fires when a search tool is the actual executable of a command segment; lets raw-text searches (logs, `.md`, `.json`, config, build/intermediate dirs) through untouched. Escape hatch `VTS_ENFORCE=0`. |
+| **Routing skill** | `skills/vs-search/SKILL.md` | Rules that bias Claude toward the indexed tools first: symbol/reference/definition lookups → `search_symbol` / `find_references` / `goto_definition`; grep is last resort. |
+| **Token-capping core** | `server/core.js` | `runTool()` shared by both adapters: turns LSP results into `kind name (in container) @ file:line`, caps at `maxResults`, appends a `… N more` footer — never ranges, kinds, or source bodies. Records a local savings ledger. |
+| **Headless LSP client** | `server/lsp.js` + `server/backends/index.js` | A minimal, fully-owned LSP client (JSON-RPC 2.0, `Content-Length` framing) that spawns the official engine over stdio, plus the spawn configs + `pickBackend(root)` autodetect and the IDE-style pre-warm (`afterInit`). |
+
+> **Engine = official, glue = ours.** clangd (LLVM) and Roslyn (Microsoft) do the analysis; this repo
+> only writes the LSP↔MCP glue. No third-party MCP server runs over your source.
+
+### Commands & tools
+- `/vs-token-safer:setup` — configure the plugin (see [Setup](#setup--configuration-command)).
+- `/vs-token-safer:savings` — show cumulative token savings.
+- MCP tools (server `vs-search`): `search_symbol`, `find_references`, `goto_definition`, `vts_warmup`,
+  `vts_setup`, `vts_config`, `vts_savings`, `vts_savings_reset`.
+- CLI (`vts`): `symbol`, `references`, `definition`, `warmup`, `setup`, `config`, `savings`,
+  `savings-reset`.
 
 ```
 $ vts symbol --q SpawnActor --projectPath ./MyGame
@@ -39,197 +127,53 @@ func SpawnActorFromClass  @ MyGame/Source/SpawnLib.cpp:31
 ✓ Saved ~4,200 tokens here (96.8% / 31× smaller than the raw index response).
 ```
 
----
+## Performance (measured)
 
-## Install
+Real A/B on a large Unreal Engine 5 project — finding one public engine symbol (`FGameplayTag`) via
+Bash grep-and-paste vs this plugin. No project source is reproduced; only aggregate counts. See
+[BENCHMARK.md](BENCHMARK.md) for method.
 
-### As a Claude Code plugin
+| | Bash grep-and-paste (whole repo) | **Plugin (clangd index, capped)** |
+| --- | ---: | ---: |
+| What the model receives | 5,654 lines / 1,010 files | 47 semantic decls (`file:line`) |
+| Tokens to the model | ~282,194 | **~2,048** |
 
-```
-/plugin marketplace add JSungMin/vs-token-safer
-/plugin install vs-token-safer
-/reload-plugins
-```
+- **Tokens: ~99.3% fewer (~138×).** grep returns the full text of every matching line (and matches by
+  text, so it returns more — comments, strings, unrelated identifiers); the plugin returns one
+  `file:line` per semantic hit, capped.
+- The mock-LSP eval (`node eval/run.mjs`, no toolchain) gates the response-shaping win on every commit:
+  raw index `~57,308 tok` → capped output `~1,515 tok` = **97.4%** (12/12 checks).
 
-This wires up the `vs-search` MCP server, the grep-blocking hook, and the routing skill. On first
-run the MCP server installs its one dependency (`@modelcontextprotocol/sdk`) into the plugin's data
-directory.
+### Accuracy difference (and why)
+This is a precision/recall trade-off, not a case of one being more correct than the other:
+- **Recall:** the plugin returns the top `N` (cap), not every textual occurrence. The withheld tail is
+  mostly comments/includes/substring noise. Need an exhaustive list? Raise `maxResults` / use grep.
+- **Precision:** grep matches every substring (a `Foo` query also hits `FooBar`), over-reporting
+  heavily; the index returns distinct **semantic** declarations — `search_symbol` is a symbol-index
+  query, `find_references`/`goto_definition` resolve the symbol at a position, not a text match.
 
-### As a standalone CLI (no IDE, no Claude Code)
-
-Not published to npm — install from a clone:
-
-```
-git clone https://github.com/JSungMin/vs-token-safer
-cd vs-token-safer/server && npm install && npm link   # provides `vts`
-# or run directly, no link:
-node /path/to/vs-token-safer/server/cli.js symbol --q SpawnActor --projectPath /path/to/proj
-```
-
-### Prerequisites — the language server
-
-vs-token-safer drives an official engine; install the one(s) you need:
-
-| Backend | Language | Engine | Install | Needs |
-| --- | --- | --- | --- | --- |
-| `clangd` | C/C++ | clangd (LLVM) — **use clangd ≥ 22** ([clangd releases](https://github.com/clangd/clangd/releases)); the clangd 19.1.x bundled with Visual Studio can deadlock on Unreal | [clangd releases](https://github.com/clangd/clangd/releases) or your package manager | `compile_commands.json` |
-| `roslyn` | C#/.NET | **Microsoft.CodeAnalysis.LanguageServer** (the engine Visual Studio / the C# Dev Kit use), `csharp-ls` fallback | install the **VS Code C# extension** (`ms-dotnettools.csharp`) — bundles the engine + its runtime; or `dotnet tool install --global csharp-ls` | `.sln` / `.csproj` |
-
-**clangd needs a compile database** (`compile_commands.json`):
-- **Unreal Engine:** generate via UBT — `<UE>/Engine/Build/BatchFiles/RunUBT … -mode=GenerateClangDatabase`.
-  - If your targets are configured to **build with clang-cl**, add **`-Compiler=VisualCpp`** — otherwise
-    `GenerateClangDatabase` fails clang-toolchain validation (`Unable to find valid <ver> C++ toolchain for
-    Clang x64`). The MSVC-compiler database still resolves the full engine include graph for clangd.
-  - **Use clangd ≥ 22.** The clangd 19.1.x bundled with Visual Studio (`…/VC/Tools/Llvm/bin/clangd.exe`)
-    **deadlocks** indexing real UE translation units in server mode (`clangd --check` parses them, but
-    queries never return). Standalone clangd 22.1.6 handles the same project in seconds and returns
-    symbols. Point `VTS_CLANGD_CMD` at a current clangd; vts warns if it detects an older one.
-  - The database is large (a full editor target ≈ tens of thousands of entries). On a **cold** index the
-    first query can be slow while clangd indexes the engine headers — see `VTS_LSP_TIMEOUT_MS` /
-    `VTS_LSP_INDEX_WAIT_MS` below, or keep the MCP server running so the index stays warm.
-  - **Pre-warm like an IDE:** the MCP server indexes the configured `projectPath` at boot (`VTS_PREWARM`,
-    on by default) so the first search is already warm; or run **`vts warmup`** once to build clangd's
-    on-disk index (`.cache/clangd`) up front. Either way you pay the warmup once, not per query.
-  - **Warm-up ordering (hit-rate):** the open-set is ordered likely-query-first — by query history (files
-    that answered past searches), then VCS recency (**git** `log` and **Perforce** `p4 opened`), then mtime.
-    This steers clangd's per-file index priority so the warm window covers what you actually search.
-  - **Shared/prebuilt index (teams/CI):** set `VTS_CLANGD_REMOTE` to a clangd-index-server address so
-    everyone queries one prebuilt index — near-zero per-developer warmup.
-- **CMake:** configure with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.
-
-**C# uses the official Visual Studio Roslyn engine automatically.** vs-token-safer auto-detects
-`Microsoft.CodeAnalysis.LanguageServer` (and the matching .NET runtime) from the VS Code C# extension
-bundle, opens your `.sln`/`.csproj`, and waits for the project load before querying — no flags needed.
-Point `VTS_ROSLYN_DLL` at a specific `Microsoft.CodeAnalysis.LanguageServer.dll`, or
-`VTS_ROSLYN_CMD`/`VTS_ROSLYN_ARGS` at any other Roslyn LSP, to override. If neither the MS engine nor
-an override is found, it falls back to `csharp-ls`.
-
----
-
-## Usage
-
-### MCP tools (server name: `vs-search`)
-
-| Tool | Purpose | Key args |
-| --- | --- | --- |
-| `search_symbol` | Find symbol declarations by name/substring | `q`, `projectPath`, `backend`, `maxResults` |
-| `find_references` | References/usages of the symbol at a position | `path`, `line`, `character` (0-based), `includeDeclaration` |
-| `goto_definition` | Definition of the symbol at a position | `path`, `line`, `character` (0-based) |
-| `vts_setup` | Persist config (`~/.vs-token-safer/config.json`) | `projectPath`, `backend`, `maxResults` |
-| `vts_config` | Show effective settings | — |
-| `vts_savings` / `vts_savings_reset` | Token-savings ledger | — |
-
-### CLI (`vts`)
-
-```
-vts symbol      --q <name> --projectPath <dir> [--backend clangd|roslyn] [--maxResults N]
-vts references  --path <file> --line N --character N [--includeDeclaration]
-vts definition  --path <file> --line N --character N
-vts setup       [--projectPath <dir>] [--backend …] [--maxResults N]
-vts config
-vts savings | vts savings-reset
-```
-
-Slash commands (plugin): `/vs-token-safer:setup`, `/vs-token-safer:savings`.
-
----
-
-## Configuration
-
-Precedence: **environment variable (`VTS_*`) > `~/.vs-token-safer/config.json` > default.**
-
-| Config key | Env var | Default | Meaning |
-| --- | --- | --- | --- |
-| `projectPath` | `VTS_PROJECT_PATH` | cwd | Project root (where the compile DB / `.sln` lives) |
-| `backend` | `VTS_BACKEND` | auto | `clangd` \| `roslyn` (auto-detected from the root) |
-| `maxResults` | `VTS_MAX_RESULTS` | `60` | Cap on returned `file:line` locations |
-| — | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | Override the clangd executable / args |
-| — | `VTS_LSP_TIMEOUT_MS` | `30000` | Per-request LSP timeout. Raise for a cold, large (e.g. UE) index |
-| — | `VTS_LSP_INDEX_WAIT_MS` | `120000` | How long the clangd warm-up waits for background-index completion before the first query |
-| — | `VTS_CLANGD_OPEN_CAP` | `100` | Max files the warm-up opens to prime clangd's index |
-| — | `VTS_PREWARM` | on (if `projectPath` set) | MCP server pre-warms the index at boot (IDE-style) so the first search is warm; set `0` to disable |
-| — | `VTS_PREWARM_HOOK` | `0` | SessionStart hook also pre-warms via a detached `vts warmup` (opt-in; mainly for CLI/non-MCP use) |
-| — | `VTS_CLANGD_REMOTE` | — | Address of a shared/prebuilt clangd index server (`--remote-index-address`); near-zero per-dev warmup |
-| — | `VTS_QUERY_HISTORY` | `~/.vs-token-safer/query-history.json` | Where the query-history ledger lives (used to order the warm-up set by likely-query-first) |
-| — | `VTS_CENTRALITY_MAX` | `1500` | Max candidates for which warm-up computes include-centrality (reads files); `0` disables. Skipped on bigger sets |
-| — | `VTS_ROSLYN_DLL` | auto | Path to a specific `Microsoft.CodeAnalysis.LanguageServer.dll` |
-| — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto (MS engine) → `csharp-ls` | Override the C# LSP executable / args |
-| — | `VTS_ENFORCE` | `1` | Set `0`/`false`/`off` to let Bash code-grep through (escape hatch) |
-
-Backend auto-detect: `compile_commands.json` (or a `.uproject`) → **clangd**; a `.sln`/`.csproj` →
-**roslyn**.
-
----
-
-## The grep-blocking hook
-
-A `PreToolUse` (Bash) hook blocks code-symbol searches — `grep`/`rg`/`ack`/`ag`/`findstr`, or
-`find -name`, over source files (`.c/.cc/.cpp/.h/.hpp/.cs`, or `src/`, `source/`, `engine/`,
-`plugins/`) — and tells Claude to use the indexed tools instead. It is **surgical**: it only fires
-when a search tool is the actual executable of a command segment, and it lets **raw text** searches
-(logs, `.md`, `.json`, config, build/intermediate dirs) through untouched. If the language server is
-unavailable, set `VTS_ENFORCE=0` so grep isn't blocked.
-
----
-
-## Backend support matrix
-
-| Backend | Status | Notes |
-| --- | --- | --- |
-| `clangd` (C/C++) | ✅ live-verified (incl. real Unreal 5.x) | `search_symbol` / `find_references` / `goto_definition` confirmed against real clangd on a `compile_commands.json` project, **including a real Unreal 5.x game project end-to-end** (returned the game `UCLASS` + its `*.generated.h` symbols). Needs a **correct** compile DB (with include dirs — Unreal: generate via UBT, `-Compiler=VisualCpp` for clang-cl targets). **Use clangd ≥ 22** — the VS-bundled clangd 19.1.x (`…/VC/Tools/Llvm/bin/clangd.exe`) deadlocks on real UE TUs; vts warns if it detects an older one. Cold UE-scale indexes: raise `VTS_LSP_TIMEOUT_MS` / `VTS_LSP_INDEX_WAIT_MS`. |
-| `roslyn` (C#/.NET) | ✅ live-verified | `search_symbol` / `find_references` / `goto_definition` confirmed against **Microsoft.CodeAnalysis.LanguageServer** (the actual VS engine) on a real `.csproj`. Auto-detected; `csharp-ls` fallback. |
-
----
-
-## How it works (architecture)
-
-```
-Claude Code ──(MCP / CLI)──▶ vs-token-safer  ──(LSP over stdio)──▶ clangd / csharp-ls ──▶ your source
-                              └ runTool(): token-cap LSP results → file:line, no bodies
-```
-
-- `server/lsp.js` — a minimal, fully-owned **LSP client** (JSON-RPC 2.0, `Content-Length` framing).
-  The one genuinely new piece.
-- `server/backends/index.js` — how to spawn each official engine + `pickBackend(root)` autodetect.
-- `server/core.js` — async `runTool()` dispatch, the token-capping formatters, the savings ledger.
-  Shared by both adapters so there is exactly one implementation per tool.
-- `server/index.js` — the MCP server (thin adapter). `server/cli.js` — the `vts` CLI (thin adapter).
-
-**Engine = official, glue = ours.** clangd (LLVM) and Roslyn (Microsoft) do the analysis; this repo
-only writes the LSP↔MCP glue. No third-party MCP server runs over your source.
-
----
-
-## Benchmark
-
-The eval (`node eval/run.mjs`, mock LSP — no toolchain needed) gates the token win on every commit:
-
-```
-raw index ~57,308 tok → capped output ~1,515 tok      = 97.4% reduction (1,000 symbols)
-```
-
-That is the response-shaping win (raw index response → capped list). Versus pasting `grep` output
-into context, the saving is typically larger still, because grep returns full matching lines.
-
----
+> So: for navigation (a definition plus representative usages) the plugin is both more accurate and far
+> cheaper. For an exhaustive occurrence audit, raise the cap or fall back to grep on purpose.
 
 ## Pre-warming & hit-rate
 
 clangd indexes asynchronously, so the *first* search after the server starts pays a one-time warm-up
-(it indexes the engine headers). vts handles this like an IDE:
+(it indexes the engine headers). vs-token-safer handles this like an IDE:
 
 - **The MCP server pre-warms at boot** (`VTS_PREWARM`, on by default when `projectPath` is set) — by the
   time you run your first search the index is already warming, and the client is cached for the server's
   lifetime, so you pay the warm-up **once per session, not per query** (later searches are sub-second).
 - **`vts warmup`** builds clangd's on-disk index (`.cache/clangd`) up front, for CLI/CI use.
-- **`VTS_CLANGD_REMOTE`** points clangd at a shared/prebuilt index server → near-zero per-developer warm-up.
+- **`VTS_CLANGD_REMOTE`** points clangd at a shared/prebuilt clangd-index-server → near-zero
+  per-developer warm-up (teams/CI query one prebuilt index).
 
 **Which files get warmed first matters.** clangd boosts the indexing priority of files you open, so vts
 orders the warm-up set *likely-query-first*: **query history** (files that answered past searches) →
-**what you're editing now** (`git status` modified/untracked + Perforce `p4 opened`) → **git-log recency**
-→ **include centrality** (headers many candidates `#include`, bounded by `VTS_CENTRALITY_MAX`) → mtime.
-On a huge tree you can only warm a small slice, so this ordering is what makes the warm window actually
-contain what you search for. Works with both git and Perforce.
+**what you're editing now** (`git status` modified/untracked + Perforce `p4 opened`) → **git-log
+recency** → **include centrality** (headers many candidates `#include`, bounded by `VTS_CENTRALITY_MAX`)
+→ mtime. On a huge tree you can only warm a small slice (hundreds of TUs out of tens of thousands in
+Unreal), so this ordering is what makes the warm window actually contain what you search for. Works with
+both **git** and **Perforce**.
 
 Measured lift (`node eval/bench-hitrate.mjs` — the real `orderForWarm()` over a synthetic workload with
 realistic locality, 2,000 files):
@@ -242,28 +186,225 @@ realistic locality, 2,000 files):
 | 20% | 24.8% | **68.5%** | 2.8× |
 | 50% | 46.3% | **80.5%** | 1.7× |
 
-The smaller the slice you can afford to warm (e.g. ~hundreds of TUs out of tens of thousands in Unreal),
-the bigger the win — arbitrary order hits almost nothing; ordering hits the majority.
+The smaller the slice you can afford to warm, the bigger the win — arbitrary order hits almost nothing;
+ordering hits the majority.
 
----
+## How much did it save? (token-savings command)
 
-## Privacy & security
+The core records, per search, the tokens it saved vs forwarding the language server's raw index
+response. Check the running total any of these ways:
 
-**Local-only, zero transmission.** The language server runs on your machine over stdio; the only
-outbound network call is the first-run `npm install` of the MCP SDK. No telemetry, no source, no
-queries leave your machine. See [PRIVACY.md](PRIVACY.md) and [SECURITY.md](SECURITY.md).
+- **In Claude Code:** run `/vs-token-safer:savings` (or just ask "how much has the plugin saved?"). It
+  calls the `vts_savings` MCP tool.
+- **From a shell:** `vts savings`
+- **Reset:** call the `vts_savings_reset` tool (or `vts savings-reset`).
 
-## Development
-
+Example output:
 ```
-npm install            # dev tooling at repo root (eslint, prettier)
-npm test               # node eval/run.mjs → EVAL PASSED
-npm run lint
-cd server && npm install   # MCP server deps, then `node index.js` to start the server
+vs-token-safer savings (local, 1 search(es))
+  total saved: ~4,200 tokens vs forwarding raw index responses
+  raw → output: 4,340 → 140 tok (~31× smaller)
+  biggest single run: 4,340 → 140 tok
+```
+> "Saved" here is vs the language server's *raw* index response. Savings vs **Bash grep** are typically
+> far larger — see [BENCHMARK.md](BENCHMARK.md).
+
+## Prerequisites
+
+- **Node.js ≥ 18** on PATH.
+- A language server for the language(s) you search:
+  - **C/C++ → clangd ≥ 22** ([clangd releases](https://github.com/clangd/clangd/releases)). The clangd
+    19.1.x bundled with Visual Studio (`…/VC/Tools/Llvm/bin/clangd.exe`) **deadlocks** indexing real
+    Unreal translation units in server mode — vts warns if it detects an older one. Needs a
+    `compile_commands.json` compile database.
+  - **C#/.NET → a Roslyn LSP.** Install the **VS Code C# extension** (`ms-dotnettools.csharp`) — vts
+    auto-detects `Microsoft.CodeAnalysis.LanguageServer` and its private .NET runtime from the bundle.
+    Fallback: `dotnet tool install --global csharp-ls`. Needs a `.sln`/`.csproj`.
+- No IDE has to be running.
+
+**clangd needs a compile database** (`compile_commands.json`):
+- **Unreal Engine:** generate via UBT — `<UE>/Engine/Build/BatchFiles/RunUBT … -mode=GenerateClangDatabase`.
+  If your targets build with **clang-cl**, add **`-Compiler=VisualCpp`** — otherwise
+  `GenerateClangDatabase` fails clang-toolchain validation (`Unable to find valid C++ toolchain for
+  Clang x64`); the MSVC-compiler database still resolves the full engine include graph for clangd.
+- **CMake:** configure with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.
+
+## Install
+
+```bash
+# 1) Add the marketplace and install (also auto-installs gamedev-log-analyzer)
+/plugin marketplace add JSungMin/vs-token-safer
+/plugin install vs-token-safer@vs-token-safer
+/reload-plugins        # first run auto-installs the server deps (no manual npm)
+
+# 2) Configure it — from inside Claude Code, just run:
+/vs-token-safer:setup
+#   It detects the backend, asks for the project path, and writes the config.
 ```
 
-Add an eval guard in `eval/run.mjs` for any new code path. See [CONTRIBUTING.md](CONTRIBUTING.md).
+Verify the `vs-search` MCP server and its tools appear, and that a `grep src/**/*.cpp` is blocked with a
+nudge toward the indexed tools (or runs freely under `VTS_ENFORCE=0`). The MCP server's one dependency
+(`@modelcontextprotocol/sdk`) installs automatically on the first session into the plugin's data
+directory.
+
+### As a standalone CLI (no IDE, no Claude Code)
+
+vs-token-safer is **not published to npm** — install the `vts` CLI from a clone:
+
+```bash
+git clone https://github.com/JSungMin/vs-token-safer
+cd vs-token-safer/server && npm install && npm link   # provides `vts`
+# or run directly, no link:
+node /path/to/vs-token-safer/server/cli.js symbol --q SpawnActor --projectPath /path/to/proj
+```
+
+## Setup / configuration command
+
+You don't edit OS environment variables. Settings live in a config file
+(`~/.vs-token-safer/config.json`) the CLI and MCP server read at startup. Configure it any of these ways:
+
+- **In Claude Code (recommended):** `/vs-token-safer:setup` — guided: it shows current settings
+  (`vts_config`), detects the backend, asks for `projectPath`, and applies via the `vts_setup` tool.
+  Then `/reload-plugins`.
+- **Ad-hoc via tools:** ask Claude to call `vts_setup { "projectPath": "…", "backend": "clangd" }`,
+  `vts_config` (show effective settings).
+- **From a shell:**
+  ```bash
+  vts setup --projectPath <root> --backend clangd
+  vts config
+  ```
+
+Backend auto-detects from the root: `compile_commands.json` (or a `.uproject`) → **clangd**; a
+`.sln`/`.csproj` → **roslyn**. Settings are read at startup → **run `/reload-plugins` after changing
+them**. Precedence: **environment variable (`VTS_*`) > config file > built-in default** (so a same-named
+env var still wins).
+
+## Updating to a new version
+
+Claude Code caches the marketplace repo, so new commits are **not** auto-fetched. To pull a newer
+version of this plugin:
+
+```bash
+# 1) Refresh the cached marketplace catalog
+/plugin marketplace update vs-token-safer
+
+# 2) Update the installed plugin (or uninstall + install to be sure)
+/plugin update vs-token-safer
+#   fallback: /plugin uninstall vs-token-safer  then  /plugin install vs-token-safer@vs-token-safer
+
+# 3) Reload so the new hook/command/MCP server take effect (deps auto-reinstall on session start)
+/reload-plugins        # or restart Claude Code
+```
+
+Check what's installed with `/plugin` (it lists each plugin's version). If a command like
+`/vs-token-safer:setup` is missing, your installed copy predates it — update as above.
+
+> Maintainer note: the `version` field in `.claude-plugin/plugin.json` (and the marketplace entry) gates
+> updates — bump it when you want clients to pick up changes. The headline plugin must bump even when the
+> change lands only in the bundled `gamedev-log-analyzer` (which keeps its own independent semver),
+> otherwise clients see "already at latest". Version history lives in
+> [Releases](https://github.com/JSungMin/vs-token-safer/releases) (auto-generated on each `v*` tag), not
+> in this README.
+
+## Configuration (env)
+
+Precedence: **environment variable (`VTS_*`) > `~/.vs-token-safer/config.json` > default.**
+
+| Config key | Env var | Default | Meaning |
+| --- | --- | --- | --- |
+| `projectPath` | `VTS_PROJECT_PATH` | cwd | Project root (where the compile DB / `.sln` lives). |
+| `backend` | `VTS_BACKEND` | auto | `clangd` \| `roslyn` (auto-detected from the root). |
+| `maxResults` | `VTS_MAX_RESULTS` | `60` | Cap on returned `file:line` locations. |
+| — | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | Override the clangd executable / args. |
+| — | `VTS_ROSLYN_DLL` | auto | Path to a specific `Microsoft.CodeAnalysis.LanguageServer.dll`. |
+| — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto (MS engine) → `csharp-ls` | Override the C# LSP executable / args. |
+| — | `VTS_LSP_TIMEOUT_MS` | `30000` | Per-request LSP timeout. Raise for a cold, large (e.g. UE) index. |
+| — | `VTS_LSP_INDEX_WAIT_MS` | `120000` | How long the clangd warm-up waits for background-index completion before the first query. |
+| — | `VTS_CLANGD_OPEN_CAP` | `100` | Max files the warm-up opens to prime clangd's index. |
+| — | `VTS_PREWARM` | on (if `projectPath` set) | MCP server pre-warms the index at boot (IDE-style); set `0` to disable. |
+| — | `VTS_PREWARM_HOOK` | `0` | SessionStart hook also pre-warms via a detached `vts warmup` (opt-in; mainly CLI/non-MCP). |
+| — | `VTS_CLANGD_REMOTE` | — | Address of a shared/prebuilt clangd index server (`--remote-index-address`); near-zero per-dev warmup. |
+| — | `VTS_QUERY_HISTORY` | `~/.vs-token-safer/query-history.json` | Where the query-history ledger lives (used to order the warm-up set likely-query-first). |
+| — | `VTS_CENTRALITY_MAX` | `1500` | Max candidates for which warm-up computes include-centrality (reads files); `0` disables. Skipped on bigger sets. |
+| — | `VTS_ENFORCE` | `1` | `0`/`false`/`off` lets Bash code-grep through (escape hatch when the language server is unavailable). |
+
+## How enforcement works
+
+- The **hook** runs before every Bash call. If the command is a code-symbol search (grep/rg/ack/ag/
+  findstr or `find -name` targeting `*.c/.cc/.cpp/.h/.hpp/.cs` or `src|source|engine|plugins/`) and is
+  *not* aimed at a log/md/json/build path, it blocks the command and tells Claude to use the indexed
+  tool instead. Otherwise it allows the command. `VTS_ENFORCE=0` disables it entirely.
+- The **skill** biases Claude toward the indexed tools proactively.
+- The **core** guarantees the token cap regardless of how Claude calls the tool.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `/vs-token-safer:setup` not in autocomplete | Plugin not installed (only marketplace added), or stale | `/plugin install vs-token-safer@vs-token-safer` → `/reload-plugins`. Check version with `/plugin`. |
+| First clangd query is very slow or times out | Cold UE-scale index — clangd is indexing engine headers | Pre-warm (`VTS_PREWARM` on, or run `vts warmup`); raise `VTS_LSP_TIMEOUT_MS` / `VTS_LSP_INDEX_WAIT_MS`. Keep the MCP server running so the index stays warm. |
+| clangd query never returns (hangs) on a real UE project | The clangd 19.1.x bundled with Visual Studio **deadlocks** on UE TUs | Install **clangd ≥ 22** and point `VTS_CLANGD_CMD` at it. vts prints a version advisory when it detects an old clangd. |
+| `GenerateClangDatabase` fails: "Unable to find valid C++ toolchain for Clang x64" | Targets build with clang-cl; UBT validates a Clang toolchain | Add **`-Compiler=VisualCpp`** to the UBT command — the MSVC database still resolves the include graph. |
+| clangd resolves only header-free symbols | Compile DB has no include dirs → system/3rd-party headers don't resolve | Use a UBT-generated DB (it includes the paths); a hand-rolled `compile_commands.json` must list the include dirs. |
+| No C# results / "No backend resolved" | Roslyn engine not found | Install the VS Code C# extension (`ms-dotnettools.csharp`), or `dotnet tool install --global csharp-ls`; or set `VTS_ROSLYN_DLL` / `VTS_ROSLYN_CMD`. |
+| Code search blocked when you wanted plain grep | The hook is steering you to the index | Set `VTS_ENFORCE=0` to let grep through (e.g. when the language server is unavailable). |
+| Wrong backend picked | Multiple project files under the root | Pin it: `VTS_BACKEND=clangd` (or `roslyn`), or pass `backend` per call. |
+
+## Status / caveats
+
+- **clangd live-verified** — `search_symbol` / `find_references` / `goto_definition` confirmed against
+  real clangd on a `compile_commands.json` project, **including a real Unreal 5.x game project
+  end-to-end** (returned the game `UCLASS` + its `*.generated.h` symbols). Needs a **correct** compile
+  DB (with include dirs) and **clangd ≥ 22** — older clangd deadlocks on real UE TUs.
+- **Roslyn live-verified** — confirmed against **Microsoft.CodeAnalysis.LanguageServer** (the actual VS
+  engine) on a real `.csproj`. Auto-detected from the VS Code C# extension bundle; `csharp-ls` fallback.
+- Cold UE-scale indexes are slow on the first query — pre-warm or raise the LSP wait/timeout envs.
+- The savings ledger and benchmark numbers are response-shaping (raw index → capped). Savings vs grep
+  are larger; see [BENCHMARK.md](BENCHMARK.md).
+
+## Permissions & safety
+
+Everything runs locally and nothing is uploaded:
+
+- The **hook** (`PreToolUse` on Bash) only inspects the command string to decide whether to redirect a
+  code-grep to the index — it does not read file contents or run anything. It honors `VTS_ENFORCE=0`.
+- The **language server** runs on your machine over stdio. The only outbound network call is the
+  first-run `npm install` of the MCP SDK. No telemetry, no source, no queries leave your machine — it
+  writes only its config + a local token-savings ledger under `~/.vs-token-safer/`.
+- **gamedev-log-analyzer** reads local log files you point it at and prints summaries.
+
+See [SECURITY.md](SECURITY.md) and [PRIVACY.md](PRIVACY.md).
+
+## Version history
+
+See the **[Releases](https://github.com/JSungMin/vs-token-safer/releases)** page — every version tag
+publishes categorized, PR-linked notes (🚀 Features / 🐛 Bug Fixes / 📝 Documentation / 🔧 Maintenance),
+generated automatically. The badge at the top always points at the latest. Highlights so far:
+
+- **v0.1.0** — initial vs-token-safer: clangd/Roslyn-backed `search_symbol` / `find_references` /
+  `goto_definition`, token-cap core, grep-blocking hook, routing skill, MCP server + `vts` CLI.
+- **v0.2.0** — clangd ≥ 22 advisory (older clangd deadlocks on UE), configurable LSP timeouts, and the
+  bundled gamedev-log-analyzer marketplace plugin.
+- **v0.3.0** — IDE-style pre-warm at boot + hit-rate-ordered warm-up set (git/Perforce), shared/prebuilt
+  remote index (`VTS_CLANGD_REMOTE`).
+- **v0.4.0** — warm-up ordering extended with working-now (`git status` / `p4 opened`) and include
+  centrality; gamedev-log-analyzer 0.10.1.
+
+## Contributing
+
+Issues and PRs welcome — bug reports, new backends/engines, additional language mappings, or docs.
+
+This repo is maintained with AI-assisted review, so PRs are judged from the diff, description, and
+evidence. Keep them small, clearly described, backed by evidence, and free of any proprietary data
+(real paths, symbols, or project identifiers). Add an eval guard in `eval/run.mjs` for any new code
+path. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.
+
+If this saved you tokens or debugging time, a star helps others find it. ⭐
+
+## Privacy
+
+These plugins collect no personal data and process everything locally — see [PRIVACY.md](PRIVACY.md).
 
 ## License
 
-[MIT](LICENSE) © JSungMin
+MIT © 2026 JSungMin


### PR DESCRIPTION
Fourth integration from `dev` (on top of v0.4.0). Docs/community polish so the repo reads like a mature, well-known project.

## What
- **README.md / README.ko.md**: badges (Claude Code, MCP, release, MIT, PRs, Stars — no npm), EN/KO switch, TOC, 'Marketplace — two plugins', What-it-does layer table, Performance (real-UE A/B ~282k → ~2k, ~138×), Pre-warming & hit-rate, Prerequisites/Install/Setup, Updating, full Configuration env table (15 vars), Troubleshooting, Status/caveats, Permissions & safety, Version history (v0.1–v0.4), Contributing.
- **BENCHMARK.md**: rider-style structure (A/B, token savings, honest search-time, accuracy, logs A/B, reproduce) with vts's measured numbers.
- **plugin.json**: declares the `gamedev-log-analyzer` dependency (one-step install) + 'Auto-installs' note — so `/plugin install vs-token-safer@vs-token-safer` pulls both.
- **dependabot**: add `/gamedev-log-analyzer/server`.

## Verification
- eval 12/12; `node eval/bench-hitrate.mjs` OK; `claude plugin validate . --strict` ✔.
- No proprietary data — synthetic / Epic-public symbols only (FGameplayTag, SpawnActor, …).

Docs-only; no code/behavior change.