### PR TITLE
fix: harden vts_git/vts_p4 + search_text (safety + correctness)

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -762,6 +762,34 @@ const svLedger = (() => { try { return JSON.parse(fs.readFileSync(SV, "utf8")); 
 const noNegativeTool = Object.values(svLedger.tools || {}).every((t) => t.rawTok >= t.outTok);
 const savingsLedgerOk = savingsAccurateOk && noNegativeTool && (svLedger.rawTok || 0) >= (svLedger.outTok || 0);
 
+// 42) hardening (critic + live-QA driven): vts_git/vts_p4 read-only allowlist (a mutating subcommand is
+// refused BEFORE it runs), search_text path= confinement (no arbitrary-file read outside the root), and
+// compactor correctness — rename → destination only, shared status listing budget, binary-diff marker,
+// and the 200-char line-truncation marker.
+const gReset = await runTool("vts_git", { argv: ["reset", "--hard"], projectPath: os.tmpdir() }); // never runs git
+const allowlistOk = gReset.isError && /READ-ONLY/.test(gReset.text) && /refused/i.test(gReset.text);
+const gShow = await runTool("vts_git", { argv: ["status"], projectPath: process.cwd() }); // read-only → allowed (runs)
+const allowlistAllowsRO = !gShow.isError && /git status/.test(gShow.text);
+const outsideFile = path.join(os.tmpdir(), `vts-eval-${process.pid}-outside.txt`);
+fs.writeFileSync(outsideFile, "TRAVERSAL_SECRET\n");
+const ptRoot = path.join(os.tmpdir(), `vts-eval-${process.pid}-ptroot`); fs.mkdirSync(ptRoot, { recursive: true });
+const trav = await runTool("search_text", { q: "TRAVERSAL_SECRET", path: outsideFile, projectPath: ptRoot });
+const traversalOk = trav.isError && /inside the project root/.test(trav.text); // refused, file NOT read
+try { fs.rmSync(outsideFile, { force: true }); fs.rmSync(ptRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+const renameOut = compactGit("status", "R  old/a.cpp -> new/b.cpp\n M src/x.cpp\n", 60);
+const renameParseOk = /renamed: 1/.test(renameOut) && /new\/b\.cpp/.test(renameOut) && !/old\/a\.cpp ->/.test(renameOut);
+const manyStatus = Array.from({ length: 10 }, (_, i) => ` M m/f${i}.cpp`).concat(Array.from({ length: 10 }, (_, i) => `?? u/g${i}.cpp`)).join("\n");
+const budgetOut = compactGit("status", manyStatus, 3);
+const budgetOk = (budgetOut.match(/^ {4}[^…\s]/gm) || []).length <= 3; // shared budget: ≤max path lines TOTAL
+const binOut = compactGit("diff", "diff --git a/img.png b/img.png\nindex 1..2 100644\nBinary files a/img.png and b/img.png differ\n", 60);
+const binaryOk = /img\.png \| \(binary\)/.test(binOut);
+const longDir = path.join(os.tmpdir(), `vts-eval-${process.pid}-longline`); fs.mkdirSync(longDir, { recursive: true });
+fs.writeFileSync(path.join(longDir, "m.js"), "x".repeat(400) + "NEEDLE\n");
+const longRes = await runTool("search_text", { q: "NEEDLE", projectPath: longDir });
+const truncMarkOk = !longRes.isError && /…/.test(longRes.text);
+try { fs.rmSync(longDir, { recursive: true, force: true }); } catch { /* ignore */ }
+const hardeningOk = allowlistOk && allowlistAllowsRO && traversalOk && renameParseOk && budgetOk && binaryOk && truncMarkOk;
+
 await disposeClients();
 try { fs.rmSync(QH, { force: true }); } catch { /* ignore */ }
 try { fs.rmSync(IG, { force: true }); } catch { /* ignore */ }
@@ -812,6 +840,7 @@ const rows = [
   ["vts_git live wrapper + search_text docs sweep", vcsToolsOk, "true", vcsToolsOk],
   ["hook: git/p4 reroute to vts wrapper (git grep stays code)", vcsHookOk, "true", vcsHookOk],
   ["savings: string-raw not inflated + no negative tool (dogfood)", savingsLedgerOk, "true", savingsLedgerOk],
+  ["hardening: ro-allowlist + path-confine + rename/binary/budget/trunc", hardeningOk, "true", hardeningOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/cli.js
+++ b/server/cli.js
@@ -32,10 +32,11 @@ Commands:
   text           Raw text/regex search (token-capped). [--q <pattern> --projectPath <dir> --path <file> --glob <pat> --docs]
                  --path <file> / --glob <pat> target a file/glob and auto-include its extension (e.g. a .md);
                  --docs (no path/glob) widens the project sweep to README/docs/config text.
-  git            Run a git command and COMPACT its output (status/log/diff grouped+deduped+capped).
-                 Pass-through: 'vts git status -s', 'vts git log --oneline', 'vts git diff'.
-  p4             Run a Perforce command and COMPACT its output (opened/status/changes/reconcile).
-                 Pass-through: 'vts p4 opened', 'vts p4 changes -m 50'.
+  git            Run a READ-ONLY git command and COMPACT its output (status/log/diff grouped+deduped+capped).
+                 Pass-through: 'vts git status -s', 'vts git log --oneline', 'vts git diff [--projectPath DIR]'.
+                 Mutating subcommands (commit/reset/checkout/push…) are refused — run git directly.
+  p4             Run a READ-ONLY Perforce command and COMPACT its output (opened/status/changes/reconcile -n).
+                 Pass-through: 'vts p4 opened', 'vts p4 changes -m 50'. reconcile is forced to preview (-n).
   warmup         Pre-build the index (IDE-style) so later searches are fast. [--projectPath --backend]
   setup          Persist config. [--projectPath --backend --maxResults]
   config         Show effective settings.
@@ -81,9 +82,21 @@ if (!rawCmd || rawCmd === "-h" || rawCmd === "--help" || rawCmd === "help") { co
 const name = COMMANDS[rawCmd] || (rawCmd.startsWith("vts_") || rawCmd.includes("_") ? rawCmd : null);
 if (!name) { console.error(`Unknown command: ${rawCmd}\n`); console.log(HELP); process.exit(2); }
 
-// git/p4 are pass-throughs: the entire tail is the VCS subcommand + flags (NOT vts --flags), so forward it
-// verbatim as argv. projectPath/maxResults come from env/config for these (the command runs in cwd).
-const args = (name === "vts_git" || name === "vts_p4") ? { argv: rest } : parseArgs(rest);
+// git/p4 are pass-throughs: the tail is the VCS subcommand + flags (NOT vts --flags), forwarded verbatim as
+// argv. The TWO vts flags `--projectPath`/`--maxResults` are lifted out first (so `vts git status
+// --projectPath X` targets X instead of handing git an unknown option); everything else goes to the command.
+let args;
+if (name === "vts_git" || name === "vts_p4") {
+  const argv = []; const extra = {};
+  for (let i = 0; i < rest.length; i++) {
+    if (rest[i] === "--projectPath") { extra.projectPath = rest[++i]; continue; }
+    if (rest[i] === "--maxResults") { extra.maxResults = rest[++i]; continue; }
+    argv.push(rest[i]);
+  }
+  args = { argv, ...extra };
+} else {
+  args = parseArgs(rest);
+}
 try {
   const { text, isError } = await runTool(name, args);
   (isError ? process.stderr : process.stdout).write(text + "\n");

--- a/server/compact.js
+++ b/server/compact.js
@@ -40,19 +40,24 @@ function compactGitStatus(raw, max) {
     // porcelain: 2-char XY, space, path. Tolerate `-s` (same shape) and a leading marker.
     const xy = l.slice(0, 2);
     const key = (xy.trim()[0] || xy[0] || "?");
-    const p = l.slice(2).trim().replace(/^"|"$/g, "");
+    let p = l.slice(2).trim().replace(/^"|"$/g, "");
+    // Renames/copies render as `old -> new`; group + show the DESTINATION (the path that now exists).
+    if ((key === "R" || key === "C") && p.includes(" -> ")) p = p.split(" -> ").pop().replace(/^"|"$/g, "");
     if (!byCode.has(key)) byCode.set(key, []);
     byCode.get(key).push(p);
   }
   const out = [`${lines.length} change(s):`];
+  let shown = 0; // ONE shared listing budget across all groups (not per-group — that could dump ~max each)
   for (const [code, paths] of byCode) {
     const label = STATUS[code] || code;
     const dirs = new Map();
     for (const p of paths) dirs.set(topDir(p), (dirs.get(topDir(p)) || 0) + 1);
     const dirSummary = [...dirs].sort((a, b) => b[1] - a[1]).slice(0, 6).map(([d, n]) => `${d}(${n})`).join(", ");
     out.push(`  ${label}: ${paths.length}  [${dirSummary}]`);
-    for (const p of paths.slice(0, Math.max(0, Math.min(paths.length, Math.floor(max / Math.max(byCode.size, 1)))))) out.push(`    ${p}`);
-    if (paths.length > Math.floor(max / Math.max(byCode.size, 1))) out.push(`    … +${paths.length - Math.floor(max / Math.max(byCode.size, 1))} more ${label}`);
+    const take = Math.min(paths.length, Math.max(0, max - shown));
+    for (const p of paths.slice(0, take)) out.push(`    ${p}`);
+    shown += take;
+    if (paths.length > take) out.push(`    … +${paths.length - take} more ${label}`);
   }
   return out.join("\n");
 }
@@ -86,8 +91,9 @@ function compactGitDiff(raw, max) {
   let cur = null;
   for (const l of lines) {
     const gm = l.match(/^diff --git a\/(.+?) b\/(.+)$/);
-    if (gm) { cur = { file: gm[2], add: 0, del: 0 }; files.push(cur); continue; }
+    if (gm) { cur = { file: gm[2].replace(/^"|"$/g, ""), add: 0, del: 0, binary: false }; files.push(cur); continue; }
     if (!cur) continue;
+    if (/^Binary files /.test(l)) { cur.binary = true; continue; } // a changed binary, no +/- body to count
     if (l.startsWith("+++") || l.startsWith("---")) continue; // file headers, not content
     if (l.startsWith("+")) cur.add++;
     else if (l.startsWith("-")) cur.del++;
@@ -99,7 +105,7 @@ function compactGitDiff(raw, max) {
     return lines.join("\n") + (total > lines.length ? `\n… +${total - lines.length} more line(s).` : "");
   }
   const shown = files.slice(0, max);
-  const body = shown.map((f) => `  ${f.file} | +${f.add} -${f.del}`).join("\n");
+  const body = shown.map((f) => `  ${f.file} | ${f.binary ? "(binary)" : `+${f.add} -${f.del}`}`).join("\n");
   const totAdd = files.reduce((s, f) => s + f.add, 0), totDel = files.reduce((s, f) => s + f.del, 0);
   return `${files.length} file(s) changed, +${totAdd} -${totDel}:\n${body}` + (files.length > shown.length ? `\n… +${files.length - shown.length} more file(s).` : "");
 }

--- a/server/core.js
+++ b/server/core.js
@@ -660,6 +660,9 @@ function findFilesUnder(root, q, max) {
 }
 // Bounded, token-capped raw-text search (no LSP) — the sanctioned alternative to grep for strings/comments
 // /config keys the symbol index can't answer. Returns file:line: trimmed-line, capped in count and time.
+// Trim a match line for output and mark truncation (…) so a hit past col 200 in a long/minified line
+// isn't silently shown without its match — and the reader knows the line was cut.
+const trimMatchLine = (s) => { const t = String(s).trim(); return t.length > 200 ? t.slice(0, 200) + "…" : t; };
 // Doc/text extensions — the non-code text a grep over README/docs/config hits. Off by default (search_text
 // stays code-only per its contract); `docs=true` widens the sweep so a docs-grep can be compacted too.
 const DOC_EXTS = /\.(c|cc|cxx|cpp|h|hpp|hh|inl|ipp|tpp|cs|ts|tsx|mts|cts|js|jsx|mjs|cjs|py|pyi|md|markdown|txt|json|ya?ml|toml|ini|cfg|conf|xml|html?|csv|rst|tex)$/i;
@@ -684,7 +687,7 @@ function scanTextUnder(root, q, max, accept) {
       let txt; try { txt = fs.readFileSync(p, "utf8"); } catch { continue; }
       if (!re.test(txt)) continue;
       const lines = txt.split(/\r?\n/);
-      for (let i = 0; i < lines.length && out.length <= max; i++) if (re.test(lines[i])) out.push(`${p.replace(/\\/g, "/")}:${i + 1}: ${lines[i].trim().slice(0, 200)}`);
+      for (let i = 0; i < lines.length && out.length <= max; i++) if (re.test(lines[i])) out.push(`${p.replace(/\\/g, "/")}:${i + 1}: ${trimMatchLine(lines[i])}`);
       if (out.length > max) break;
     }
     if (timedOut) break;
@@ -705,7 +708,7 @@ function scanTextFile(absPath, q, max) {
   const out = [];
   let txt; try { txt = fs.readFileSync(absPath, "utf8"); } catch { return out; }
   const lines = txt.split(/\r?\n/);
-  for (let i = 0; i < lines.length && out.length <= max; i++) if (re.test(lines[i])) out.push(`${absPath.replace(/\\/g, "/")}:${i + 1}: ${lines[i].trim().slice(0, 200)}`);
+  for (let i = 0; i < lines.length && out.length <= max; i++) if (re.test(lines[i])) out.push(`${absPath.replace(/\\/g, "/")}:${i + 1}: ${trimMatchLine(lines[i])}`);
   if (out.length > max) { out.length = max; out.truncated = "cap"; }
   return out;
 }
@@ -739,7 +742,9 @@ function runExternal(bin, argv, root) {
     const out = execFileSync(bin, argv, {
       cwd: root, encoding: "utf8",
       timeout: envInt("VTS_EXTERNAL_TIMEOUT_MS", 20000),
-      maxBuffer: 64 * 1024 * 1024,
+      // A huge diff/log is exactly what compaction is for — don't let a big-but-valid output trip ENOBUFS
+      // and read as a failure. 256MB headroom (env-tunable); the compactor shrinks it after capture.
+      maxBuffer: envInt("VTS_EXTERNAL_MAXBUFFER", 256 * 1024 * 1024),
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
     });
@@ -758,6 +763,13 @@ function toArgv(a) {
   if (typeof a.sub === "string" && a.sub.trim()) return a.sub.trim().split(/\s+/);
   return [];
 }
+
+// vts_git/vts_p4 are COMPACTION wrappers for READ-ONLY commands — they must NOT become an arbitrary-VCS-
+// execution surface. Default-DENY: only these read-only subcommands run; anything else (commit/reset/
+// checkout/clean/push/merge/rebase, p4 submit/revert/edit/add/delete/sync-write) is refused. `p4 reconcile`
+// is read-only ONLY with -n, so it's forced to preview below.
+const GIT_READONLY = new Set(["status", "log", "diff", "show", "blame", "shortlog", "ls-files", "ls-tree", "describe", "rev-parse", "rev-list", "cat-file", "name-rev", "whatchanged", "reflog", "grep", "diff-tree", "cherry", "count-objects"]);
+const P4_READONLY = new Set(["opened", "status", "changes", "describe", "filelog", "fstat", "files", "print", "dirs", "diff", "diff2", "where", "info", "annotate", "sizes", "cstat", "reconcile", "have"]);
 
 // ---- single dispatcher (async) ----
 export async function runTool(name, a = {}) {
@@ -886,7 +898,11 @@ export async function runTool(name, a = {}) {
       const docs = a.docs === true || a.docs === "true";
       let runScan, scopeLabel;
       if (a.path) {
-        const abs = path.isAbsolute(String(a.path)) ? String(a.path) : path.join(root, String(a.path));
+        const abs = path.resolve(path.isAbsolute(String(a.path)) ? String(a.path) : path.join(root, String(a.path)));
+        // Confine the target to the project root — a `path=` outside it (absolute elsewhere, or ../ escape)
+        // would turn this "local file:line" tool into an arbitrary-file read. Reject it.
+        const rel = path.relative(path.resolve(root), abs);
+        if (rel.startsWith("..") || path.isAbsolute(rel)) return err(`search_text path must be inside the project root (${root}). Refusing to read ${a.path}.`);
         runScan = (n) => scanTextFile(abs, String(a.q), n);
         scopeLabel = `in ${String(a.path)}`;
       } else if (a.glob) {
@@ -915,9 +931,17 @@ export async function runTool(name, a = {}) {
       const argv = toArgv(a);
       if (!argv.length) return err(`${bin} needs a subcommand (e.g. argv:["status"] or args:"status -s").`);
       const sub = String(argv[0]).toLowerCase();
+      // SAFETY: default-deny to read-only subcommands so the compaction wrapper can't run a mutating VCS op.
+      const allowed = bin === "git" ? GIT_READONLY : P4_READONLY;
+      if (!allowed.has(sub)) {
+        const mut = bin === "git" ? "commit/reset/checkout/clean/push/merge/rebase" : "submit/revert/edit/add/delete";
+        return err(`vts_${bin} runs READ-ONLY ${bin} subcommands only (it just compacts output) — "${sub}" is refused. Run mutating commands (${mut}) directly with ${bin}. Allowed: ${[...allowed].slice(0, 10).join(", ")}…`);
+      }
       // `git status` long-format is prose; compactGitStatus parses the porcelain `XY path` shape. Force it
       // (idempotent — leave an explicit -s/--short/--porcelain alone) so a plain `git status` compacts too.
       if (bin === "git" && sub === "status" && !argv.some((t) => /^(-s|--short|--porcelain)/.test(t))) argv.push("--porcelain");
+      // `p4 reconcile` MUTATES the workspace unless previewing — force -n so the wrapper is always read-only.
+      if (bin === "p4" && sub === "reconcile" && !argv.some((t) => t === "-n" || t === "--preview" || /^-[a-z]*n/i.test(t))) argv.push("-n");
       const { out: stdout, err: stderr, code } = runExternal(bin, argv, root);
       const raw = stdout || stderr || "";
       if (!stdout && (code !== 0 || stderr)) {

--- a/server/index.js
+++ b/server/index.js
@@ -167,10 +167,11 @@ const TOOLS = [
   {
     name: "vts_git",
     description:
-      "Run a git command and return its output COMPACTED (token-capped) — for status/log/diff, which the " +
-      "language-server index can't help with but whose raw dump is verbose and repetitive. status groups " +
-      "by change-type + directory; log keeps one line per commit; diff collapses to a per-file +/- " +
-      "diffstat (no hunk bodies). Use instead of a raw `git status/log/diff` to save tokens.",
+      "Run a READ-ONLY git command and return its output COMPACTED (token-capped) — for status/log/diff, " +
+      "which the language-server index can't help with but whose raw dump is verbose and repetitive. status " +
+      "groups by change-type + directory; log keeps one line per commit; diff collapses to a per-file +/- " +
+      "diffstat (no hunk bodies). Mutating subcommands (commit/reset/checkout/clean/push/merge/rebase) are " +
+      "REFUSED — this only compacts output; run those directly. Use instead of a raw `git status/log/diff`.",
     inputSchema: {
       type: "object",
       properties: {
@@ -184,9 +185,10 @@ const TOOLS = [
   {
     name: "vts_p4",
     description:
-      "Run a Perforce (p4) command and return its output COMPACTED (token-capped) — for opened/status/" +
-      "reconcile/changes, whose raw output is long and repetitive. Groups files by action + depot " +
-      "directory and caps the list. Use instead of a raw `p4 opened` etc. to save tokens.",
+      "Run a READ-ONLY Perforce (p4) command and return its output COMPACTED (token-capped) — for opened/" +
+      "status/reconcile/changes, whose raw output is long and repetitive. Groups files by action + depot " +
+      "directory and caps the list. `reconcile` is forced to preview (-n); mutating subcommands (submit/" +
+      "revert/edit/add/delete) are REFUSED — run those directly. Use instead of a raw `p4 opened` etc.",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
Critic + live-QA review of the v0.17.0 compaction surface — real holes present in shipped **0.17.1**.

## SAFETY (the important ones)
- **Arbitrary VCS execution.** `vts_git`/`vts_p4` ran *any* argv via `runExternal` — a mutating subcommand (`git reset --hard`, `p4 submit`) executed through a tool advertised as read-only compaction. **Live-confirmed** (`vts git rev-parse` ran). Now **default-deny** read-only allowlist; mutating subs refused before running. `p4 reconcile` forced to `-n`.
- **Path traversal.** `search_text path=` read an absolute/`..` path **outside the root** — arbitrary file read. **Live-confirmed** (read a /tmp file). Now confined to the project root.

## CORRECTNESS (compact.js)
- git status **renames** (`R old -> new`) showed the literal arrow; now → destination path. Status listing budget is **one shared cap** across groups (was per-group → could dump ~max each).
- git diff **binary files** reported `+0 -0` (hid the change); now `(binary)`. Quoted paths unquoted.

## STABILITY / UX
- `runExternal` maxBuffer 64MB→256MB (`VTS_EXTERNAL_MAXBUFFER`) — a huge valid diff/log isn't a spurious failure.
- CLI `vts git/p4` lift out `--projectPath`/`--maxResults` (was forwarded to git → cryptic error).
- search_text marks 200-char line truncation with `…`.

## Verify
`node eval/run.mjs` → EVAL PASSED (**43/43**, +2 guards: savings accuracy from #37 + this hardening). Lint clean. Live-QA reconfirmed all four fixes (reset refused, traversal refused, --projectPath works, rename→dest).

Theme: reliability/safety hardening — ships as a **patch** with the #37 ledger fix (both `fix:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)