### PR TITLE
dev → main: adaptive include-centrality (prefix-read + time budget + growing cache) — v0.6.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,8 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
 - `server/cli.js` — `vts <cmd>`. `server/index.js` — MCP server (async handler → `await runTool`).
 - `server/sdk.js` — createRequire MCP-SDK resolution. `server/ensure-deps.mjs` — SessionStart installer.
 - `server/warmset.js` — prewarm ORDERING: `orderForWarm` (query-history > working-now [`git status` /
-  `p4 opened`] > git-log recency > include-centrality [bounded by `VTS_CENTRALITY_MAX`] > mtime) +
+  `p4 opened`] > git-log recency > include-centrality [adaptive: prefix-read + `VTS_CENTRALITY_BUDGET_MS`
+  + persistent include-graph cache that grows across warmups; `VTS_CENTRALITY_MAX` bounds the loop] > mtime) +
   `recordQueryResults`. Steers clangd's open-set so the warm window hits likely queries; git + Perforce.
   Used by `backends/index.js` afterInit + `core.js` (records result files per search).
 - `hooks/block-code-grep.js` + `hooks.json` — grep-block (escape hatch `VTS_ENFORCE=0`).

--- a/README.ko.md
+++ b/README.ko.md
@@ -167,7 +167,8 @@ vts는 이를 IDE처럼 처리합니다:
 **무엇을 먼저 데우느냐가 중요합니다.** clangd는 열린 파일의 인덱싱 우선순위를 높이므로, vts는 warm-up
 대상을 *곧 검색할 것 우선*으로 정렬합니다: **쿼리 이력**(과거 검색이 반환한 파일) → **지금 편집
 중**(`git status` 수정/미추적 + Perforce `p4 opened`) → **git 커밋 최근성** → **include 중심성**(여러
-후보가 `#include`하는 헤더, `VTS_CENTRALITY_MAX`로 제한) → mtime. 거대한 트리에선 일부(언리얼의 수만
+후보가 `#include`하는 헤더 — **적응형**: 영속 include-그래프 캐시를 매 warm-up마다 시간예산만큼 채워
+커버리지가 회차에 걸쳐 늘어남) → mtime. 거대한 트리에선 일부(언리얼의 수만
 TU 중 수백 개)만 데울 수 있으므로, 이 정렬이 warm 윈도가 실제 검색 대상을 포함하게 만드는 핵심입니다.
 git·Perforce 모두 지원.
 
@@ -314,7 +315,8 @@ Claude Code는 마켓플레이스 repo를 캐시하므로 새 커밋이 **자동
 | — | `VTS_PREWARM_HOOK` | `0` | SessionStart 훅도 detached `vts warmup`으로 pre-warm(opt-in; 주로 CLI/비-MCP). |
 | — | `VTS_CLANGD_REMOTE` | — | 공유/사전구축 clangd 인덱스 서버 주소(`--remote-index-address`); 개발자별 warmup ~0. |
 | — | `VTS_QUERY_HISTORY` | `~/.vs-token-safer/query-history.json` | 쿼리 이력 원장 위치(warm-up 세트를 곧-검색-우선으로 정렬하는 데 사용). |
-| — | `VTS_CENTRALITY_MAX` | `1500` | warm-up이 include 중심성을 계산할 후보 최대 수(파일을 읽음); `0`이면 비활성. 더 큰 세트는 건너뜀. |
+| — | `VTS_CENTRALITY_MAX` | `20000` | 중심성 스캔이 순회할 후보 상한; `0`이면 중심성 비활성. |
+| — | `VTS_CENTRALITY_BUDGET_MS` | `400` | warm-up당 *신규* include-프리픽스 읽기 예산. 중심성은 **적응형** — 매 warm-up이 예산만큼 새/변경 파일을 영속 include-그래프 캐시(`VTS_INCLUDE_GRAPH`)에 채워 회차마다 커버리지가 늘어남(`0`=캐시만). |
 | — | `VTS_ENFORCE` | `1` | `0`/`false`/`off`이면 Bash 코드 grep 허용(언어 서버 불가 시 탈출구). |
 
 ## 강제(enforcement) 동작 방식

--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ clangd indexes asynchronously, so the *first* search after the server starts pay
 **Which files get warmed first matters.** clangd boosts the indexing priority of files you open, so vts
 orders the warm-up set *likely-query-first*: **query history** (files that answered past searches) →
 **what you're editing now** (`git status` modified/untracked + Perforce `p4 opened`) → **git-log
