### PR TITLE
docs: a session restart is required after a plugin update (not just /reload-plugins)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -353,9 +353,19 @@ Claude Code는 마켓플레이스 repo를 캐시하므로 새 커밋이 **자동
 /plugin update vs-token-safer
 #   안 되면: /plugin uninstall vs-token-safer  그 다음  /plugin install vs-token-safer@vs-token-safer
 
-# 3) 새 훅/명령어/MCP 서버 적용 (의존성은 세션 시작 시 자동 재설치)
-/reload-plugins        # 또는 Claude Code 재시작
+# 3) 훅/명령어/스킬 리로드
+/reload-plugins
+
+# 4) Claude Code 세션 재시작 — 이 단계는 선택이 아니라 필수입니다.
+#    /reload-plugins는 훅·명령어·스킬만 리로드합니다. vs-search MCP 서버는 세션 시작 때 한 번 뜨는
+#    자식 프로세스라, 재시작 전까지 옛 코드를 계속 돌립니다. 그래서 새 버전의 도구(search_symbol,
+#    find_references 등)는 세션을 껐다 켜기 전엔 실제로 바뀌지 않습니다.
 ```
+
+> ⚠️ **새 플러그인 버전은 세션을 재시작해야 완전히 적용됩니다.** `/reload-plugins`만으로는 부족합니다 —
+> 돌고 있는 `vs-search` MCP 서버 프로세스는 리로드로 재시작되지 않아, Claude Code를 껐다 켜기 전까지
+> 이전 버전의 도구 코드를 그대로 제공합니다. 훅·명령어·스킬은 리로드로 갱신되지만, MCP 서버(따라서 모든
+> `search_*` / `find_*` 도구)는 재시작에서만 갱신됩니다.
 
 `/plugin`으로 설치 상태와 버전을 확인할 수 있습니다. `/vs-token-safer:setup` 같은 명령이 안 보이면
 설치본이 구버전이니 위 절차로 업데이트하세요.

--- a/README.md
+++ b/README.md
@@ -319,7 +319,9 @@ when you need references and definitions resolved across the engine include grap
 Verify the `vs-search` MCP server and its tools appear, and that a `grep src/**/*.cpp` is blocked with a
 nudge toward the indexed tools (or runs freely under `VTS_ENFORCE=0`). The MCP server's one dependency
 (`@modelcontextprotocol/sdk`) installs automatically on the first session, into the plugin's data
-directory.
+directory. **Already had Claude Code open when you installed? Restart the session** — the MCP server only
+starts (and later, only picks up a new version) on a fresh session, not on `/reload-plugins` alone (see
+[Updating](#updating-to-a-new-version)).
 
 ### As a standalone CLI (no IDE, no Claude Code)
 
@@ -366,9 +368,19 @@ version of this plugin:
 /plugin update vs-token-safer
 #   fallback: /plugin uninstall vs-token-safer  then  /plugin install vs-token-safer@vs-token-safer
 
-# 3) Reload so the new hook/command/MCP server take effect (deps auto-reinstall on session start)
-/reload-plugins        # or restart Claude Code
+# 3) Reload the hooks/commands/skills
+/reload-plugins
+
+# 4) RESTART the Claude Code session — this step is REQUIRED, not optional.
+#    `/reload-plugins` reloads hooks/commands/skills, but the vs-search MCP server is a child process
+#    spawned ONCE at session start. It keeps running the OLD code until you restart, so the new
+#    plugin version's tools (search_symbol, find_references, …) won't actually change until you do.
 ```
+
+> ⚠️ **A new plugin version only takes full effect after a session restart.** `/reload-plugins` is not
+> enough on its own — the running `vs-search` MCP server process is not restarted by it, so it serves the
+> previous version's tool code until you quit and reopen Claude Code. Hooks/commands/skills update on
+> reload; the MCP server (and therefore every `search_*` / `find_*` tool) updates only on restart.
 
 Check what's installed with `/plugin` (it lists each plugin's version). If a command like
 `/vs-token-safer:setup` is missing, your installed copy predates it, so update as above.


### PR DESCRIPTION
Docs-only, no version bump.

`/reload-plugins` reloads hooks/commands/skills, but the `vs-search` MCP server is a child process spawned once at session start — it keeps serving the previous version's tool code (`search_*` / `find_*`) until Claude Code is restarted. Several of this session's releases (e.g. the clangd latency fix, find_references-by-name) only take effect on the user's side after a restart.

- Updating section: split into reload (step 3) + **required** restart (step 4), with a ⚠️ explaining why reload alone isn't enough. EN + KO.
- Install: a restart note for users who already had Claude Code open.