### PR TITLE
refactor: drop unused compactGrepLines (dead code)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,9 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   with discover) harvests bypassed-search result files into query-history — the self-improvement loop runs
   unattended every server start.
 - `agents/code-locator.md` — context-isolated locator subagent (delegates a lookup, returns only file:line).
-- `server/compact.js` — PURE output-compaction fns (`compactGit`/`compactP4`/`compactGrepLines`, string→string,
-  no spawn) for the `vts_git`/`vts_p4` wrappers. Eval exercises them on canned input (deterministic).
+- `server/compact.js` — PURE output-compaction fns (`compactGit`/`compactP4`, string→string, no spawn) for the
+  `vts_git`/`vts_p4` wrappers. Eval exercises them on canned input (deterministic). (No grep compaction here —
+  grep reroutes to search_text, which scans + token-caps itself; there is no raw grep output to compact.)
 - `server/cli.js` — `vts <cmd>`. `server/index.js` — MCP server (async handler → `await runTool`).
 - `server/sdk.js` — createRequire MCP-SDK resolution. `server/ensure-deps.mjs` — SessionStart installer.
 - `server/warmset.js` — prewarm ORDERING: `orderForWarm` (query-history > working-now [`git status` /

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -685,7 +685,7 @@ const returnWhenFoundOk =
 // 38) output compaction — pure string→string compaction of git/p4/grep output: grouping by type/dir,
 // identical-line dedup (×N), per-file diffstat, and capping. Deterministic (no toolchain), so asserted
 // directly on canned input. The token win comes from collapsing the repetitive boilerplate a raw dump has.
-const { compactGit, compactP4, compactGrepLines } = await import("../server/compact.js");
+const { compactGit, compactP4 } = await import("../server/compact.js");
 const gitStatusRaw = [" M server/core.js", " M server/cli.js", "?? server/compact.js", "?? eval/new.mjs", "A  server/index.js"].join("\n");
 const gitStatusOut = compactGit("status", gitStatusRaw, 60);
 const gitLogRaw = Array.from({ length: 50 }, (_, i) => `abc${i} commit subject ${i}`).join("\n");
@@ -693,8 +693,6 @@ const gitLogOut = compactGit("log", gitLogRaw, 10);
 const gitDiffRaw = "diff --git a/x.js b/x.js\n--- a/x.js\n+++ b/x.js\n@@ -1 +1,2 @@\n-old\n+new\n+added\ndiff --git a/y.js b/y.js\n--- a/y.js\n+++ b/y.js\n@@ -1 +1 @@\n-a\n+b\n";
 const gitDiffOut = compactGit("diff", gitDiffRaw, 60);
 const gitDiffStatOut = compactGit("diff", " x.js | 3 +++\n y.js | 2 +-\n 2 files changed, 4 insertions(+), 1 deletion(-)\n", 60); // --stat: no unified headers → passthrough, not mangled
-const grepRaw = "src/Foo.cpp:1:SpawnActor\n".repeat(200) + "src/Bar.cpp:9:other\n";
-const grepOut = compactGrepLines(grepRaw, 60);
 const p4OpenedRaw = Array.from({ length: 30 }, (_, i) => `//depot/Game/Src/F${i}.cpp#${i} - edit default change (text)`).join("\n");
 const p4Out = compactP4("opened", p4OpenedRaw, 60);
 const compactPureOk =
@@ -702,7 +700,6 @@ const compactPureOk =
   /… \+40 more commit/.test(gitLogOut) &&                                  // 50 commits → 10 shown + 40 more
   /x\.js \| \+2 -1/.test(gitDiffOut) && /y\.js \| \+1 -1/.test(gitDiffOut) && // per-file diffstat, bodies dropped
   /2 files changed/.test(gitDiffStatOut) && /x\.js \| 3/.test(gitDiffStatOut) && // --stat passthrough, not "(no file changes)"
-  /\(×200\)/.test(grepOut) && tok(grepOut) < tok(grepRaw) / 5 &&            // 200 identical hits → one ×200 row
   /edit: 30/.test(p4Out) && /depot\/Game\/Src/.test(p4Out);                 // p4 opened grouped by action + dir
 
 // 39) vts_git live — run the wrapper against a REAL temp git repo (git is in CI; guard 34 already spawns it)
@@ -797,7 +794,7 @@ const rows = [
   ["gen-compile-db apply: out-of-tree DB+index + inTree guard + perf flags", applyOk, "true", applyOk],
   ["perf: persisted clangd index detected (skip TU re-parse)", persistedIndexOk, "true", persistedIndexOk],
   ["perf: return-when-found poll on a loading index", returnWhenFoundOk, "true", returnWhenFoundOk],
-  ["compact: git/p4/grep output grouped+deduped+capped (pure)", compactPureOk, "true", compactPureOk],
+  ["compact: git/p4 output grouped+deduped+capped (pure)", compactPureOk, "true", compactPureOk],
   ["vts_git live wrapper + search_text docs sweep", vcsToolsOk, "true", vcsToolsOk],
   ["hook: git/p4 reroute to vts wrapper (git grep stays code)", vcsHookOk, "true", vcsHookOk],
 ];

--- a/server/compact.js
+++ b/server/compact.js
@@ -1,10 +1,11 @@
 /*
- * vs-token-safer — output compaction for commands the language-server index can't help with: a raw
- * `git`/`p4`/grep dump is verbose, repetitive, and mostly boilerplate. These PURE string→string functions
- * group, deduplicate, and cap that output before it reaches the model — the same token-first principle as
- * the symbol/reference formatters, applied to VCS + text-search output (the slice rtk covers, kept under
- * our roof, our cap, our savings ledger). No spawning here — the wrapper in core.js runs the command and
- * feeds the raw stdout in; eval exercises these directly with canned strings (deterministic, no toolchain).
+ * vs-token-safer — output compaction for VCS commands the language-server index can't help with: a raw
+ * `git`/`p4` dump is verbose, repetitive, and mostly boilerplate. These PURE string→string functions group,
+ * deduplicate, and cap that output before it reaches the model — the same token-first principle as the
+ * symbol/reference formatters, applied to VCS output (the slice rtk covers, kept under our roof, our cap,
+ * our savings ledger). No spawning here — the wrapper in core.js runs the command and feeds the raw stdout
+ * in; eval exercises these directly with canned strings (deterministic, no toolchain). (Text search is
+ * NOT here: grep reroutes to search_text, which scans + token-caps itself — no raw grep output to compact.)
  */
 
 const splitLines = (raw) => String(raw == null ? "" : raw).split(/\r?\n/);
@@ -27,42 +28,6 @@ const topDir = (p) => {
   const i = s.indexOf("/");
   return i === -1 ? "(root)" : s.slice(0, i);
 };
-
-// ---- grep / text-search output ----
-// Raw grep output (`path:line:content`, possibly with many identical hits) → grouped by file, identical
-// lines collapsed, capped. The biggest win is a pattern that matches the same boilerplate hundreds of times.
-export function compactGrepLines(raw, max = 60) {
-  const lines = nonEmpty(raw);
-  if (!lines.length) return "(no matches)";
-  // Group by the leading `path:` token. Within a file, collapse identical lines to one `(×N)` row; cap the
-  // number of UNIQUE rows shown (the `… +K more unique` summary only fires on a genuine cap, never for the
-  // dedup itself — a `(×200)` row hides nothing).
-  const byFile = new Map();
-  for (const l of lines) {
-    const m = l.match(/^([^:]+):/);
-    const file = m ? m[1] : "(stdin)";
-    if (!byFile.has(file)) byFile.set(file, []);
-    byFile.get(file).push(l);
-  }
-  const parts = [];
-  let shownUnique = 0, totalUnique = 0, capped = false;
-  for (const [file, fl] of byFile) {
-    const counts = new Map();
-    for (const l of fl) counts.set(l, (counts.get(l) || 0) + 1);
-    totalUnique += counts.size;
-    if (capped) continue;
-    const rows = [];
-    for (const [l, n] of counts) {
-      if (shownUnique >= max) { capped = true; break; }
-      rows.push("  " + (n > 1 ? `${l}  (×${n})` : l));
-      shownUnique++;
-    }
-    parts.push(`${file} (${fl.length})\n` + rows.join("\n"));
-  }
-  let body = parts.join("\n");
-  if (capped || shownUnique < totalUnique) body += `\n… +${totalUnique - shownUnique} more unique match-line(s) across ${byFile.size} file(s) — narrow the pattern or raise maxResults.`;
-  return body;
-}
 
 // ---- git ----
 // `git status --porcelain`/`-s`: `XY path`. Group by status code (counts) and untracked files by top dir.


### PR DESCRIPTION
Follow-up to #33. `compactGrepLines` had **no production caller** — grep reroutes to `search_text`, which scans + token-caps itself, so there is never a raw grep dump to compact. It was exported + eval-tested but unused (tripped `no-unused-vars` when imported in core.js, which I'd patched by dropping the import — leaving the function orphaned in compact.js).

Removes the function, its eval assertion, and the doc references. Keeps `compactGit`/`compactP4` (used by `vts_git`/`vts_p4`).

**Verify:** `node eval/run.mjs` → EVAL PASSED (41/41); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)