### PR TITLE
docs: README currency + de-slop (v0.7.0 nav surface, eval count, em-dash fix)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -47,12 +47,12 @@ $ grep -rn "SpawnActor" Source/**/*.cpp
 
 ---
 
-Claude가 Bash `grep` 대신 공식 언어 서버 인덱스로 코드 내비게이션 — 심볼 검색, 참조(references) 찾기,
-정의 이동, hover, 파일 아웃라인, 그리고 의미 기반 프로젝트 전역 rename — 을 하게 만드는 Claude Code
-플러그인입니다(C/C++은 **clangd**(LLVM), C#/.NET은 Roslyn 기반 LSP인
-`Microsoft.CodeAnalysis.LanguageServer`, 즉 Visual Studio / C# Dev Kit가 쓰는 엔진). 검색이 폭발할 때는
-간결한 `file:line` 목록(소스 본문 없음)만 반환해 토큰을 상한선으로 막습니다. `grep`이 느리고 컨텍스트를
-잡아먹는 대형 Unreal C++ 및 .NET/C# 코드베이스를 위해 만들었습니다.
+Claude가 Bash `grep` 대신 공식 언어 서버 인덱스로 심볼 검색, 참조(references) 찾기, 정의로 이동을 하게
+만드는 Claude Code 플러그인입니다(C/C++은 **clangd**(LLVM), C#/.NET은 Roslyn 기반 LSP인
+`Microsoft.CodeAnalysis.LanguageServer`, 즉 Visual Studio / C# Dev Kit가 쓰는 엔진). hover, 파일
+아웃라인, 프로젝트 전역 rename도 같은 인덱스로 처리합니다. 검색이 폭발할 때는 간결한 `file:line`
+목록(소스 본문 없음)만 반환해 토큰을 상한선으로 막습니다. `grep`이 느리고 컨텍스트를 잡아먹는 대형
+Unreal C++ 및 .NET/C# 코드베이스를 위해 만들었습니다.
 
 [rider-mcp-enforcer](https://github.com/JSungMin/rider-mcp-enforcer)의 IDE 비종속 형제 프로젝트입니다.
 토큰 효율 목표는 같지만 실행 중인 IDE의 MCP 서버를 프록시하지 않고 공식 언어 서버를 헤드리스로

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,8 +47,9 @@ $ grep -rn "SpawnActor" Source/**/*.cpp
 
 ---
 
-Claude가 Bash `grep` 대신 공식 언어 서버 인덱스로 심볼 검색, 참조(references) 찾기, 정의로 이동을 하게
-만드는 Claude Code 플러그인입니다(C/C++은 **clangd**(LLVM), C#/.NET은 Roslyn 기반 LSP인
+Claude가 Bash `grep` 대신 공식 언어 서버 인덱스로 코드 내비게이션 — 심볼 검색, 참조(references) 찾기,
+정의 이동, hover, 파일 아웃라인, 그리고 의미 기반 프로젝트 전역 rename — 을 하게 만드는 Claude Code
+플러그인입니다(C/C++은 **clangd**(LLVM), C#/.NET은 Roslyn 기반 LSP인
 `Microsoft.CodeAnalysis.LanguageServer`, 즉 Visual Studio / C# Dev Kit가 쓰는 엔진). 검색이 폭발할 때는
 간결한 `file:line` 목록(소스 본문 없음)만 반환해 토큰을 상한선으로 막습니다. `grep`이 느리고 컨텍스트를
 잡아먹는 대형 Unreal C++ 및 .NET/C# 코드베이스를 위해 만들었습니다.
@@ -143,7 +144,7 @@ func SpawnActorFromClass  @ MyGame/Source/SpawnLib.cpp:31
   줄(주석, 문자열, 무관한 식별자)을 끌어옵니다. 플러그인은 의미 기반 히트당 `file:line` 하나만, 그것도
   캡해서 반환합니다.
 - 목-LSP eval(`node eval/run.mjs`, 툴체인 불필요)이 매 커밋 응답 정형화 절감을 게이트합니다: raw 인덱스
-  `~57,308 tok` → 캡된 출력 `~1,515 tok` = **97.4%** (체크 12/12).
+  `~57,308 tok` → 캡된 출력 `~1,515 tok` = **97.4%** (체크 14/14).
 
 ### 정확도 차이와 그 이유
 "누가 더 맞다"가 아니라 정밀도/재현율 트레이드오프입니다:

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ $ grep -rn "SpawnActor" Source/**/*.cpp
 
 ---
 
-A Claude Code plugin that routes symbol search, find-references, and go-to-definition through an
-official language server's index instead of Bash `grep`: **clangd** (LLVM) for C/C++, and a Roslyn-based
-LSP (`Microsoft.CodeAnalysis.LanguageServer`, the engine Visual Studio and the C# Dev Kit use) for
-C#/.NET. It caps the tokens a search flood can spend by returning a compact `file:line` list, never
-source bodies. It's built for large Unreal C++ and .NET/C# codebases, where `grep` is slow and burns
-context.
+A Claude Code plugin that routes code navigation — symbol search, references, definition, hover, file
+outline, and a semantic project-wide rename — through an official language server's index instead of
+Bash `grep`: **clangd** (LLVM) for C/C++, and a Roslyn-based LSP (`Microsoft.CodeAnalysis.LanguageServer`,
+the engine Visual Studio and the C# Dev Kit use) for C#/.NET. It caps the tokens a search flood can spend
+by returning a compact `file:line` list, never source bodies. It's built for large Unreal C++ and
+.NET/C# codebases, where `grep` is slow and burns context.
 
 It's the IDE-agnostic sibling of
 [rider-mcp-enforcer](https://github.com/JSungMin/rider-mcp-enforcer). Same token-efficiency goal, but
@@ -148,7 +148,7 @@ Bash grep-and-paste vs this plugin. No project source is reproduced, only aggreg
   text so it returns more of them (comments, strings, unrelated identifiers). The plugin returns one
   `file:line` per semantic hit, capped.
 - The mock-LSP eval (`node eval/run.mjs`, no toolchain) gates the response-shaping win on every commit:
-  raw index `~57,308 tok` → capped output `~1,515 tok` = **97.4%** (12/12 checks).
+  raw index `~57,308 tok` → capped output `~1,515 tok` = **97.4%** (14/14 checks).
 
 ### Accuracy difference (and why)
 This is a precision/recall trade-off, not a case of one being more correct than the other:

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ $ grep -rn "SpawnActor" Source/**/*.cpp
 
 ---
 
-A Claude Code plugin that routes code navigation — symbol search, references, definition, hover, file
-outline, and a semantic project-wide rename — through an official language server's index instead of
-Bash `grep`: **clangd** (LLVM) for C/C++, and a Roslyn-based LSP (`Microsoft.CodeAnalysis.LanguageServer`,
-the engine Visual Studio and the C# Dev Kit use) for C#/.NET. It caps the tokens a search flood can spend
-by returning a compact `file:line` list, never source bodies. It's built for large Unreal C++ and
-.NET/C# codebases, where `grep` is slow and burns context.
+A Claude Code plugin that routes symbol search, find-references, and go-to-definition through an
+official language server's index instead of Bash `grep`: **clangd** (LLVM) for C/C++, and a Roslyn-based
+LSP (`Microsoft.CodeAnalysis.LanguageServer`, the engine Visual Studio and the C# Dev Kit use) for
+C#/.NET. Hover, file outline, and a project-wide rename go through the same index. It caps the tokens a
+search flood can spend by returning a compact `file:line` list, never source bodies. It's built for large
+Unreal C++ and .NET/C# codebases, where `grep` is slow and burns context.
 
 It's the IDE-agnostic sibling of
 [rider-mcp-enforcer](https://github.com/JSungMin/rider-mcp-enforcer). Same token-efficiency goal, but


### PR DESCRIPTION
Docs-only. No version bump, no release tag.

- Intro names the v0.7.0 nav surface (hover/outline/rename) in plain prose — no em-dash interjection (that AI tell was briefly introduced then removed).
- Performance section eval-check count corrected 12/12 -> 14/14.
- EN/KO mirrored, zero semantic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)