### PR TITLE
Release v0.9.0 — log-analysis steer to gamedev-log + Grep-tool warn matcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
 (`vts`). npm package + plugin name: `vs-token-safer`.
 
 ## First, orient (every session)
-1. Read this file, then `node eval/run.mjs` — must print `EVAL PASSED` (15/15) before you change anything.
+1. Read this file, then `node eval/run.mjs` — must print `EVAL PASSED` (17/17) before you change anything.
 2. Resume context lives in: this file · the wiki (`wiki_query "vs-token-safer"`, pages under
    `.omc/wiki/`) · memory anchor `project-vs-token-safer`. The wiki **Status and TODO** page is the
    live checklist.
@@ -99,7 +99,13 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   through a shell (clangd.exe / dotnet host stay shell:false to survive paths with spaces). `langIdForPath`
   (lsp.js) maps file ext → LSP languageId so one backend serves several extensions.
 - **grep-block hook** now covers `js/jsx/mjs/cjs/ts/tsx/mts/cts/py/pyi` too (default on, per user) so vts
-  self-enforces while we develop it; `VTS_ENFORCE=0` still the escape hatch.
+  self-enforces while we develop it; `VTS_ENFORCE=0` still the escape hatch. matcher is `Bash|Grep`: Bash
+  code-grep BLOCKS (vts default), the built-in **Grep tool** WARNS-only (never block — it's the fallback),
+  and a search aimed at a LOG (`Logs/` dir or `.log/.jsonl`) WARNS+allows with a gamedev-log pointer.
+- **log steer (rider 0.2.8 parity).** `core.js` `looksLogTarget(a)` (path/projectPath/paths vs `LOG_PATHISH`)
+  appends a one-line gamedev-log pointer (`LOG_STEER`) to ANY tool result whose target is a log; empty
+  symbol results carry `EMPTY_HINT` (stale-index + definitions-only + log→gamedev-log), find_files/search_text
+  empties carry `LOG_EMPTY_HINT`. Additive text only, never blocks. Mirrors `../rider-mcp-enforcer` proxy steer.
 
 ## Next (see wiki "Status and TODO")
 P1 DONE: core rename, `index.js`/`sdk.js`/`ensure-deps.mjs`, grep-block `hooks/`, `skills/`+`commands/`,

--- a/README.ko.md
+++ b/README.ko.md
@@ -93,6 +93,10 @@ dogfood합니다.
 2. 그 위치를 vs-token-safer의 `goto_definition`/`find_references`(또는 `search_symbol`)에 넘겨 코드를
    엽니다. raw 로그를 grep하거나 덤프하지 않고요.
 
+역방향도 동작합니다: 코드 검색(vs-search 도구나 Bash/Grep 검색)이 로그를 겨냥하면 — `Logs/` 디렉터리나
+`.log`/`.jsonl` 파일 — vs-token-safer가 코드 인덱스에서 빈 결과를 주는 대신 gamedev-log로 안내합니다.
+언어 서버 인덱스는 소스를 다루지 로그를 다루지 않으니까요.
+
 ## 무엇을 하나
 
 clangd와 Roslyn은 그 자체로 이미 의미 기반 심볼/참조 분석을 합니다. 이 플러그인이 그 위에 더하는 건
@@ -146,7 +150,7 @@ func SpawnActorFromClass  @ MyGame/Source/SpawnLib.cpp:31
   줄(주석, 문자열, 무관한 식별자)을 끌어옵니다. 플러그인은 의미 기반 히트당 `file:line` 하나만, 그것도
   캡해서 반환합니다.
 - 목-LSP eval(`node eval/run.mjs`, 툴체인 불필요)이 매 커밋 응답 정형화 절감을 게이트합니다: raw 인덱스
-  `~57,308 tok` → 캡된 출력 `~1,515 tok` = **97.4%** (체크 15/15).
+  `~57,308 tok` → 캡된 출력 `~1,515 tok` = **97.4%** (체크 17/17).
 
 ### 정확도 차이와 그 이유
 "누가 더 맞다"가 아니라 정밀도/재현율 트레이드오프입니다:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ symbol/source. A typical loop:
 2. Hand that location to vs-token-safer's `goto_definition` / `find_references` (or `search_symbol`) to
    open and understand the code, without ever grepping or dumping the raw log.
 
+The handoff also runs in reverse: if a code search (a vs-search tool, or a Bash/Grep search) is aimed at a
+log — a `Logs/` dir or a `.log`/`.jsonl` file — vs-token-safer points you back at gamedev-log instead of
+returning an empty result from the code index. The language-server index covers source, not logs.
+
 ## What it does
 
 clangd and Roslyn already do semantic symbol/reference analysis on their own. What this plugin adds on
@@ -150,7 +154,7 @@ Bash grep-and-paste vs this plugin. No project source is reproduced, only aggreg
   text so it returns more of them (comments, strings, unrelated identifiers). The plugin returns one
   `file:line` per semantic hit, capped.
 - The mock-LSP eval (`node eval/run.mjs`, no toolchain) gates the response-shaping win on every commit:
-  raw index `~57,308 tok` → capped output `~1,515 tok` = **97.4%** (15/15 checks).
+  raw index `~57,308 tok` → capped output `~1,515 tok` = **97.4%** (17/17 checks).
 
 ### Accuracy difference (and why)
 This is a precision/recall trade-off, not a case of one being more correct than the other:

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -218,10 +218,12 @@ const runHook = (payload) => {
 const hCode = runHook({ tool_name: "Bash", tool_input: { command: "grep -rn Foo src/Thing.cpp" } });
 const hLog = runHook({ tool_name: "Bash", tool_input: { command: "grep Error Saved/Logs/run.log" } });
 const hGrep = runHook({ tool_name: "Grep", tool_input: { pattern: "Foo", glob: "*.ts" } });
+const hGrepLog = runHook({ tool_name: "Grep", tool_input: { pattern: "Error", path: "Saved/Logs" } }); // bare Logs dir
 const hookOk =
   hCode.status === 2 && /Blocked/.test(hCode.err) &&
   hLog.status === 0 && /gamedev-log/.test(hLog.out) &&
-  hGrep.status === 0 && /Grep tool/.test(hGrep.out);
+  hGrep.status === 0 && /Grep tool/.test(hGrep.out) &&
+  hGrepLog.status === 0 && /gamedev-log/.test(hGrepLog.out);
 
 await disposeClients();
 try { fs.rmSync(QH, { force: true }); } catch { /* ignore */ }

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -195,6 +195,34 @@ const wiringOk =
 const multiLangOk = detectOk && langOk && wiringOk;
 for (const d of [tsDir, pyDir, pkgDir, mixDir]) { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ } }
 
+// 16) log steer (rider 0.2.8 parity) — a search aimed at a Logs/ path appends a gamedev-log pointer to the
+// result (additive, never blocks); an empty result carries the same hint for the path-less case.
+const logRoot = path.join(os.tmpdir(), `vts-eval-${process.pid}-Logs`);
+const logDir = path.join(logRoot, "Logs", "sub"); // projectPath contains a `Logs/` segment → LOG_PATHISH hits
+fs.mkdirSync(logDir, { recursive: true });
+const lsRes = await runTool("search_text", { q: "anything", projectPath: logDir }); // log target → LOG_STEER
+const ffRes = await runTool("find_files", { q: "no_such_file_xyz", projectPath: os.tmpdir() }); // empty, non-log
+const logSteerOk =
+  !lsRes.isError && /This looks like a LOG target/.test(lsRes.text) && // path-based steer (LOG_STEER)
+  !ffRes.isError && /gamedev-log/.test(ffRes.text);                    // path-less empty hint (LOG_EMPTY_HINT)
+try { fs.rmSync(logRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+
+// 17) PreToolUse hook vectors: Bash code-grep BLOCKS (exit 2), Bash log-grep WARNS+allows (gamedev-log),
+// Grep tool on code WARNS+allows. Runs the actual hook as a child with JSON stdin.
+const { spawnSync } = await import("node:child_process");
+const hookPath = new URL("../hooks/block-code-grep.js", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+const runHook = (payload) => {
+  const r = spawnSync(process.execPath, [hookPath], { input: JSON.stringify(payload), encoding: "utf8" });
+  return { status: r.status, out: r.stdout || "", err: r.stderr || "" };
+};
+const hCode = runHook({ tool_name: "Bash", tool_input: { command: "grep -rn Foo src/Thing.cpp" } });
+const hLog = runHook({ tool_name: "Bash", tool_input: { command: "grep Error Saved/Logs/run.log" } });
+const hGrep = runHook({ tool_name: "Grep", tool_input: { pattern: "Foo", glob: "*.ts" } });
+const hookOk =
+  hCode.status === 2 && /Blocked/.test(hCode.err) &&
+  hLog.status === 0 && /gamedev-log/.test(hLog.out) &&
+  hGrep.status === 0 && /Grep tool/.test(hGrep.out);
+
 await disposeClients();
 try { fs.rmSync(QH, { force: true }); } catch { /* ignore */ }
 try { fs.rmSync(IG, { force: true }); } catch { /* ignore */ }
@@ -215,6 +243,8 @@ const rows = [
   ["new tools: hover/symbols/files/text", newToolsOk, "true", newToolsOk],
   ["rename preview + apply + multi-edit", renameOk, "true", renameOk],
   ["js/ts + python backends: detect + langId", multiLangOk, "true", multiLangOk],
+  ["log steer + empty hint → gamedev-log", logSteerOk, "true", logSteerOk],
+  ["hook: block code / warn log+grep", hookOk, "true", hookOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -1,82 +1,155 @@
 #!/usr/bin/env node
 /*
- * vs-token-safer — PreToolUse hook
- * Blocks Bash code-symbol searches (grep/rg/ack/ag/findstr, or `find -name`, over source
- * files) and tells Claude to use the vs-search MCP tools (or the `vts` CLI) instead. Raw text
- * searches (logs, md, json, config) pass through.
+ * vs-token-safer — PreToolUse hook (matchers: Bash, Grep)
  *
- * It only triggers when a search tool is the ACTUAL executable of a command segment — so
- * `node setup.mjs ...`, `cd ".../plugins/..."`, etc. are never blocked just because a path
- * or argument happens to contain "rg", "plugins", "source", and the like.
+ * Steers code search toward the language-server index (vs-search MCP) instead of text search, and steers
+ * LOG analysis toward gamedev-log. Three vectors:
+ *   - Bash: grep/rg/ack/ag/findstr (or `find -name`) over C/C++/C#/JS/TS/Py source → BLOCKED by default
+ *     (exit 2); VTS_ENFORCE=0 disables. Raw non-code text (md, json, config) passes.
+ *   - Grep TOOL (built-in): the model's reflexive code search lives here, not Bash — so a Bash-only hook
+ *     never fired where the habit is. The Grep branch nudges too, but is **warn-ONLY, never block**: Grep
+ *     is the sanctioned fallback (and the right call on a just-edited/unindexed file), so blocking it would
+ *     strand the model.
+ *   - LOG steer: a search aimed at a Logs/ dir or a .log/.jsonl file (Bash OR Grep) gets a warn-only
+ *     pointer to gamedev-log — the language-server index doesn't cover logs, and they aren't blocked.
  *
- * Protocol: exit 0 = allow; exit 2 + stderr = block, stderr shown to the model.
+ * The Bash branch only triggers when a search tool is the ACTUAL executable of a command segment — so
+ * `node setup.mjs ...`, `cd ".../plugins/..."`, etc. are never flagged just because a path or argument
+ * happens to contain "rg", "plugins", "source", and the like.
+ *
+ * Protocol: exit 0 = allow; exit 2 + stderr = block, stderr shown to the model. A warn is an exit-0 with a
+ * hookSpecificOutput.additionalContext payload on stdout (stderr on exit 0 isn't reliably surfaced).
  */
 
 const SEARCH_EXECS = new Set(["grep", "rg", "ack", "ag", "findstr"]);
+// ripgrep --type aliases for the languages we index (the Grep tool's `type` param forwards to rg).
+const CODE_TYPES = new Set(["c", "cpp", "csharp", "cs", "cxx", "cc", "cuda", "js", "ts", "typescript", "javascript", "jsx", "tsx", "py", "python"]);
+const CODE_EXT_RE = /\.(c|cc|cxx|cpp|h|hpp|hh|inl|ipp|tpp|cs|ts|tsx|mts|cts|js|jsx|mjs|cjs|py|pyi)\b/;
+const CODE_DIR_RE = /(^|[\s"'/\\])(src|source|sources|engine|plugins)[\\/]/;
+const TEXT_TARGET_RE = /\.(log|txt|md|markdown|json|ya?ml|csv|tsv|xml|html?|ini|cfg|conf|toml|lock)\b/;
+// A log-ish target: a Logs/ (or Saved/Logs/) dir, or a .log/.jsonl/.log.N file. Precise enough to skip
+// "log" inside "catalog" and ordinary source paths.
+const LOG_TARGET_RE = /(^|[\s"'/\\])(saved[/\\])?logs[/\\]|\.(log|jsonl)(\.\d+)?\b/i;
 
 function execOf(segment) {
   const tokens = segment.trim().split(/\s+/);
   let i = 0;
-  // skip leading env-var assignments: FOO=bar grep ...
-  while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++;
+  while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++; // skip FOO=bar prefixes
   let exec = (tokens[i] || "").toLowerCase();
-  // strip any path prefix and a Windows extension → basename
-  exec = exec.replace(/^.*[\\/]/, "").replace(/\.(exe|bat|cmd|ps1)$/, "");
-  return exec;
+  return exec.replace(/^.*[\\/]/, "").replace(/\.(exe|bat|cmd|ps1)$/, ""); // basename, strip win ext
+}
+
+function isSearchSegment(segment) {
+  const exec = execOf(segment);
+  return SEARCH_EXECS.has(exec) || (exec === "find" && /\s-name(\s|$)/.test(segment.toLowerCase()));
 }
 
 function isCodeSearchSegment(segment) {
-  const exec = execOf(segment);
+  if (!isSearchSegment(segment)) return false;
   const s = segment.toLowerCase();
-  const isSearch = SEARCH_EXECS.has(exec) || (exec === "find" && /\s-name(\s|$)/.test(s));
-  if (!isSearch) return false;
-
-  const codeExt = /\.(c|cc|cxx|cpp|h|hpp|hh|inl|ipp|tpp|cs|ts|tsx|mts|cts|js|jsx|mjs|cjs|py|pyi)\b/.test(s);
-  const codeDir = /(^|[\s"'/\\])(src|source|sources|engine|plugins)[\\/]/.test(s);
+  const codeExt = CODE_EXT_RE.test(s);
+  const codeDir = CODE_DIR_RE.test(s);
   const textTarget =
-    /\.(log|txt|md|markdown|json|ya?ml|csv|tsv|xml|html?|ini|cfg|conf|toml|lock)\b/.test(s) ||
+    TEXT_TARGET_RE.test(s) ||
     /(^|[\s"'/\\])(logs?|build|intermediate|saved|node_modules|\.git)[\\/]/.test(s);
-
   return (codeExt || codeDir) && !textTarget;
 }
+
+// A search segment whose target is a LOG (steer to gamedev-log; never blocked).
+function isLogSearchSegment(segment) {
+  return isSearchSegment(segment) && LOG_TARGET_RE.test(segment);
+}
+
+// Grep TOOL — nudge only on an EXPLICIT code signal (a code-ext glob, a code `type`, or a code path). A
+// bare Grep over the cwd (no path/glob/type) is NOT nudged: can't confirm it targets code, and silence
+// beats noise. An explicit non-code glob/path opts out.
+function isCodeGrepTool(ti) {
+  const glob = String(ti.glob || "").toLowerCase();
+  const type = String(ti.type || "").toLowerCase();
+  const p = String(ti.path || "").replace(/\\/g, "/").toLowerCase();
+  if (glob && TEXT_TARGET_RE.test(glob)) return false;
+  if (p && TEXT_TARGET_RE.test(p)) return false;
+  const globIsCode = !!glob && CODE_EXT_RE.test(glob);
+  const pathIsCode = (!!p && CODE_EXT_RE.test(p)) || CODE_DIR_RE.test(p);
+  return globIsCode || CODE_TYPES.has(type) || pathIsCode;
+}
+function isLogGrepTool(ti) {
+  const glob = String(ti.glob || "");
+  const p = String(ti.path || "");
+  return LOG_TARGET_RE.test(glob) || LOG_TARGET_RE.test(p);
+}
+
+function emitWarn(text) {
+  // allow, but inject the nudge into the model's context (stderr on exit 0 isn't reliably surfaced).
+  process.stdout.write(
+    JSON.stringify({ hookSpecificOutput: { hookEventName: "PreToolUse", additionalContext: text } }) + "\n"
+  );
+}
+
+const GREP_NUDGE =
+  "[vs-token-safer] Code search via the Grep tool. For symbol / references / definition on ESTABLISHED " +
+  "code, prefer the vs-search MCP tools (search_symbol / find_references / goto_definition) — semantic " +
+  "(language-server index) and token-capped to file:line — or search_text / find_files, or the " +
+  "code-locator subagent. For a JUST-edited / unindexed file or a quick literal peek, Grep is fine — carry " +
+  "on. Disable: VTS_ENFORCE=0.";
+const LOG_NUDGE =
+  "[vs-token-safer] This search targets a LOG. The language-server index only covers source code — for log " +
+  "analysis use gamedev-log (/gamedev-log-analyzer:logs, or the gamedev-log CLI: summary / search / locate " +
+  "/ fields / diff) instead of grep. Disable: VTS_ENFORCE=0.";
+
+const BLOCK_MSG =
+  "[vs-token-safer] Blocked a code-symbol search via Bash.\n" +
+  "Use the vs-search MCP tools (server: 'vs-search') instead — they query the language\n" +
+  "server's index (clangd for C++, Roslyn for C#, tsserver for JS/TS, pyright for Python)\n" +
+  "and are token-capped to file:line:\n" +
+  "  - symbol / class / function / type → search_symbol  (args: q, projectPath, backend, maxResults)\n" +
+  "  - references / usages of a symbol  → find_references (args: path, line, character — 0-based)\n" +
+  "  - definition of a symbol           → goto_definition (args: path, line, character — 0-based)\n" +
+  "  - raw text / string / comment      → search_text     (args: q, projectPath) — token-capped grep\n" +
+  "  - file by name                     → find_files      (args: q, projectPath) — glob or substring\n" +
+  "Or delegate the whole lookup to the context-isolated `code-locator` subagent.\n" +
+  "CLI alternative (no MCP): `vts symbol --q <name> --projectPath <root>` (also: vts text / files / hover).\n" +
+  "Backend auto-detects from the root (compile_commands.json → clangd, .sln/.csproj → roslyn,\n" +
+  "tsconfig/package.json → typescript, pyproject.toml/*.py → pyright);\n" +
+  "override with backend=… or VTS_BACKEND, set the root via projectPath or VTS_PROJECT_PATH.\n" +
+  "For logs/config text, target a non-code file (or use gamedev-log for logs), or set VTS_ENFORCE=0.";
 
 let input = "";
 process.stdin.on("data", (d) => (input += d));
 process.stdin.on("end", () => {
-  let cmd = "";
+  let j;
   try {
-    cmd = ((JSON.parse(input).tool_input) || {}).command || "";
+    j = JSON.parse(input);
   } catch {
     process.exit(0); // unparseable — don't block
   }
-  if (!cmd) process.exit(0);
+  const toolName = j.tool_name || "";
+  const ti = j.tool_input || {};
 
-  // Escape hatch: if the language server is unavailable (no compile_commands.json / no .sln),
-  // blocking grep would leave Claude with no way to search code. Set VTS_ENFORCE=0 (or false/off).
+  // Escape hatch: if the language server is unavailable, blocking grep would strand the model. Set
+  // VTS_ENFORCE=0 (or false/off) to disable the block AND the nudges.
   const enforce = String(process.env.VTS_ENFORCE ?? "1").toLowerCase();
   if (enforce === "0" || enforce === "false" || enforce === "off") process.exit(0);
 
-  // Evaluate each shell segment independently; only an actual search-tool invocation counts.
-  const segments = cmd.split(/\|\||&&|[|;&\n]/g);
-  const blocked = segments.some((seg) => seg.trim() && isCodeSearchSegment(seg));
-  if (!blocked) process.exit(0);
+  // Grep TOOL — warn-only, never block (Grep is the sanctioned fallback).
+  if (toolName === "Grep") {
+    if (isLogGrepTool(ti)) emitWarn(LOG_NUDGE);
+    else if (isCodeGrepTool(ti)) emitWarn(GREP_NUDGE);
+    process.exit(0);
+  }
 
-  process.stderr.write(
-    "[vs-token-safer] Blocked a code-symbol search via Bash.\n" +
-      "Use the vs-search MCP tools (server: 'vs-search') instead — they query the language\n" +
-      "server's index (clangd for C++, Roslyn for C#, tsserver for JS/TS, pyright for Python)\n" +
-      "and are token-capped to file:line:\n" +
-      "  - symbol / class / function / type → search_symbol  (args: q, projectPath, backend, maxResults)\n" +
-      "  - references / usages of a symbol  → find_references (args: path, line, character — 0-based)\n" +
-      "  - definition of a symbol           → goto_definition (args: path, line, character — 0-based)\n" +
-      "  - raw text / string / comment      → search_text     (args: q, projectPath) — token-capped grep\n" +
-      "  - file by name                     → find_files      (args: q, projectPath) — glob or substring\n" +
-      "Or delegate the whole lookup to the context-isolated `code-locator` subagent.\n" +
-      "CLI alternative (no MCP): `vts symbol --q <name> --projectPath <root>` (also: vts text / files / hover).\n" +
-      "Backend auto-detects from the root (compile_commands.json → clangd, .sln/.csproj → roslyn,\n" +
-      "tsconfig/package.json → typescript, pyproject.toml/*.py → pyright);\n" +
-      "override with backend=… or VTS_BACKEND, set the root via projectPath or VTS_PROJECT_PATH.\n" +
-      "For logs/config text, target a non-code file, or set VTS_ENFORCE=0."
-  );
-  process.exit(2); // block
+  // Bash — code-grep is blocked (vts default); a log-targeted search is steered (warn) but allowed.
+  const cmd = ti.command || "";
+  if (!cmd) process.exit(0);
+  const segments = cmd.split(/\|\||&&|[|;&\n]/g).filter((s) => s.trim());
+
+  if (segments.some(isCodeSearchSegment)) {
+    process.stderr.write(BLOCK_MSG + "\n");
+    process.exit(2); // block
+  }
+  if (segments.some(isLogSearchSegment)) {
+    emitWarn(LOG_NUDGE);
+    process.exit(0); // logs were never blocked — just point at the right tool
+  }
+  process.exit(0);
 });

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -29,7 +29,9 @@ const CODE_DIR_RE = /(^|[\s"'/\\])(src|source|sources|engine|plugins)[\\/]/;
 const TEXT_TARGET_RE = /\.(log|txt|md|markdown|json|ya?ml|csv|tsv|xml|html?|ini|cfg|conf|toml|lock)\b/;
 // A log-ish target: a Logs/ (or Saved/Logs/) dir, or a .log/.jsonl/.log.N file. Precise enough to skip
 // "log" inside "catalog" and ordinary source paths.
-const LOG_TARGET_RE = /(^|[\s"'/\\])(saved[/\\])?logs[/\\]|\.(log|jsonl)(\.\d+)?\b/i;
+// `logs([/\\]|$)` so a bare `Saved/Logs` dir (the common Grep `path` form, no trailing slash) still hits,
+// while `(^|sep)` anchoring still rejects "catalog"/"dialogs"/"mylogs".
+const LOG_TARGET_RE = /(^|[\s"'/\\])(saved[/\\])?logs([/\\]|$)|\.(log|jsonl)(\.\d+)?\b/i;
 
 function execOf(segment) {
   const tokens = segment.trim().split(/\s+/);

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -16,7 +16,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "Bash|Grep",
         "hooks": [
           {
             "type": "command",

--- a/server/core.js
+++ b/server/core.js
@@ -39,6 +39,27 @@ const SYMBOL_KIND = {
   25: "operator", 26: "type",
 };
 
+// --- log steer (mirrors rider-mcp-enforcer 0.2.8): a code search aimed at a LOG should go to the
+// gamedev-log analyzer, not the language-server index. The index only covers source — a hover/read/search
+// pointed at a log returns empty or errors, and the model often burns calls before switching tools.
+// A log-ish target: a Logs/ (or Saved/Logs/) dir, or a .log/.jsonl/.log.N file. Precise enough to skip
+// "log" inside "catalog" and ordinary source paths.
+const LOG_PATHISH = /(^|[/\\])(saved[/\\])?logs[/\\]|\.(log|jsonl)(\.\d+)?$/i;
+function looksLogTarget(a) {
+  return [a.path, a.projectPath, a.paths].flat().filter((v) => typeof v === "string").some((v) => LOG_PATHISH.test(v));
+}
+const LOG_STEER =
+  "\n\n↪ This looks like a LOG target. The language-server index only covers source code, not logs — use " +
+  "the gamedev-log tools (/gamedev-log-analyzer:logs, or the gamedev-log CLI: summary / search / locate / " +
+  "fields / diff) for log analysis instead.";
+// Appended to an empty symbol result (mirrors rider's honest empty-result hint): an empty answer can be a
+// stale index, a definitions-only match, or a string that only lives in a log (excluded from the index).
+const EMPTY_HINT =
+  " If you JUST edited the target, the index may lag the save — retry, or use search_text for a literal " +
+  "match. search_symbol matches DEFINITIONS, not every reference. Looking for something in a LOG? Logs " +
+  "aren't indexed — use gamedev-log.";
+const LOG_EMPTY_HINT = " Looking for something in a LOG? Logs aren't indexed for code search — use gamedev-log for log content.";
+
 function applySetup(args) {
   let current = {};
   try { current = JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8")) || {}; } catch { /* new */ }
@@ -229,7 +250,8 @@ export async function runTool(name, a = {}) {
   const finishOut = (rawObj, body) => {
     const rawTok = tok(JSON.stringify(rawObj)), outTok = tok(body);
     try { recordSavings(rawTok, outTok); } catch { /* best-effort */ }
-    return out(body + savingsLine(rawTok, outTok));
+    // Additive log steer (never blocks): if this call targets a log path, point at gamedev-log.
+    return out(body + (looksLogTarget(a) ? LOG_STEER : "") + savingsLine(rawTok, outTok));
   };
   try {
     if (name === "vts_setup") {
@@ -256,7 +278,7 @@ export async function runTool(name, a = {}) {
       const root = a.projectPath || PROJECT_PATH || process.cwd();
       const max = Number(a.maxResults) || MAX_RESULTS;
       const files = findFilesUnder(root, String(a.q), max);
-      if (!files.length) return finishOut([], `No files matching "${a.q}" under ${root}.`);
+      if (!files.length) return finishOut([], `No files matching "${a.q}" under ${root}.` + LOG_EMPTY_HINT);
       return finishOut(files, `${files.length} file(s) matching "${a.q}":\n` + files.join("\n"));
     }
     if (name === "search_text") {
@@ -264,7 +286,7 @@ export async function runTool(name, a = {}) {
       const root = a.projectPath || PROJECT_PATH || process.cwd();
       const max = Number(a.maxResults) || MAX_RESULTS;
       const hits = scanTextUnder(root, String(a.q), max);
-      if (!hits.length) return finishOut([], `No text matches for "${a.q}" under ${root}.`);
+      if (!hits.length) return finishOut([], `No text matches for "${a.q}" under ${root}.` + LOG_EMPTY_HINT);
       return finishOut(hits, `${hits.length} match(es) for "${a.q}" (text search; for symbols prefer search_symbol):\n` + hits.join("\n"));
     }
 
@@ -280,7 +302,7 @@ export async function runTool(name, a = {}) {
       const syms = (await c.symbol(String(a.q))) || [];
       try { recordQueryResults(root, syms.map((s) => fromUri(s.location.uri))); } catch { /* best-effort */ }
       const adv = backendAdvisory(backendName);
-      if (!syms.length) return finishOut([], adv + `No symbols matching "${a.q}" (backend: ${backendName}).`);
+      if (!syms.length) return finishOut([], adv + `No symbols matching "${a.q}" (backend: ${backendName}).` + EMPTY_HINT);
       return finishOut(syms, adv + `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root}):\n` + fmtSymbols(syms, max));
     }
     if (name === "find_references") {

--- a/server/core.js
+++ b/server/core.js
@@ -44,7 +44,7 @@ const SYMBOL_KIND = {
 // pointed at a log returns empty or errors, and the model often burns calls before switching tools.
 // A log-ish target: a Logs/ (or Saved/Logs/) dir, or a .log/.jsonl/.log.N file. Precise enough to skip
 // "log" inside "catalog" and ordinary source paths.
-const LOG_PATHISH = /(^|[/\\])(saved[/\\])?logs[/\\]|\.(log|jsonl)(\.\d+)?$/i;
+const LOG_PATHISH = /(^|[/\\])(saved[/\\])?logs([/\\]|$)|\.(log|jsonl)(\.\d+)?$/i;
 function looksLogTarget(a) {
   return [a.path, a.projectPath, a.paths].flat().filter((v) => typeof v === "string").some((v) => LOG_PATHISH.test(v));
 }

--- a/skills/vs-search/SKILL.md
+++ b/skills/vs-search/SKILL.md
@@ -18,6 +18,9 @@ be open; the engine is spawned headlessly. Karpathy-style rules: do the listed t
 - Raw text / string / comment / config key (the symbol index can't answer) → `search_text`  (args: `q`, `projectPath`). Token-capped; the sanctioned grep replacement.
 - File by name (substring or glob) → `find_files`  (args: `q`, `projectPath`). Replaces `find -name`.
 - Show/adjust config → `vts_config` / `vts_setup`. Token savings → `vts_savings`. Pre-warm → `vts_warmup`.
+- **Log file** (`.log`/`.jsonl`, or a `Logs/` dir) → NOT a vs-search tool. The language-server index covers
+  source, not logs — use **gamedev-log** (`/gamedev-log-analyzer:logs`). vts-search results aimed at a log
+  carry a one-line pointer there.
 
 Delegate a whole "where is X / what calls Y / find file W" lookup to the **`code-locator`** subagent —
 it runs the searches in its own context and returns just the `file:line` table, so the matches never


### PR DESCRIPTION
## What lands

Two commits past v0.8.0 — ports rider-mcp-enforcer 0.2.8's log-analysis steer and its missing enforcement vectors to vts.

- **Log steer** (`6a355b3`): a code search aimed at a LOG (`Logs/` dir or `.log`/`.jsonl` file) gets a one-line pointer to gamedev-log instead of an empty code-index result. `core.js looksLogTarget` appends `LOG_STEER` to any tool result on a log target; empty results carry stale-index / definitions-only / log hints. Hook matcher `Bash|Grep`: the built-in Grep tool warns-only (never blocks), a Bash/Grep search on a log warns+allows, Bash code-grep still blocks by default.
- **Reviewer fix** (`8048960`): `LOG_*` regexes now match a bare `Saved/Logs` dir (no trailing slash — the common form) so the headline steer fires on the most common input; added the eval guard that previously passed vacuously.

## Review points

- **Token-first held**: the steer is additive one-line text; output stays `file:line`, capped, no bodies.
- **No over-block**: Grep tool is warn-ONLY (never exit 2); Bash code-grep still blocks (vts design); `VTS_ENFORCE=0` silences everything. Regex rejects `catalog`/`dialogs`/`.tsv`/`.json`.
- **code-reviewer pass** (no CRITICAL/HIGH); two MEDIUM regex/eval gaps fixed before this PR.
- eval **17/17** (new: core log-steer/empty-hint; hook block/warn-log/warn-grep via child process). Live-verified by CLI + dogfooding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)