### PR TITLE
fix: savings-ledger accuracy (string-raw inflation + negative entries)

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -748,6 +748,20 @@ const vcsHookOk =
   /cli\.js" text --q "DOC_NEEDLE" --path "README\.md"/.test(hDocsGrep.updatedInput?.command || "") && // docs grep → targeted text
   hVcsOff.status === 0 && !/vts_git/.test(JSON.parse(hVcsOff.out || "{}").hookSpecificOutput?.updatedInput?.command || ""); // disabled → no VCS reroute
 
+// 41) savings-ledger accuracy (dogfood-found): (a) rawTokensOf measures a STRING raw verbatim (vts_git/
+// vts_p4 stdout — NOT via JSON.stringify, which escapes \n→\\n and over-reports savings) while an array/
+// object stays JSON (the forwarded-index baseline); (b) recordSavings floors to break-even so no tool ever
+// records NEGATIVE savings on a tiny result. The isolated ledger (SV) has accumulated every run above.
+const { rawTokensOf } = await import("../server/core.js");
+const strRaw = "line1\nline2\nline3\nline4\nline5";
+const savingsAccurateOk =
+  rawTokensOf(strRaw) === tok(strRaw) &&                       // string measured as-is
+  rawTokensOf(strRaw) < tok(JSON.stringify(strRaw)) &&         // JSON.stringify would have inflated it
+  rawTokensOf([{ name: "X", l: 1 }]) === tok(JSON.stringify([{ name: "X", l: 1 }])); // array → JSON baseline
+const svLedger = (() => { try { return JSON.parse(fs.readFileSync(SV, "utf8")); } catch { return {}; } })();
+const noNegativeTool = Object.values(svLedger.tools || {}).every((t) => t.rawTok >= t.outTok);
+const savingsLedgerOk = savingsAccurateOk && noNegativeTool && (svLedger.rawTok || 0) >= (svLedger.outTok || 0);
+
 await disposeClients();
 try { fs.rmSync(QH, { force: true }); } catch { /* ignore */ }
 try { fs.rmSync(IG, { force: true }); } catch { /* ignore */ }
@@ -797,6 +811,7 @@ const rows = [
   ["compact: git/p4 output grouped+deduped+capped (pure)", compactPureOk, "true", compactPureOk],
   ["vts_git live wrapper + search_text docs sweep", vcsToolsOk, "true", vcsToolsOk],
   ["hook: git/p4 reroute to vts wrapper (git grep stays code)", vcsHookOk, "true", vcsHookOk],
+  ["savings: string-raw not inflated + no negative tool (dogfood)", savingsLedgerOk, "true", savingsLedgerOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/core.js
+++ b/server/core.js
@@ -34,6 +34,11 @@ export const PREWARM_BACKENDS = cfg("VTS_PREWARM_BACKENDS", "prewarmBackends", "
 const CONFIG_KEYS = ["projectPath", "backend", "maxResults", "prewarmBackends", "tee", "excludeCommands", "usdPerMtok"];
 
 const tok = (s) => Math.round(Buffer.byteLength(String(s), "utf8") / 4);
+// The token size of the RAW alternative a tool replaces. A STRING raw (vts_git/vts_p4 stdout) is exactly
+// what the model would otherwise read, so measure it as-is; an ARRAY/OBJECT (an LSP index response that
+// would be forwarded as JSON) is measured as JSON. Measuring a string via JSON.stringify would inflate it
+// (every \n → \\n, plus quotes) and OVER-report savings — a dogfood-found ledger bug for the git/p4 wrappers.
+export const rawTokensOf = (rawObj) => tok(typeof rawObj === "string" ? rawObj : JSON.stringify(rawObj));
 // LSP SymbolKind → short label (kept terse for the token cap). Covers the full enum so JS/TS/Python
 // symbols (constants, properties, fields, enum members…) render with a name instead of a raw `kN`.
 const SYMBOL_KIND = {
@@ -92,6 +97,10 @@ const dayKey = (d = new Date()) => d.toISOString().slice(0, 10); // YYYY-MM-DD (
 // the model never has to ingest) — override with VTS_USD_PER_MTOK; purely informational.
 const USD_PER_MTOK = parseFloat(cfg("VTS_USD_PER_MTOK", "usdPerMtok", "3")) || 3;
 function recordSavings(rawTok, outTok, tool) {
+  // vts output is never genuinely larger than the raw alternative for the SAME query; a computed negative is
+  // an artifact of the JSON-of-already-capped-data baseline on tiny results. Floor to break-even so the
+  // ledger never shows a tool "costing" tokens (dogfood-found: search_text/find_files went slightly negative).
+  if (outTok > rawTok) outTok = rawTok;
   const s = readSavings();
   s.runs = (s.runs || 0) + 1;
   s.rawTok = (s.rawTok || 0) + rawTok;
@@ -755,7 +764,7 @@ export async function runTool(name, a = {}) {
   const out = (text) => ({ text, isError: false });
   const err = (text) => ({ text, isError: true });
   const finishOut = (rawObj, body) => {
-    const rawTok = tok(JSON.stringify(rawObj)), outTok = tok(body);
+    const rawTok = rawTokensOf(rawObj), outTok = tok(body);
     try { recordSavings(rawTok, outTok, name); } catch { /* best-effort */ }
     // One-time setup nudge if never configured; additive log steer if this call targets a log. Neither blocks.
     let pre = "";


### PR DESCRIPTION
Dogfood-found while reviewing `vts savings` this session — two **measurement-accuracy** bugs (actual compaction/output unchanged).

1. **vts_git/vts_p4 over-reported savings.** `finishOut` measured raw as `tok(JSON.stringify(rawObj))`, but their raw is a **string** (git/p4 stdout) — `JSON.stringify` escapes every `\n`→`\n` and adds quotes, inflating the baseline. New `rawTokensOf()` measures a string raw verbatim; arrays/objects stay JSON (the forwarded-index baseline for LSP tools). **Live:** vts_git raw now equals the real stdout size (35,160 tok = (77382+63252)/4), 33x — was inflated before.
2. **Negative savings on tiny results.** `search_text`/`find_files` recorded negative per-tool savings (body header > the small JSON-of-capped-data baseline). `recordSavings` now **floors to break-even** — vts never genuinely returns more than the raw alternative for the same query.

## Review points
- Measurement-only: no change to tool output or compaction. The ledger (a headline feature + the input to self-learn) just gets honest.
- `rawTokensOf` exported + unit-guarded; ledger no-negative invariant guarded.

## Verify
`node eval/run.mjs` → EVAL PASSED (**42/42**, +1 guard); lint clean. Live-verified on this repo (vts_git 33x accurate, tiny search_text floored to 0 not negative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)