-recency** → **include centrality** (headers many candidates `#include`, bounded by `VTS_CENTRALITY_MAX`)
+recency** → **include centrality** (headers many candidates `#include` — computed adaptively: a
+persistent include-graph cache that fills a time budget's worth each warm-up, growing coverage over runs)
 → mtime. On a huge tree you can only warm a small slice (hundreds of TUs out of tens of thousands in
 Unreal), so this ordering is what makes the warm window actually contain what you search for. Works with
 both **git** and **Perforce**.
@@ -325,7 +326,8 @@ Precedence: **environment variable (`VTS_*`) > `~/.vs-token-safer/config.json` >
 | — | `VTS_PREWARM_HOOK` | `0` | SessionStart hook also pre-warms via a detached `vts warmup` (opt-in; mainly CLI/non-MCP). |
 | — | `VTS_CLANGD_REMOTE` | — | Address of a shared/prebuilt clangd index server (`--remote-index-address`); near-zero per-dev warmup. |
 | — | `VTS_QUERY_HISTORY` | `~/.vs-token-safer/query-history.json` | Where the query-history ledger lives (used to order the warm-up set likely-query-first). |
-| — | `VTS_CENTRALITY_MAX` | `1500` | Max candidates for which warm-up computes include-centrality (reads files); `0` disables. Skipped on bigger sets. |
+| — | `VTS_CENTRALITY_MAX` | `20000` | Upper bound on candidates the centrality scan iterates; `0` disables centrality entirely. |
+| — | `VTS_CENTRALITY_BUDGET_MS` | `400` | Per-warm-up budget for *new* include-prefix reads. Centrality is **adaptive**: each warm-up scans a budget's worth of new/changed files into a persistent include-graph cache (`VTS_INCLUDE_GRAPH`), so coverage grows across warm-ups (`0` = cache only). |
 | — | `VTS_ENFORCE` | `1` | `0`/`false`/`off` lets Bash code-grep through (escape hatch when the language server is unavailable). |
 
 ## How enforcement works

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -13,6 +13,8 @@ process.env.VTS_CLANGD_ARGS = new URL("./_mock-lsp.mjs", import.meta.url).pathna
 // so the eval's recordQueryResults calls never touch the user's real ~/.vs-token-safer ledger.
 const QH = path.join(os.tmpdir(), `vts-eval-qh-${process.pid}.json`);
 process.env.VTS_QUERY_HISTORY = QH;
+const IG = path.join(os.tmpdir(), `vts-eval-ig-${process.pid}.json`); // isolate the include-graph cache
+process.env.VTS_INCLUDE_GRAPH = IG;
 const { runTool, disposeClients, prewarm } = await import("../server/core.js");
 
 const tok = (s) => Math.round(Buffer.byteLength(String(s), "utf8") / 4);
@@ -107,11 +109,20 @@ fs.writeFileSync(path.join(cdir, "leaf.cpp"), "int x;\n");
 const cands = ["a.cpp", "b.cpp", "leaf.cpp", "hub.h"].map((f) => path.join(cdir, f));
 const cord = orderForWarm(cdir, cands, 10).map((p) => p.toLowerCase());
 const idx = (n) => cord.findIndex((p) => p.endsWith(n));
-const centralityOk = idx("hub.h") !== -1 && idx("hub.h") < idx("leaf.cpp");
+const centralityRankOk = idx("hub.h") !== -1 && idx("hub.h") < idx("leaf.cpp");
+// adaptive cache: the first run persisted the include-graph; a second run with the read budget at 0
+// (cache-only — no fresh file reads) must still rank hub.h first, proving the cache is reused & grows.
+const graphPersisted = fs.existsSync(IG);
+process.env.VTS_CENTRALITY_BUDGET_MS = "0";
+const cord2 = orderForWarm(cdir, cands, 10).map((p) => p.toLowerCase());
+delete process.env.VTS_CENTRALITY_BUDGET_MS;
+const cacheReuseOk = cord2.findIndex((p) => p.endsWith("hub.h")) < cord2.findIndex((p) => p.endsWith("leaf.cpp"));
+const centralityOk = centralityRankOk && graphPersisted && cacheReuseOk;
 try { fs.rmSync(cdir, { recursive: true, force: true }); } catch { /* ignore */ }
 
 await disposeClients();
 try { fs.rmSync(QH, { force: true }); } catch { /* ignore */ }
+try { fs.rmSync(IG, { force: true }); } catch { /* ignore */ }
 
 const rows = [
   ["LSP client handshake + symbol", lspOk, "true", lspOk],
@@ -125,7 +136,7 @@ const rows = [
   ["clangd version advisory + gate", advisoryOk, "true", advisoryOk],
   ["prewarm guard + vts_warmup", warmOk, "true", warmOk],
   ["warm ordering (history) + remote arg", orderingOk, "true", orderingOk],
-  ["centrality ranks hub > leaf", centralityOk, "true", centralityOk],
+  ["centrality + adaptive graph cache", centralityOk, "true", centralityOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/warmset.js
+++ b/server/warmset.js
@@ -6,7 +6,8 @@
  *   query-history  (LFU + recency) — files that answered past searches (strongest evidence)
  *   working-now    — files open/modified right now (git status / Perforce `p4 opened`)
  *   git-recency    — recently-committed files (git log)
- *   centrality     — include fan-in among candidates (bounded; widely-reused headers help many queries)
+ *   centrality     — include fan-in among candidates (adaptive: prefix-read + per-warmup time budget +
+ *                    a persistent include-graph cache that GROWS coverage across warmups)
  *   mtime          — filesystem recency fallback (p4 edit/sync updates mtime too)
  * Background indexing still covers everything eventually; this only front-loads the likely targets.
  * Keep the open-set small (cap) — over-prewarming pollutes/saturates the worker.
@@ -17,8 +18,28 @@ import os from "node:os";
 import path from "node:path";
 
 const HIST_FILE = process.env.VTS_QUERY_HISTORY || path.join(os.homedir(), ".vs-token-safer", "query-history.json");
+const GRAPH_FILE = process.env.VTS_INCLUDE_GRAPH || path.join(os.homedir(), ".vs-token-safer", "include-graph.json");
 const norm = (p) => path.resolve(p).replace(/\\/g, "/").toLowerCase();
 const envInt = (name, def) => { const v = parseInt(process.env[name], 10); return Number.isFinite(v) && v >= 0 ? v : def; };
+
+// Read only the top of a file (where #includes live) — cheap enough to scan many files for centrality.
+function readIncludePrefix(f, maxBytes = 65536) {
+  let fd;
+  try { fd = fs.openSync(f, "r"); } catch { return null; }
+  try { const buf = Buffer.alloc(maxBytes); const n = fs.readSync(fd, buf, 0, maxBytes, 0); return buf.toString("utf8", 0, n); }
+  catch { return null; }
+  finally { try { fs.closeSync(fd); } catch { /* ignore */ } }
+}
+function parseIncludes(txt) {
+  const out = []; const re = /#\s*include\s*["<]([^">]+)[">]/g; let m;
+  while ((m = re.exec(txt))) out.push(path.basename(m[1]).toLowerCase());
+  return out;
+}
+// Persistent include-graph cache ({ normPath: { m: mtimeMs, i: [includedBasename,...] } }) so centrality
+// scanning AMORTIZES across warmups instead of re-reading every file each time. mtime invalidates stale
+// entries automatically.
+function loadGraph() { try { return JSON.parse(fs.readFileSync(GRAPH_FILE, "utf8")) || {}; } catch { return {}; } }
+function saveGraph(g) { try { fs.mkdirSync(path.dirname(GRAPH_FILE), { recursive: true }); fs.writeFileSync(GRAPH_FILE, JSON.stringify(g)); } catch { /* best-effort */ } }
 const readHist = () => { try { return JSON.parse(fs.readFileSync(HIST_FILE, "utf8")) || {}; } catch { return {}; } };
 // LFU with a recency tiebreak (scan-resistant-ish: a one-off scan adds n=1, repeated use compounds).
 const score = (e, now) => e.n + 1 / (1 + (now - e.t));
@@ -100,25 +121,45 @@ function workingFiles(root) {
   return set;
 }
 
-// ③ Dependency centrality (bounded): among candidates, count include fan-in — how many candidates
-// `#include` each one. High fan-in = reused widely → warming it helps many queries. Reads files, so it's
-// gated to a max candidate count (VTS_CENTRALITY_MAX, default 1500; 0 disables) to stay cheap on huge
-// trees, where clangd's preamble already pulls central headers transitively when a TU is opened.
+// ③ Dependency centrality — among candidates, count include fan-in (how many candidates `#include`
+// each one). High fan-in = reused widely → warming it helps many queries. ADAPTIVE so it doesn't all-or-
+// nothing-skip big trees: it reads only each file's include-prefix, spends at most VTS_CENTRALITY_BUDGET_MS
+// per warmup on NEW/changed files, and persists what it scans to an include-graph cache (mtime-keyed).
+// So coverage GROWS across warmups — first run scans a budget's worth, later runs reuse the cache and
+// extend it, until the whole module is mapped (then only changed files are rescanned). VTS_CENTRALITY_MAX
+// bounds the stat loop (0 = disable centrality); VTS_CENTRALITY_BUDGET_MS bounds fresh reads (0 = cache-only).
 function centralityRank(candidates) {
-  const max = envInt("VTS_CENTRALITY_MAX", 1500);
-  if (!max || candidates.length > max) return new Map();
+  const maxIter = envInt("VTS_CENTRALITY_MAX", 20000);
+  if (maxIter === 0) return new Map(); // disabled
+  const list = candidates.slice(0, maxIter);
+  const budgetMs = envInt("VTS_CENTRALITY_BUDGET_MS", 400);
   const byName = new Map();
-  for (const f of candidates) { const b = path.basename(f).toLowerCase(); if (!byName.has(b)) byName.set(b, norm(f)); }
+  for (const f of list) { const b = path.basename(f).toLowerCase(); if (!byName.has(b)) byName.set(b, norm(f)); }
+  const graph = loadGraph();
+  const start = Date.now();
+  let dirty = false;
   const fanin = new Map();
-  for (const f of candidates) {
-    let txt; try { txt = fs.readFileSync(f, "utf8"); } catch { continue; }
-    const self = norm(f); const seen = new Set();
-    const re = /#\s*include\s*["<]([^">]+)[">]/g; let m;
-    while ((m = re.exec(txt))) {
-      const target = byName.get(path.basename(m[1]).toLowerCase());
-      if (target && target !== self && !seen.has(target)) { seen.add(target); fanin.set(target, (fanin.get(target) || 0) + 1); }
+  for (const f of list) {
+    const nf = norm(f);
+    let st; try { st = fs.statSync(f).mtimeMs; } catch { continue; }
+    const cached = graph[nf];
+    let inc;
+    if (cached && cached.m === st) inc = cached.i;
+    else if (Date.now() - start < budgetMs) {
+      const txt = readIncludePrefix(f);
+      if (txt == null) continue;
+      inc = parseIncludes(txt);
+      graph[nf] = { m: st, i: inc };
+      dirty = true;
+    } else inc = cached ? cached.i : null; // budget spent → reuse stale cache, else defer to a later warmup
+    if (!inc) continue;
+    const seen = new Set();
+    for (const b of inc) {
+      const target = byName.get(b);
+      if (target && target !== nf && !seen.has(target)) { seen.add(target); fanin.set(target, (fanin.get(target) || 0) + 1); }
     }
   }
+  if (dirty) saveGraph(graph);
   return fanin;
 }
 


### PR DESCRIPTION
Fifth integration from `dev` (on top of v0.5.0).

## What
Replace the all-or-nothing `VTS_CENTRALITY_MAX` skip with an **adaptive** centrality scan, so the ③ signal works on big modules (Unreal game modules are 3k+ files, which the old 1500 cap skipped entirely):
- read only each file's **include-prefix** (top 64 KB) instead of the whole file;
- spend at most **`VTS_CENTRALITY_BUDGET_MS`** (default 400) per warm-up on new/changed files;
- persist the include-graph to a cache (**`VTS_INCLUDE_GRAPH`**, mtime-keyed) so coverage **grows across warm-ups** and only changed files are rescanned;
- `VTS_CENTRALITY_MAX` now just bounds the stat loop (default 20000; `0` = disable centrality).

## Verified (real 3,235-file module, numbers only)
Cache fills 614 → 1425 → 2069 → 2667 → 3156 → 3235 over 6 warm-ups (300 ms budget each), then steady-state. Earlier: centrality top-50 headers covered ~42% of intra-module include edges (~114× vs arbitrary) — now reachable on big modules instead of skipped.

## Verification
- eval 12/12 (centrality + adaptive-cache-reuse guard: persists graph, reuses with budget=0); query-history + include-graph isolated to temp files in the eval.
- No proprietary data — synthetic / counts only.

## Docs
README EN/KO env table (`VTS_CENTRALITY_BUDGET_MS`, updated `VTS_CENTRALITY_MAX`) + ordering description; CLAUDE.md.