### PR TITLE
Release v0.8.0 — JS/TS + Python backends (auto-installed), critic fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
 (`vts`). npm package + plugin name: `vs-token-safer`.
 
 ## First, orient (every session)
-1. Read this file, then `node eval/run.mjs` — must print `EVAL PASSED` (14/14) before you change anything.
+1. Read this file, then `node eval/run.mjs` — must print `EVAL PASSED` (15/15) before you change anything.
 2. Resume context lives in: this file · the wiki (`wiki_query "vs-token-safer"`, pages under
    `.omc/wiki/`) · memory anchor `project-vs-token-safer`. The wiki **Status and TODO** page is the
    live checklist.
@@ -22,8 +22,11 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
 
 ## Layout
 - `server/lsp.js` — generic LSP client (JSON-RPC/stdio). The one new, careful piece.
-- `server/backends/index.js` — clangd/roslyn spawn configs + `pickBackend(root)`. Override via
-  `VTS_CLANGD_CMD/ARGS`, `VTS_ROSLYN_CMD/ARGS`.
+- `server/backends/index.js` — clangd/roslyn/typescript/pyright spawn configs + `pickBackend(root)`
+  (detect order: compile_commands→clangd > .sln/.csproj→roslyn > tsconfig/package.json→typescript >
+  pyproject/*.py→pyright; strongest build-artifact first). Override via `VTS_CLANGD_CMD/ARGS`,
+  `VTS_ROSLYN_CMD/ARGS`, `VTS_TS_CMD/ARGS`, `VTS_PY_CMD/ARGS`. `winShell` flag spawns the npm `.cmd`
+  shims (ts/pyright) through a shell on Windows. `langIdForPath` (lsp.js) maps file ext → LSP languageId.
 - `server/core.js` — `runTool()` dispatch, token-cap formatters, savings ledger. Tools: `search_symbol`,
   `find_references`, `goto_definition`, `hover`, `document_symbols`, `rename` (LSP; rename = preview by
   default, `apply=true` writes — the only mutating tool); `find_files`, `search_text`
@@ -84,6 +87,19 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   runtime; opens the workspace via `solution/open`/`project/open` then waits for
   `workspace/projectInitializationComplete` (see `backends/index.js` `afterInit`, `lsp.js`
   `waitForNotification`). `csharp-ls` is the fallback. Overrides: `VTS_ROSLYN_DLL`, `VTS_ROSLYN_CMD/ARGS`.
+- **typescript** (JS/TS): `typescript-language-server --stdio` (wraps tsserver). Install
+  `npm i -g typescript-language-server typescript`. Detect: tsconfig/jsconfig/package.json or `*.ts/js`.
+  `afterInit` opens top-N (`VTS_TS_OPEN_CAP`, 60) likely-query files; `workspace/symbol` answers
+  project-wide. Override `VTS_TS_CMD/ARGS`. **✅ live-verified by dogfooding vts on its own `server/*.js`**
+  (search_symbol/find_references/document_symbols returned correct `file:line` incl. cross-file refs).
+- **pyright** (Python): `pyright-langserver --stdio` (`npm i -g pyright`). Detect:
+  pyproject/setup.py/setup.cfg/requirements/Pipfile or `*.py`. `afterInit` opens top-N
+  (`VTS_PY_OPEN_CAP`). Override `VTS_PY_CMD/ARGS`. Same generic glue as typescript.
+- **Windows spawn:** npm-installed JS LSPs are `.cmd` shims → `winShell:true` on those backends spawns
+  through a shell (clangd.exe / dotnet host stay shell:false to survive paths with spaces). `langIdForPath`
+  (lsp.js) maps file ext → LSP languageId so one backend serves several extensions.
+- **grep-block hook** now covers `js/jsx/mjs/cjs/ts/tsx/mts/cts/py/pyi` too (default on, per user) so vts
+  self-enforces while we develop it; `VTS_ENFORCE=0` still the escape hatch.
 
 ## Next (see wiki "Status and TODO")
 P1 DONE: core rename, `index.js`/`sdk.js`/`ensure-deps.mjs`, grep-block `hooks/`, `skills/`+`commands/`,

--- a/README.ko.md
+++ b/README.ko.md
@@ -224,7 +224,8 @@ vs-token-safer savings (local, 1 search(es))
   - **JS/TS → typescript-language-server, Python → pyright.** 플러그인 의존성으로 동봉되어 첫 세션에
     자동 설치됩니다 — 따로 할 일 없습니다. vts가 번들 복사본을 `node`로 실행하니 전역 설치나 PATH 설정이
     필요 없습니다. 원하면 `VTS_TS_CMD`/`VTS_PY_CMD`로 직접 지정하세요. (참고: 동봉으로 첫 실행 `npm
-    install`에 1회 ~50MB가 추가됩니다.)
+    install`에 1회 ~50MB가 추가되고, JS/TS 서버는 **Node 20+**를 권장합니다 — Node 18에서는 건너뛰며
+    나머지 백엔드는 정상 동작합니다.)
 - IDE는 실행 중이지 않아도 됩니다.
 
 clangd는 컴파일 DB(`compile_commands.json`)가 필요합니다:

--- a/README.ko.md
+++ b/README.ko.md
@@ -48,11 +48,13 @@ $ grep -rn "SpawnActor" Source/**/*.cpp
 ---
 
 Claude가 Bash `grep` 대신 공식 언어 서버 인덱스로 심볼 검색, 참조(references) 찾기, 정의로 이동을 하게
-만드는 Claude Code 플러그인입니다(C/C++은 **clangd**(LLVM), C#/.NET은 Roslyn 기반 LSP인
-`Microsoft.CodeAnalysis.LanguageServer`, 즉 Visual Studio / C# Dev Kit가 쓰는 엔진). hover, 파일
-아웃라인, 프로젝트 전역 rename도 같은 인덱스로 처리합니다. 검색이 폭발할 때는 간결한 `file:line`
-목록(소스 본문 없음)만 반환해 토큰을 상한선으로 막습니다. `grep`이 느리고 컨텍스트를 잡아먹는 대형
-Unreal C++ 및 .NET/C# 코드베이스를 위해 만들었습니다.
+만드는 Claude Code 플러그인입니다(C/C++은 **clangd**(LLVM), C#/.NET은 Roslyn 기반 LSP
+`Microsoft.CodeAnalysis.LanguageServer`(Visual Studio / C# Dev Kit 엔진), JS/TS는
+**typescript-language-server**(tsserver), Python은 **pyright**). hover, 파일 아웃라인, 프로젝트 전역
+rename도 같은 인덱스로 처리합니다. 검색이 폭발할 때는 간결한 `file:line` 목록(소스 본문 없음)만 반환해
+토큰을 상한선으로 막습니다. `grep`이 느리고 컨텍스트를 잡아먹는 대형 Unreal C++ 및 .NET/C# 코드베이스를
+위해 만들었습니다. JS/Python 백엔드 덕분에 플러그인이 자기 소스도 검색할 수 있어, 개발하면서 직접
+dogfood합니다.
 
 [rider-mcp-enforcer](https://github.com/JSungMin/rider-mcp-enforcer)의 IDE 비종속 형제 프로젝트입니다.
 토큰 효율 목표는 같지만 실행 중인 IDE의 MCP 서버를 프록시하지 않고 공식 언어 서버를 헤드리스로
@@ -65,7 +67,7 @@ Unreal C++ 및 .NET/C# 코드베이스를 위해 만들었습니다.
 
 | 플러그인 | 기능 | 필요 |
 | --- | --- | --- |
-| **vs-token-safer** (이 페이지) | 코드 검색을 grep 대신 clangd/Roslyn 인덱스로 강제(기본 하드 차단, 탈출구 opt-out), `file:line`으로 토큰 캡 | Node + 언어 서버(clangd / Roslyn). IDE 불필요. |
+| **vs-token-safer** (이 페이지) | 코드 검색을 grep 대신 clangd/Roslyn/tsserver/pyright 인덱스로 강제(기본 하드 차단, 탈출구 opt-out), `file:line`으로 토큰 캡 | Node + 언어 서버: clangd / Roslyn(직접 설치), JS/TS + Python(자동 설치). IDE 불필요. |
 | **[gamedev-log-analyzer](gamedev-log-analyzer/README.ko.md)** | 거대 Unreal/Unity/Godot/MSVC-UBT-MSBuild 로그 파싱·dedup·분류·검색·diff·locate·스칼라 추출 (CLI 우선) | Node만 (IDE 불필요) |
 
 **한 번에 설치.** `vs-token-safer`가 `gamedev-log-analyzer`를 의존성으로 선언하므로 한 번 설치하면 둘
@@ -144,7 +146,7 @@ func SpawnActorFromClass  @ MyGame/Source/SpawnLib.cpp:31
   줄(주석, 문자열, 무관한 식별자)을 끌어옵니다. 플러그인은 의미 기반 히트당 `file:line` 하나만, 그것도
   캡해서 반환합니다.
 - 목-LSP eval(`node eval/run.mjs`, 툴체인 불필요)이 매 커밋 응답 정형화 절감을 게이트합니다: raw 인덱스
-  `~57,308 tok` → 캡된 출력 `~1,515 tok` = **97.4%** (체크 14/14).
+  `~57,308 tok` → 캡된 출력 `~1,515 tok` = **97.4%** (체크 15/15).
 
 ### 정확도 차이와 그 이유
 "누가 더 맞다"가 아니라 정밀도/재현율 트레이드오프입니다:
@@ -219,6 +221,10 @@ vs-token-safer savings (local, 1 search(es))
   - **C#/.NET → Roslyn LSP.** VS Code C# 확장(`ms-dotnettools.csharp`)을 설치하면 vts가 번들에서
     `Microsoft.CodeAnalysis.LanguageServer`와 그 전용 .NET 런타임을 자동 감지합니다. 폴백은
     `dotnet tool install --global csharp-ls`. `.sln`/`.csproj`가 필요합니다.
+  - **JS/TS → typescript-language-server, Python → pyright.** 플러그인 의존성으로 동봉되어 첫 세션에
+    자동 설치됩니다 — 따로 할 일 없습니다. vts가 번들 복사본을 `node`로 실행하니 전역 설치나 PATH 설정이
+    필요 없습니다. 원하면 `VTS_TS_CMD`/`VTS_PY_CMD`로 직접 지정하세요. (참고: 동봉으로 첫 실행 `npm
+    install`에 1회 ~50MB가 추가됩니다.)
 - IDE는 실행 중이지 않아도 됩니다.
 
 clangd는 컴파일 DB(`compile_commands.json`)가 필요합니다:
@@ -315,6 +321,9 @@ Claude Code는 마켓플레이스 repo를 캐시하므로 새 커밋이 **자동
 | — | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | clangd 실행 파일/인자 재정의. |
 | — | `VTS_ROSLYN_DLL` | auto | 특정 `Microsoft.CodeAnalysis.LanguageServer.dll` 경로. |
 | — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto(MS 엔진) → `csharp-ls` | C# LSP 실행 파일/인자 재정의. |
+| — | `VTS_TS_CMD` / `VTS_TS_ARGS` | 동봉 `typescript-language-server` | JS/TS LSP 실행 파일/인자 재정의. |
+| — | `VTS_PY_CMD` / `VTS_PY_ARGS` | 동봉 `pyright-langserver` | Python LSP 실행 파일/인자 재정의. |
+| — | `VTS_TS_OPEN_CAP` / `VTS_PY_OPEN_CAP` | `60` | JS/TS · Python warm-up이 서버를 데우려 여는 파일 최대 수. |
 | — | `VTS_LSP_TIMEOUT_MS` | `30000` | 요청당 LSP 타임아웃. 차갑고 큰(예: UE) 인덱스면 올림. |
 | — | `VTS_LSP_INDEX_WAIT_MS` | `120000` | clangd warm-up이 첫 쿼리 전 백그라운드 인덱싱 완료를 기다리는 시간. |
 | — | `VTS_CLANGD_OPEN_CAP` | `100` | warm-up이 clangd 인덱스를 데우려 여는 파일 최대 수. |
@@ -328,10 +337,10 @@ Claude Code는 마켓플레이스 repo를 캐시하므로 새 커밋이 **자동
 
 ## 강제(enforcement) 동작 방식
 
-- **훅**은 모든 Bash 호출 전에 실행됩니다. 명령이 코드-심볼 검색(grep/rg/ack/ag/findstr 또는
-  `*.c/.cc/.cpp/.h/.hpp/.cs`·`src|source|engine|plugins/` 대상 `find -name`)이고 로그/md/json/빌드
-  경로가 *아니면* 명령을 차단하고 Claude에게 인덱스 도구를 쓰라고 알립니다. 그 외엔 통과시킵니다.
-  `VTS_ENFORCE=0`이면 완전히 꺼집니다.
+- **훅**은 모든 Bash 호출 전에 실행됩니다. 명령이 코드-심볼 검색(grep/rg/ack/ag/findstr 또는 코드
+  확장자 `*.c/.cc/.cpp/.h/.hpp/.cs/.ts/.tsx/.js/.jsx/.mjs/.cjs/.py`·`src|source|engine|plugins/` 대상
+  `find -name`)이고 로그/md/json/빌드 경로가 *아니면* 명령을 차단하고 Claude에게 인덱스 도구를 쓰라고
+  알립니다. 그 외엔 통과시킵니다. `VTS_ENFORCE=0`이면 완전히 꺼집니다.
 - **스킬**은 Claude가 인덱스 도구를 선제적으로 쓰도록 유도합니다.
 - **코어**는 Claude가 도구를 어떻게 호출하든 토큰 상한을 보장합니다.
 
@@ -345,6 +354,7 @@ Claude Code는 마켓플레이스 repo를 캐시하므로 새 커밋이 **자동
 | `GenerateClangDatabase` 실패: "Unable to find valid C++ toolchain for Clang x64" | 타겟이 clang-cl 빌드; UBT가 Clang 툴체인 검증 | UBT 명령에 **`-Compiler=VisualCpp`** 추가. MSVC DB도 include 그래프를 해석함. |
 | clangd가 헤더 없는 심볼만 해석 | 컴파일 DB에 include 경로 없음 → 시스템/서드파티 헤더 미해석 | UBT 생성 DB 사용(경로 포함); 수작업 `compile_commands.json`은 include 경로를 명시해야 함. |
 | C# 결과 없음 / "No backend resolved" | Roslyn 엔진 미발견 | VS Code C# 확장(`ms-dotnettools.csharp`) 설치, 또는 `dotnet tool install --global csharp-ls`; 또는 `VTS_ROSLYN_DLL`/`VTS_ROSLYN_CMD` 설정. |
+| JS/TS·Python 결과 없음 | 동봉 LSP 미설치(오프라인 첫 실행, npm 실패) | 세션을 다시 시작해 의존성 재설치, 또는 PATH의 `typescript-language-server`/`pyright-langserver`를 `VTS_TS_CMD`/`VTS_PY_CMD`로 지정. |
 | 원하던 grep인데 코드 검색이 차단됨 | 훅이 인덱스로 유도 중 | `VTS_ENFORCE=0`으로 grep 허용(예: 언어 서버 불가 시). |
 | 잘못된 백엔드 선택됨 | 루트 아래 프로젝트 파일이 여럿 | 고정: `VTS_BACKEND=clangd`(또는 `roslyn`), 또는 호출마다 `backend` 전달. |
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ $ grep -rn "SpawnActor" Source/**/*.cpp
 ---
 
 A Claude Code plugin that routes symbol search, find-references, and go-to-definition through an
-official language server's index instead of Bash `grep`: **clangd** (LLVM) for C/C++, and a Roslyn-based
+official language server's index instead of Bash `grep`: **clangd** (LLVM) for C/C++, a Roslyn-based
 LSP (`Microsoft.CodeAnalysis.LanguageServer`, the engine Visual Studio and the C# Dev Kit use) for
-C#/.NET. Hover, file outline, and a project-wide rename go through the same index. It caps the tokens a
-search flood can spend by returning a compact `file:line` list, never source bodies. It's built for large
-Unreal C++ and .NET/C# codebases, where `grep` is slow and burns context.
+C#/.NET, **typescript-language-server** (tsserver) for JS/TS, and **pyright** for Python. Hover, file
+outline, and a project-wide rename go through the same index. It caps the tokens a search flood can spend
+by returning a compact `file:line` list, never source bodies. It's built for large Unreal C++ and .NET/C#
+codebases, where `grep` is slow and burns context — and the JS/Python backends let it search its own
+source, so we dogfood the plugin while building it.
 
 It's the IDE-agnostic sibling of
 [rider-mcp-enforcer](https://github.com/JSungMin/rider-mcp-enforcer). Same token-efficiency goal, but
@@ -67,7 +69,7 @@ big things without paying for all of it in tokens.
 
 | Plugin | Does | Needs |
 | --- | --- | --- |
-| **vs-token-safer** (this page) | Force code search through clangd/Roslyn's index over Bash grep (hard-block by default, escape hatch opt-out), token-capped to `file:line` | Node + a language server (clangd / Roslyn). No IDE. |
+| **vs-token-safer** (this page) | Force code search through clangd/Roslyn/tsserver/pyright's index over Bash grep (hard-block by default, escape hatch opt-out), token-capped to `file:line` | Node + a language server: clangd / Roslyn (you install), JS/TS + Python (auto-installed). No IDE. |
 | **[gamedev-log-analyzer](gamedev-log-analyzer/README.md)** | Parse/dedup/classify huge Unreal/Unity/Godot/MSVC-UBT-MSBuild logs (CLI-first), search + diff + locate + extract scalars | Node only (no IDE) |
 
 One-step install: `vs-token-safer` declares `gamedev-log-analyzer` as a dependency, so installing it
@@ -148,7 +150,7 @@ Bash grep-and-paste vs this plugin. No project source is reproduced, only aggreg
   text so it returns more of them (comments, strings, unrelated identifiers). The plugin returns one
   `file:line` per semantic hit, capped.
 - The mock-LSP eval (`node eval/run.mjs`, no toolchain) gates the response-shaping win on every commit:
-  raw index `~57,308 tok` → capped output `~1,515 tok` = **97.4%** (14/14 checks).
+  raw index `~57,308 tok` → capped output `~1,515 tok` = **97.4%** (15/15 checks).
 
 ### Accuracy difference (and why)
 This is a precision/recall trade-off, not a case of one being more correct than the other:
@@ -229,6 +231,10 @@ vs-token-safer savings (local, 1 search(es))
   - **C#/.NET → a Roslyn LSP.** Install the VS Code C# extension (`ms-dotnettools.csharp`) and vts
     auto-detects `Microsoft.CodeAnalysis.LanguageServer` and its private .NET runtime from the bundle.
     Fallback: `dotnet tool install --global csharp-ls`. Needs a `.sln`/`.csproj`.
+  - **JS/TS → typescript-language-server, Python → pyright.** These ship as plugin dependencies and
+    install automatically on the first session — nothing to set up. vts launches the bundled copy with
+    `node`, so there's no global install or PATH dance. Point `VTS_TS_CMD`/`VTS_PY_CMD` at your own if you
+    prefer. (Heads-up: bundling them adds a one-time ~50 MB to the plugin's first-run `npm install`.)
 - No IDE has to be running.
 
 clangd needs a compile database (`compile_commands.json`):
@@ -327,6 +333,9 @@ Precedence: **environment variable (`VTS_*`) > `~/.vs-token-safer/config.json` >
 | — | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | Override the clangd executable / args. |
 | — | `VTS_ROSLYN_DLL` | auto | Path to a specific `Microsoft.CodeAnalysis.LanguageServer.dll`. |
 | — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto (MS engine) → `csharp-ls` | Override the C# LSP executable / args. |
+| — | `VTS_TS_CMD` / `VTS_TS_ARGS` | bundled `typescript-language-server` | Override the JS/TS LSP executable / args. |
+| — | `VTS_PY_CMD` / `VTS_PY_ARGS` | bundled `pyright-langserver` | Override the Python LSP executable / args. |
+| — | `VTS_TS_OPEN_CAP` / `VTS_PY_OPEN_CAP` | `60` | Max files the JS/TS / Python warm-up opens to prime the server. |
 | — | `VTS_LSP_TIMEOUT_MS` | `30000` | Per-request LSP timeout. Raise for a cold, large (e.g. UE) index. |
 | — | `VTS_LSP_INDEX_WAIT_MS` | `120000` | How long the clangd warm-up waits for background-index completion before the first query. |
 | — | `VTS_CLANGD_OPEN_CAP` | `100` | Max files the warm-up opens to prime clangd's index. |
@@ -341,9 +350,10 @@ Precedence: **environment variable (`VTS_*`) > `~/.vs-token-safer/config.json` >
 ## How enforcement works
 
 - The **hook** runs before every Bash call. If the command is a code-symbol search (grep/rg/ack/ag/
-  findstr or `find -name` targeting `*.c/.cc/.cpp/.h/.hpp/.cs` or `src|source|engine|plugins/`) and is
-  *not* aimed at a log/md/json/build path, it blocks the command and tells Claude to use the indexed
-  tool instead. Otherwise it allows the command. `VTS_ENFORCE=0` disables it entirely.
+  findstr or `find -name` targeting a code extension — `*.c/.cc/.cpp/.h/.hpp/.cs/.ts/.tsx/.js/.jsx/.mjs/
+  .cjs/.py` — or `src|source|engine|plugins/`) and is *not* aimed at a log/md/json/build path, it blocks
+  the command and tells Claude to use the indexed tool instead. Otherwise it allows the command.
+  `VTS_ENFORCE=0` disables it entirely.
 - The **skill** biases Claude toward the indexed tools proactively.
 - The **core** guarantees the token cap no matter how Claude calls the tool.
 
@@ -357,6 +367,7 @@ Precedence: **environment variable (`VTS_*`) > `~/.vs-token-safer/config.json` >
 | `GenerateClangDatabase` fails: "Unable to find valid C++ toolchain for Clang x64" | Targets build with clang-cl; UBT validates a Clang toolchain | Add **`-Compiler=VisualCpp`** to the UBT command; the MSVC database still resolves the include graph. |
 | clangd resolves only header-free symbols | Compile DB has no include dirs → system/3rd-party headers don't resolve | Use a UBT-generated DB (it includes the paths); a hand-rolled `compile_commands.json` must list the include dirs. |
 | No C# results / "No backend resolved" | Roslyn engine not found | Install the VS Code C# extension (`ms-dotnettools.csharp`), or `dotnet tool install --global csharp-ls`; or set `VTS_ROSLYN_DLL` / `VTS_ROSLYN_CMD`. |
+| No JS/TS or Python results | The bundled LSP didn't install (offline first run, npm failure) | Re-run the session so deps reinstall, or set `VTS_TS_CMD` / `VTS_PY_CMD` at a `typescript-language-server` / `pyright-langserver` on PATH. |
 | Code search blocked when you wanted plain grep | The hook is steering you to the index | Set `VTS_ENFORCE=0` to let grep through (e.g. when the language server is unavailable). |
 | Wrong backend picked | Multiple project files under the root | Pin it: `VTS_BACKEND=clangd` (or `roslyn`), or pass `backend` per call. |
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ vs-token-safer savings (local, 1 search(es))
   - **JS/TS → typescript-language-server, Python → pyright.** These ship as plugin dependencies and
     install automatically on the first session — nothing to set up. vts launches the bundled copy with
     `node`, so there's no global install or PATH dance. Point `VTS_TS_CMD`/`VTS_PY_CMD` at your own if you
-    prefer. (Heads-up: bundling them adds a one-time ~50 MB to the plugin's first-run `npm install`.)
+    prefer. (Heads-up: bundling them adds a one-time ~50 MB to the plugin's first-run `npm install`, and
+    the JS/TS server wants **Node 20+** — on Node 18 it's skipped and the other backends still work.)
 - No IDE has to be running.
 
 clangd needs a compile database (`compile_commands.json`):

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -154,6 +154,47 @@ const renameMultiOk = !rm.isError && /APPLIED/.test(rm.text) && fs.readFileSync(
 try { fs.rmSync(rdir, { recursive: true, force: true }); } catch { /* ignore */ }
 const renameOk = renamePreviewOk && renameApplyOk && renameMultiOk;
 
+// 15) JS/TS + Python backends — auto-detect ordering and languageId mapping. Pure functions, so no
+// live tsserver/pyright is needed; this guards that adding the new backends didn't shadow clangd/roslyn
+// and that didOpen gets the right languageId per file extension.
+const { pickBackend } = await import("../server/backends/index.js");
+const { langIdForPath } = await import("../server/lsp.js");
+const mkBeDir = (sub, files) => {
+  const d = path.join(os.tmpdir(), `vts-be-${process.pid}-${sub}`);
+  fs.mkdirSync(d, { recursive: true });
+  for (const [n, body] of Object.entries(files)) fs.writeFileSync(path.join(d, n), body);
+  return d;
+};
+const tsDir = mkBeDir("ts", { "tsconfig.json": "{}", "app.ts": "export const x = 1;\n" });
+const pyDir = mkBeDir("py", { "pyproject.toml": "", "main.py": "x = 1\n" });
+const pkgDir = mkBeDir("pkg", { "package.json": "{}" });
+const mixDir = mkBeDir("mix", { "compile_commands.json": "[]", "package.json": "{}" }); // C++ DB + package.json → clangd wins
+const detectOk =
+  pickBackend(tsDir) === "typescript" &&
+  pickBackend(pyDir) === "pyright" &&
+  pickBackend(pkgDir) === "typescript" &&
+  pickBackend(mixDir) === "clangd";
+const langOk =
+  langIdForPath("a.ts", "typescript") === "typescript" &&
+  langIdForPath("a.tsx", "typescript") === "typescriptreact" &&
+  langIdForPath("a.mjs", "typescript") === "javascript" &&
+  langIdForPath("a.py", "pyright") === "python" &&
+  langIdForPath("a.cs", "roslyn") === "csharp" &&
+  langIdForPath("a.cpp", "clangd") === "cpp" &&
+  langIdForPath("noext", "pyright") === "python"; // unknown ext → backend default
+// nodeLspBackend wiring: ts/pyright end with --stdio, winShell is a boolean, and when the bundled bin
+// resolved we launch via `node <bin>` (cmd = this node, ≥2 args). Install-state-agnostic (the bin may or
+// may not be present in CI), so it asserts the shape, not a specific path.
+const tsArgs = BACKENDS.typescript.args(process.cwd());
+const pyArgs = BACKENDS.pyright.args(process.cwd());
+const wiringOk =
+  tsArgs[tsArgs.length - 1] === "--stdio" && pyArgs[pyArgs.length - 1] === "--stdio" &&
+  typeof BACKENDS.typescript.winShell === "boolean" && typeof BACKENDS.pyright.winShell === "boolean" &&
+  (BACKENDS.typescript.cmd === process.execPath ? tsArgs.length >= 2 && BACKENDS.typescript.winShell === false : true) &&
+  (BACKENDS.pyright.cmd === process.execPath ? pyArgs.length >= 2 && BACKENDS.pyright.winShell === false : true);
+const multiLangOk = detectOk && langOk && wiringOk;
+for (const d of [tsDir, pyDir, pkgDir, mixDir]) { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ } }
+
 await disposeClients();
 try { fs.rmSync(QH, { force: true }); } catch { /* ignore */ }
 try { fs.rmSync(IG, { force: true }); } catch { /* ignore */ }
@@ -173,6 +214,7 @@ const rows = [
   ["centrality + adaptive graph cache", centralityOk, "true", centralityOk],
   ["new tools: hover/symbols/files/text", newToolsOk, "true", newToolsOk],
   ["rename preview + apply + multi-edit", renameOk, "true", renameOk],
+  ["js/ts + python backends: detect + langId", multiLangOk, "true", multiLangOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -31,7 +31,7 @@ function isCodeSearchSegment(segment) {
   const isSearch = SEARCH_EXECS.has(exec) || (exec === "find" && /\s-name(\s|$)/.test(s));
   if (!isSearch) return false;
 
-  const codeExt = /\.(c|cc|cxx|cpp|h|hpp|hh|inl|ipp|tpp|cs)\b/.test(s);
+  const codeExt = /\.(c|cc|cxx|cpp|h|hpp|hh|inl|ipp|tpp|cs|ts|tsx|mts|cts|js|jsx|mjs|cjs|py|pyi)\b/.test(s);
   const codeDir = /(^|[\s"'/\\])(src|source|sources|engine|plugins)[\\/]/.test(s);
   const textTarget =
     /\.(log|txt|md|markdown|json|ya?ml|csv|tsv|xml|html?|ini|cfg|conf|toml|lock)\b/.test(s) ||
@@ -64,7 +64,8 @@ process.stdin.on("end", () => {
   process.stderr.write(
     "[vs-token-safer] Blocked a code-symbol search via Bash.\n" +
       "Use the vs-search MCP tools (server: 'vs-search') instead — they query the language\n" +
-      "server's index (clangd for C++, Roslyn for C#) and are token-capped to file:line:\n" +
+      "server's index (clangd for C++, Roslyn for C#, tsserver for JS/TS, pyright for Python)\n" +
+      "and are token-capped to file:line:\n" +
       "  - symbol / class / function / type → search_symbol  (args: q, projectPath, backend, maxResults)\n" +
       "  - references / usages of a symbol  → find_references (args: path, line, character — 0-based)\n" +
       "  - definition of a symbol           → goto_definition (args: path, line, character — 0-based)\n" +
@@ -72,7 +73,8 @@ process.stdin.on("end", () => {
       "  - file by name                     → find_files      (args: q, projectPath) — glob or substring\n" +
       "Or delegate the whole lookup to the context-isolated `code-locator` subagent.\n" +
       "CLI alternative (no MCP): `vts symbol --q <name> --projectPath <root>` (also: vts text / files / hover).\n" +
-      "Backend auto-detects from the root (compile_commands.json → clangd, .sln/.csproj → roslyn);\n" +
+      "Backend auto-detects from the root (compile_commands.json → clangd, .sln/.csproj → roslyn,\n" +
+      "tsconfig/package.json → typescript, pyproject.toml/*.py → pyright);\n" +
       "override with backend=… or VTS_BACKEND, set the root via projectPath or VTS_PROJECT_PATH.\n" +
       "For logs/config text, target a non-code file, or set VTS_ENFORCE=0."
   );

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -8,8 +8,9 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { toUri, envInt } from "../lsp.js";
+import { toUri, envInt, langIdForPath } from "../lsp.js";
 import { orderForWarm } from "../warmset.js";
+import { resolveBinJs } from "../resolve-bin.js";
 
 const env = (name, def) => { const v = process.env[name]; return v && v !== "" ? v : def; };
 const splitArgs = (s) => (s ? s.split(/\s+/).filter(Boolean) : null);
@@ -115,6 +116,18 @@ function findShallow(root, re, depth = 2) {
   return null;
 }
 
+// Build a backend def for a Node-based LSP shipped as an npm dep. Prefer the bundled bin (launched via
+// `node <bin.js>` — no PATH lookup, no Windows `.cmd`/shell quoting, spaces-safe). Honor a VTS_*_CMD
+// override; otherwise fall back to the global PATH binary (winShell on Windows for its `.cmd` shim).
+function nodeLspBackend(binJs, cmdOverride, globalName, argsEnv, rest) {
+  const extra = ["--stdio"];
+  if (cmdOverride) return { cmd: cmdOverride, args: () => splitArgs(env(argsEnv)) || extra, winShell: true, ...rest };
+  if (binJs) return { cmd: process.execPath, args: () => splitArgs(env(argsEnv)) || [binJs, ...extra], winShell: false, ...rest };
+  return { cmd: globalName, args: () => splitArgs(env(argsEnv)) || extra, winShell: true, ...rest };
+}
+const TS_BIN = resolveBinJs("typescript-language-server", "typescript-language-server");
+const PY_BIN = resolveBinJs("pyright", "pyright-langserver");
+
 export const BACKENDS = {
   // C/C++ via clangd (LLVM). Needs compile_commands.json (Unreal: generate via UBT
   // `-mode=GenerateClangDatabase`, or CMake `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`). LIVE-TARGET.
@@ -192,11 +205,39 @@ export const BACKENDS = {
         }
       : null,
   },
+  // JS/TS via typescript-language-server (wraps the official tsserver). Shipped as an npm dep in
+  // server/package.json → auto-installed for every user (no manual `npm i -g`); we resolve its bundled
+  // bin and launch `node <cli.mjs> --stdio`. Override via VTS_TS_CMD/ARGS; without the bundled copy it
+  // falls back to a PATH `typescript-language-server` (winShell on Windows for the `.cmd` shim). tsserver
+  // indexes lazily per open document, so the warm-up opens the top-N likely-query files; workspace/symbol
+  // still answers across the project.
+  typescript: nodeLspBackend(TS_BIN, env("VTS_TS_CMD"), "typescript-language-server", "VTS_TS_ARGS", {
+    detect: (root) => exists(root, "tsconfig.json", "jsconfig.json", "package.json") || !!findShallow(root, /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/, 1),
+    afterInit: async (client, root) => {
+      const files = findAllShallow(root, /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/i, 3);
+      const open = orderForWarm(root, files, envInt("VTS_TS_OPEN_CAP", 60));
+      for (const f of open) client.didOpen(f, langIdForPath(f, "typescript"));
+    },
+  }),
+  // Python via pyright-langserver (Microsoft's type checker / LSP). Same model: npm dep → auto-installed,
+  // launched as `node <langserver.index.js> --stdio`; override via VTS_PY_CMD/ARGS. Pyright analyzes on
+  // open + walks imports; warm-up opens the top-N likely-query files; workspace/symbol answers project-wide.
+  pyright: nodeLspBackend(PY_BIN, env("VTS_PY_CMD"), "pyright-langserver", "VTS_PY_ARGS", {
+    detect: (root) => exists(root, "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile") || !!findShallow(root, /\.py$/, 1),
+    afterInit: async (client, root) => {
+      const files = findAllShallow(root, /\.pyi?$/i, 3);
+      const open = orderForWarm(root, files, envInt("VTS_PY_OPEN_CAP", 60));
+      for (const f of open) client.didOpen(f, "python");
+    },
+  }),
 };
 
-// Auto-pick a backend from what's in the project root (C++ compile-db/uproject → clangd; .sln/.csproj → roslyn).
+// Auto-pick a backend from what's in the project root. Order = strongest signal first: a C++ compile
+// database / uproject (clangd) and a .sln/.csproj (roslyn) are unambiguous build artifacts, so they win
+// over the weaker JS/Python markers (a package.json or stray *.py shows up in many repos). Disambiguate
+// explicitly with VTS_BACKEND / backend=… when a root carries more than one.
 export function pickBackend(root) {
-  for (const name of ["clangd", "roslyn"]) {
+  for (const name of ["clangd", "roslyn", "typescript", "pyright"]) {
     try { if (BACKENDS[name].detect(root)) return name; } catch { /* ignore */ }
   }
   return "";

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -122,7 +122,10 @@ function findShallow(root, re, depth = 2) {
 function nodeLspBackend(binJs, cmdOverride, globalName, argsEnv, rest) {
   const extra = ["--stdio"];
   if (cmdOverride) return { cmd: cmdOverride, args: () => splitArgs(env(argsEnv)) || extra, winShell: true, ...rest };
-  if (binJs) return { cmd: process.execPath, args: () => splitArgs(env(argsEnv)) || [binJs, ...extra], winShell: false, ...rest };
+  // Bundled bin: cmd is `node`, so the bin path MUST stay argv[0]. A VTS_*_ARGS override replaces only
+  // the trailing flags (the user can't know the bundled bin path) — without this, `node <user-flags>`
+  // would spawn bare node with no server script and hang.
+  if (binJs) return { cmd: process.execPath, args: () => [binJs, ...(splitArgs(env(argsEnv)) || extra)], winShell: false, ...rest };
   return { cmd: globalName, args: () => splitArgs(env(argsEnv)) || extra, winShell: true, ...rest };
 }
 const TS_BIN = resolveBinJs("typescript-language-server", "typescript-language-server");

--- a/server/core.js
+++ b/server/core.js
@@ -9,7 +9,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { LspClient, fromUri } from "./lsp.js";
+import { LspClient, fromUri, langIdForPath } from "./lsp.js";
 import { pickBackend, BACKENDS, clangdAdvisory } from "./backends/index.js";
 import { recordQueryResults } from "./warmset.js";
 
@@ -30,7 +30,14 @@ export const MAX_RESULTS = parseInt(cfg("VTS_MAX_RESULTS", "maxResults", "60"), 
 const CONFIG_KEYS = ["projectPath", "backend", "maxResults"];
 
 const tok = (s) => Math.round(Buffer.byteLength(String(s), "utf8") / 4);
-const SYMBOL_KIND = { 5: "class", 6: "method", 9: "ctor", 12: "func", 13: "var", 23: "struct", 26: "type", 11: "interface", 10: "enum" };
+// LSP SymbolKind → short label (kept terse for the token cap). Covers the full enum so JS/TS/Python
+// symbols (constants, properties, fields, enum members…) render with a name instead of a raw `kN`.
+const SYMBOL_KIND = {
+  1: "file", 2: "module", 3: "namespace", 4: "package", 5: "class", 6: "method", 7: "prop", 8: "field",
+  9: "ctor", 10: "enum", 11: "interface", 12: "func", 13: "var", 14: "const", 15: "str", 16: "num",
+  17: "bool", 18: "array", 19: "obj", 20: "key", 22: "enum-member", 23: "struct", 24: "event",
+  25: "operator", 26: "type",
+};
 
 function applySetup(args) {
   let current = {};
@@ -77,7 +84,7 @@ function getClient(root, backendName) {
   if (clients.has(key)) return clients.get(key);
   const b = BACKENDS[backendName];
   const p = (async () => {
-    const c = new LspClient(b.cmd, b.args(root), { cwd: root });
+    const c = new LspClient(b.cmd, b.args(root), { cwd: root, shell: process.platform === "win32" && !!b.winShell });
     await c.initialize(root);
     if (typeof b.afterInit === "function") await b.afterInit(c, root); // e.g. Roslyn solution/open + load wait
     return c;
@@ -263,9 +270,9 @@ export async function runTool(name, a = {}) {
 
     const root = a.projectPath || PROJECT_PATH || process.cwd();
     const backendName = a.backend || BACKEND || pickBackend(root);
-    if (!backendName) return err(`No backend resolved. Pass backend=clangd|roslyn, set VTS_BACKEND, or ensure the project root has compile_commands.json (C++) or a .sln/.csproj (C#).`);
+    if (!backendName) return err(`No backend resolved. Pass backend=clangd|roslyn|typescript|pyright, set VTS_BACKEND, or ensure the project root has compile_commands.json (C++), a .sln/.csproj (C#), a tsconfig/package.json (JS/TS), or a pyproject.toml/*.py (Python).`);
     const max = Number(a.maxResults) || MAX_RESULTS;
-    const lang = backendName === "roslyn" ? "csharp" : "cpp";
+    const lang = langIdForPath(a.path, backendName); // languageId for didOpen (hover/document_symbols/rename); unused by search_symbol
 
     if (name === "search_symbol") {
       if (!a.q) return err("search_symbol needs q (the symbol name/substring).");

--- a/server/ensure-deps.mjs
+++ b/server/ensure-deps.mjs
@@ -30,7 +30,10 @@ try {
   const isWin = process.platform === "win32";
   const local = path.join(path.dirname(process.execPath), isWin ? "npm.cmd" : "npm");
   const npm = fs.existsSync(local) ? `"${local}"` : "npm";
-  execSync(`${npm} install --no-audit --no-fund --loglevel=error`, { cwd: DATA, stdio: "ignore" });
+  // Deps grew (typescript + typescript-language-server + pyright ≈ 50 MB), so a stalled registry could
+  // otherwise block this SessionStart hook indefinitely. Bound it; on timeout the catch drops the marker
+  // so the next session retries.
+  execSync(`${npm} install --no-audit --no-fund --loglevel=error`, { cwd: DATA, stdio: "ignore", timeout: 300000 });
 } catch (e) {
   // Surface the reason on stderr (visible in hook logs) instead of failing completely silently;
   // the MCP server self-heals at spawn, but a logged cause speeds diagnosis when even that can't.

--- a/server/index.js
+++ b/server/index.js
@@ -28,7 +28,7 @@ const TOOLS = [
       properties: {
         q: { type: "string", description: "Symbol name or substring to search for." },
         projectPath: { type: "string", description: "Project root (default: configured projectPath or cwd)." },
-        backend: { type: "string", description: "clangd | roslyn (default: auto-detect from the root)." },
+        backend: { type: "string", description: "clangd | roslyn | typescript | pyright (default: auto-detect from the root)." },
         maxResults: { type: "number", description: "Cap on returned locations (default 60)." },
       },
       required: ["q"],
@@ -167,7 +167,7 @@ const TOOLS = [
       type: "object",
       properties: {
         projectPath: { type: "string", description: "Default project root." },
-        backend: { type: "string", description: "clangd | roslyn (default: auto)." },
+        backend: { type: "string", description: "clangd | roslyn | typescript | pyright (default: auto)." },
         maxResults: { type: "number", description: "Default cap on returned locations." },
       },
     },
@@ -190,7 +190,7 @@ const TOOLS = [
   {
     name: "vts_warmup",
     description: "Pre-build the language-server index (IDE-style) so later searches are fast. Spawns + warms the backend without running a query.",
-    inputSchema: { type: "object", properties: { projectPath: { type: "string" }, backend: { type: "string", enum: ["clangd", "roslyn"] } } },
+    inputSchema: { type: "object", properties: { projectPath: { type: "string" }, backend: { type: "string", enum: ["clangd", "roslyn", "typescript", "pyright"] } } },
   },
 ];
 

--- a/server/lsp.js
+++ b/server/lsp.js
@@ -19,12 +19,33 @@ export const fromUri = (u) => {
   try { return fileURLToPath(u); } catch { return u.replace(/^file:\/\//, ""); }
 };
 
+// LSP `textDocument/didOpen` wants a languageId. One backend can serve several extensions
+// (typescript-language-server handles .ts/.tsx/.js/.jsx; pyright handles .py/.pyi), so derive the id
+// from the file extension and fall back to the backend's primary language when the extension is unknown.
+const EXT_LANG = {
+  ".c": "c", ".cc": "cpp", ".cxx": "cpp", ".cpp": "cpp", ".h": "cpp", ".hpp": "cpp", ".hh": "cpp", ".inl": "cpp", ".ipp": "cpp", ".tpp": "cpp",
+  ".cs": "csharp",
+  ".ts": "typescript", ".tsx": "typescriptreact", ".mts": "typescript", ".cts": "typescript",
+  ".js": "javascript", ".jsx": "javascriptreact", ".mjs": "javascript", ".cjs": "javascript",
+  ".py": "python", ".pyi": "python",
+};
+const BACKEND_LANG = { clangd: "cpp", roslyn: "csharp", typescript: "typescript", pyright: "python" };
+export function langIdForPath(p, backend) {
+  const m = String(p || "").toLowerCase().match(/\.[^.\\/]+$/);
+  return (m && EXT_LANG[m[0]]) || BACKEND_LANG[backend] || "cpp";
+}
+
 export class LspClient {
-  constructor(cmd, args = [], { cwd = process.cwd(), env = process.env } = {}) {
+  constructor(cmd, args = [], { cwd = process.cwd(), env = process.env, shell = false } = {}) {
     this.cmd = cmd;
     this.args = args;
     this.cwd = cwd;
     this.env = env;
+    // On Windows, npm-installed LSP CLIs (typescript-language-server, pyright-langserver) are `.cmd`
+    // shims that child_process.spawn can't launch without a shell. Enabled per-backend (winShell) only
+    // for those — clangd.exe / the dotnet host resolve directly and may sit under a path with spaces
+    // that shell-quoting would mangle, so they stay shell:false.
+    this.shell = shell;
     this.proc = null;
     this.nextId = 1;
     this.pending = new Map(); // id -> {resolve, reject}
@@ -36,7 +57,12 @@ export class LspClient {
   }
 
   start() {
-    this.proc = spawn(this.cmd, this.args, { cwd: this.cwd, env: this.env, stdio: ["pipe", "pipe", "pipe"] });
+    // In shell mode, fold args into the command string and pass [] — spawn(cmd, [non-empty], {shell:true})
+    // is deprecated (DEP0190: args aren't escaped). Our shell-mode args are simple flags (`--stdio`); a
+    // user override with spaces should quote inside VTS_TS_CMD/VTS_PY_CMD.
+    const cmd = this.shell ? [this.cmd, ...this.args].join(" ") : this.cmd;
+    const args = this.shell ? [] : this.args;
+    this.proc = spawn(cmd, args, { cwd: this.cwd, env: this.env, stdio: ["pipe", "pipe", "pipe"], shell: this.shell });
     this.proc.stdout.on("data", (d) => this._onData(d));
     this.proc.stderr.on("data", (d) => { this.stderr += d.toString(); if (this.stderr.length > 20000) this.stderr = this.stderr.slice(-20000); });
     this.proc.on("error", (e) => this._failAll(new Error(`failed to spawn ${this.cmd}: ${e.message}`)));

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vs-token-safer",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vs-token-safer",
-      "version": "0.1.0",
+      "version": "0.7.0",
       "license": "MIT",
       "bin": {
         "vs-token-safer": "index.js",
@@ -16,7 +16,10 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.0"
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "pyright": "^1.1.400",
+        "typescript": "^5.0.0",
+        "typescript-language-server": "^5.0.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -527,6 +530,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -906,6 +923,23 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pyright": {
+      "version": "1.1.410",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.410.tgz",
+      "integrity": "sha512-3ImEV3F3YPMJZDwmouvKj3Ytxkw/adZFGlsOsNKiS+B97Th4h7TFElFKpBG/j1nqx6kXFPQjnzOU+zTBOkki2g==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "pyright": "index.js",
+        "pyright-langserver": "langserver.index.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
@@ -1186,6 +1220,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-language-server": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-5.3.0.tgz",
+      "integrity": "sha512-5puofxZHgFdAYtfNpmwCAvgtaYgg8wrUnH30m7Ze3QuguId5RNRadKASpOpyDxTyUdAF51FjhTdjntLw/EuWcQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "typescript-language-server": "lib/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/unpipe": {

--- a/server/package.json
+++ b/server/package.json
@@ -10,8 +10,13 @@
   "license": "MIT",
   "author": { "name": "JSungMin" },
   "bin": { "vts": "cli.js", "vs-token-safer": "index.js" },
-  "files": ["index.js", "cli.js", "core.js", "lsp.js", "sdk.js", "backends/"],
+  "files": ["index.js", "cli.js", "core.js", "lsp.js", "sdk.js", "resolve-bin.js", "warmset.js", "ensure-deps.mjs", "backends/"],
   "scripts": { "start": "node index.js", "test": "node ../eval/run.mjs" },
-  "optionalDependencies": { "@modelcontextprotocol/sdk": "^1.12.0" },
+  "optionalDependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "typescript-language-server": "^5.0.0",
+    "typescript": "^5.0.0",
+    "pyright": "^1.1.400"
+  },
   "engines": { "node": ">=18" }
 }

--- a/server/resolve-bin.js
+++ b/server/resolve-bin.js
@@ -1,0 +1,41 @@
+// Resolve a bundled language-server's bin entry to an absolute .js path, searching the SAME
+// node_modules locations as the MCP SDK (sdk.js): the plugin data dir (installed, populated by the
+// ensure-deps SessionStart hook / sdk self-heal), the plugin's bundled copy, then local node_modules
+// (dev). typescript-language-server and pyright ship as npm deps in server/package.json, so they get
+// installed automatically for every user — no manual `npm i -g`. We launch them with `node <bin.js>`
+// rather than the PATH shim so there's no Windows `.cmd`/shell quoting to get wrong, and a path with
+// spaces is passed literally. Returns null if the package isn't installed anywhere; the caller then
+// falls back to a PATH-resolved global binary (with winShell on Windows).
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const DATA = process.env.CLAUDE_PLUGIN_DATA;
+const ROOT = process.env.CLAUDE_PLUGIN_ROOT;
+const HERE = path.dirname(fileURLToPath(import.meta.url)); // server/
+
+function anchors() {
+  const a = [];
+  if (DATA) a.push(path.join(DATA, "package.json"));
+  if (ROOT) a.push(path.join(ROOT, "server", "package.json"));
+  a.push(path.join(HERE, "package.json")); // dev / local node_modules
+  return a;
+}
+
+export function resolveBinJs(pkg, binName) {
+  for (const anchor of anchors()) {
+    try {
+      const req = createRequire(pathToFileURL(anchor).href);
+      const pj = req.resolve(`${pkg}/package.json`);
+      const meta = JSON.parse(fs.readFileSync(pj, "utf8"));
+      const rel = typeof meta.bin === "string" ? meta.bin : meta.bin && meta.bin[binName];
+      if (!rel) continue;
+      const abs = path.join(path.dirname(pj), rel);
+      if (fs.existsSync(abs)) return abs;
+    } catch {
+      /* try the next anchor */
+    }
+  }
+  return null;
+}

--- a/server/sdk.js
+++ b/server/sdk.js
@@ -60,6 +60,7 @@ function installIntoData() {
     execSync(`${npm} install --no-audit --no-fund --loglevel=error`, {
       cwd: DATA,
       stdio: ["ignore", "ignore", "inherit"],
+      timeout: 300000, // deps grew to ~50 MB (ts + pyright); bound the synchronous install so a stalled registry can't wedge the server spawn
     });
   } catch (e) {
     console.error(`[${TAG}] dependency install failed:`, e?.message || e);

--- a/skills/vs-search/SKILL.md
+++ b/skills/vs-search/SKILL.md
@@ -28,14 +28,18 @@ CLI equivalent (no MCP needed): `vts symbol --q <name> --projectPath <root>`,
 `vts hover …`, `vts symbols --path <file>`, `vts text --q <pattern>`, `vts files --q <glob>`.
 
 ## Backends & projectPath
-- Backend auto-detects from the project root: `compile_commands.json` (or a `.uproject`) → **clangd**;
-  a `.sln`/`.csproj` → **roslyn**. Override with `backend=clangd|roslyn` or env `VTS_BACKEND`.
+- Backend auto-detects from the project root (strongest build-artifact first): `compile_commands.json`
+  (or a `.uproject`) → **clangd**; a `.sln`/`.csproj` → **roslyn**; a `tsconfig`/`jsconfig`/`package.json`
+  → **typescript** (tsserver); a `pyproject.toml`/`*.py` → **pyright**. Override with
+  `backend=clangd|roslyn|typescript|pyright` or env `VTS_BACKEND` when a root carries more than one.
 - Set the root via `projectPath` or env `VTS_PROJECT_PATH` (default: cwd).
 - **clangd needs `compile_commands.json`.** Unreal: generate via UBT
   `-mode=GenerateClangDatabase`; CMake: `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`. Without it, clangd
   indexes nothing useful — tell the user to generate it.
 - **roslyn** defaults to the `csharp-ls` dotnet tool; point `VTS_ROSLYN_CMD`/`VTS_ROSLYN_ARGS` at
   `Microsoft.CodeAnalysis.LanguageServer` for the exact Visual Studio engine. Currently best-effort.
+- **typescript** (JS/TS) and **pyright** (Python) ship as plugin deps and auto-install — no setup. vts
+  launches the bundled copy with `node`. Override via `VTS_TS_CMD`/`VTS_PY_CMD`.
 
 ## Truncated results
 Symbol/reference lists are capped at `maxResults` (default 60). A trailing `… N more` means the set
@@ -52,6 +56,7 @@ partial set and claim it's complete.
 
 ## Fallback
 If a `vs-search` tool errors (engine missing/failed to spawn): clangd not installed → install LLVM
-clangd; roslyn not installed → `dotnet tool install --global csharp-ls`. Until the engine works,
+clangd; roslyn not installed → `dotnet tool install --global csharp-ls`; typescript/pyright not found →
+re-run the session so the bundled deps reinstall (or set `VTS_TS_CMD`/`VTS_PY_CMD`). Until the engine works,
 code-grep is blocked by the hook — the user can set `VTS_ENFORCE=0` to allow grep as a fallback. Do
 not loop on blocked grep; surface the fix and move on.


### PR DESCRIPTION
## What lands

Two commits past v0.7.0 — adds two language-server backends behind the existing generic LSP client/registry, shipped so they install automatically for every user.

- **JS/TS (`typescript-language-server`, wraps tsserver) + Python (`pyright`)** backends (`ba39e03`). Both ship as optionalDependencies in `server/package.json` → ensure-deps / sdk.js `npm install` them into `${CLAUDE_PLUGIN_DATA}`, no manual `npm i -g`. New `server/resolve-bin.js` locates the bundled bin and launches `node <bin.js>` (sidesteps Windows `.cmd`/shell). `pickBackend` order = clangd > roslyn > typescript > pyright. `langIdForPath` maps file-ext → LSP languageId; `SYMBOL_KIND` extended to the full LSP enum. grep-block hook now covers js/ts/py (default on).
- **critic fixes** (`7c5ef5c`): `VTS_TS_ARGS`/`VTS_PY_ARGS` override no longer drops the bundled bin path; `vts_warmup` schema enum + backend descriptions include typescript|pyright; npm install gets a 300s timeout (deps grew ~50MB); docs note JS/TS needs Node 20+.

## Review points

- **Token-first held**: new backends reuse the same formatters → `file:line`, capped, no bodies.
- **Local-only**: tsserver/pyright spawn locally over stdio; only network is the first-run `npm install`.
- **Cross-platform spawn**: bundled bin via `node` (shell:false, spaces-safe); winShell only for a global-PATH fallback.
- **Live-verified by dogfooding** vts on its own `server/*.js` (symbol/refs/document_symbols) + a temp `.py` via pyright — both through the bundled bins, incl. through the MCP server post-restart.
- eval **15/15** (new guard: detect ordering, langId mapping, nodeLspBackend wiring, install-state-agnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)