### PR TITLE
Release v0.17.3 — vts_git cwd fix + compactor polish (patch)

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -790,6 +790,29 @@ const truncMarkOk = !longRes.isError && /…/.test(longRes.text);
 try { fs.rmSync(longDir, { recursive: true, force: true }); } catch { /* ignore */ }
 const hardeningOk = allowlistOk && allowlistAllowsRO && traversalOk && renameParseOk && budgetOk && binaryOk && truncMarkOk;
 
+// 43) polish: (a) vts_git/vts_p4 run in CWD, not the configured PROJECT_PATH — `vts git status` in repo B
+// shows repo B even when VTS_PROJECT_PATH points at repo A (was the live-QA surprise); (b) p4 changes parses
+// the quoted desc + optional *pending*; (c) the generic dedup summary says "unique line(s)".
+const mkGitRepo = (sub, files) => {
+  const d = path.join(os.tmpdir(), `vts-eval-${process.pid}-${sub}`);
+  fs.mkdirSync(d, { recursive: true });
+  spawnSync("git", ["-C", d, "init", "-q"]); spawnSync("git", ["-C", d, "config", "user.email", "e@x.t"]);
+  spawnSync("git", ["-C", d, "config", "user.name", "t"]); spawnSync("git", ["-C", d, "config", "core.autocrlf", "false"]);
+  for (const [n, b] of Object.entries(files)) fs.writeFileSync(path.join(d, n), b);
+  return d;
+};
+const repoA = mkGitRepo("repoA", { "aaa.cpp": "int a;\n" });
+spawnSync("git", ["-C", repoA, "add", "-A"]); spawnSync("git", ["-C", repoA, "commit", "-qm", "init"]); // clean
+const repoB = mkGitRepo("repoB", { "bbb_untracked.cpp": "int b;\n" }); // dirty (untracked)
+const cpCwd = spawnSync(process.execPath, [cliPath, "git", "status"], { cwd: repoB, encoding: "utf8", env: { ...process.env, VTS_PROJECT_PATH: repoA, VTS_ENFORCE: "0", VTS_CONFIG_FILE: CF } });
+const gitCwdOk = /bbb_untracked/.test(cpCwd.stdout || "") && !/aaa\.cpp/.test(cpCwd.stdout || ""); // CWD repoB won, not repoA
+for (const d of [repoA, repoB]) { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ } }
+const p4ch = compactP4("changes", "Change 42 on 2026/01/02 by alice@ws *pending* 'rework combat'\nChange 41 on 2026/01/01 by bob@ws 'tidy'\n", 60);
+const p4ChangesOk = /42 2026\/01\/02 alice@ws \*pending\* rework combat/.test(p4ch) && /41 .*bob@ws tidy/.test(p4ch);
+const dedupOut = compactGit("unknownsub", Array.from({ length: 10 }, (_, i) => `uline${i}`).join("\n"), 3);
+const dedupWordOk = /more unique line\(s\)/.test(dedupOut);
+const polishOk = gitCwdOk && p4ChangesOk && dedupWordOk;
+
 await disposeClients();
 try { fs.rmSync(QH, { force: true }); } catch { /* ignore */ }
 try { fs.rmSync(IG, { force: true }); } catch { /* ignore */ }
@@ -841,6 +864,7 @@ const rows = [
   ["hook: git/p4 reroute to vts wrapper (git grep stays code)", vcsHookOk, "true", vcsHookOk],
   ["savings: string-raw not inflated + no negative tool (dogfood)", savingsLedgerOk, "true", savingsLedgerOk],
   ["hardening: ro-allowlist + path-confine + rename/binary/budget/trunc", hardeningOk, "true", hardeningOk],
+  ["polish: git/p4 run in cwd + p4-changes parse + dedup wording", polishOk, "true", polishOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/compact.js
+++ b/server/compact.js
@@ -102,7 +102,7 @@ function compactGitDiff(raw, max) {
     // No `diff --git` headers → not a unified diff (likely `--stat` / `--name-only`, already terse). Don't
     // mangle it: dedup + cap the raw output and pass it through.
     const { lines, total } = dedupCap(nonEmpty(raw), max);
-    return lines.join("\n") + (total > lines.length ? `\n… +${total - lines.length} more line(s).` : "");
+    return lines.join("\n") + (total > lines.length ? `\n… +${total - lines.length} more unique line(s).` : "");
   }
   const shown = files.slice(0, max);
   const body = shown.map((f) => `  ${f.file} | ${f.binary ? "(binary)" : `+${f.add} -${f.del}`}`).join("\n");
@@ -118,7 +118,7 @@ export function compactGit(sub, raw, max = 60) {
   // Unknown subcommand → generic dedup+cap (still a win on repetitive output).
   const { lines, total } = dedupCap(nonEmpty(raw), max);
   if (!lines.length) return "(no output).";
-  return lines.join("\n") + (total > lines.length ? `\n… +${total - lines.length} more line(s).` : "");
+  return lines.join("\n") + (total > lines.length ? `\n… +${total - lines.length} more unique line(s).` : "");
 }
 
 // ---- perforce ----
@@ -154,9 +154,13 @@ function compactP4Changes(raw, max) {
   const lines = nonEmpty(raw);
   if (!lines.length) return "(no changes).";
   const shown = lines.slice(0, max).map((l) => {
-    const m = l.match(/^Change (\d+) on (\S+) by (\S+)\s+(?:'(.*)'|\*pending\*\s*'(.*)')?/);
+    // `Change N on DATE by user@ws [*pending*] 'desc'` — grab the head fields and the quoted desc wherever
+    // it sits (the optional *pending* marker no longer breaks the match).
+    const m = l.match(/^Change (\d+) on (\S+) by (\S+)/);
     if (!m) return l.slice(0, 200);
-    return `${m[1]} ${m[2]} ${m[3]} ${(m[4] || m[5] || "").slice(0, 80)}`.trim();
+    const pending = /\*pending\*/.test(l) ? "*pending* " : "";
+    const desc = (l.match(/'([^']*)'/) || ["", ""])[1].slice(0, 80);
+    return `${m[1]} ${m[2]} ${m[3]} ${pending}${desc}`.trim();
   });
   return shown.join("\n") + (lines.length > shown.length ? `\n… +${lines.length - shown.length} more change(s).` : "");
 }
@@ -167,7 +171,7 @@ export function compactP4(sub, raw, max = 60) {
   if (s === "changes") return compactP4Changes(raw, max);
   const { lines, total } = dedupCap(nonEmpty(raw), max);
   if (!lines.length) return "(no output).";
-  return lines.join("\n") + (total > lines.length ? `\n… +${total - lines.length} more line(s).` : "");
+  return lines.join("\n") + (total > lines.length ? `\n… +${total - lines.length} more unique line(s).` : "");
 }
 
 // Exposed for the eval (deterministic unit coverage of the grouping helpers).

--- a/server/core.js
+++ b/server/core.js
@@ -925,7 +925,9 @@ export async function runTool(name, a = {}) {
     // is verbose + repetitive — group/dedup/cap reclaims the tokens. The grep-block hook reroutes a plain
     // `git status` / `p4 opened` here transparently; the savings ledger aggregates them per tool.
     if (name === "vts_git" || name === "vts_p4") {
-      const root = a.projectPath || PROJECT_PATH || process.cwd();
+      // git/p4 are cwd-relative — run where the user/agent IS, not the configured PROJECT_PATH (which would
+      // surprise: `vts git status` in repo B showing the configured repo A). Explicit projectPath still wins.
+      const root = a.projectPath || process.cwd();
       const max = Number(a.maxResults) || MAX_RESULTS;
       const bin = name === "vts_git" ? "git" : "p4";
       const argv = toArgv(a);
@@ -945,8 +947,10 @@ export async function runTool(name, a = {}) {
       const { out: stdout, err: stderr, code } = runExternal(bin, argv, root);
       const raw = stdout || stderr || "";
       if (!stdout && (code !== 0 || stderr)) {
-        // command failed (binary missing, not a repo/workspace, bad args) — surface stderr verbatim, no cap.
-        return err(`${bin} ${argv.join(" ")} failed (exit ${code}):\n${(stderr || "no output").slice(0, 1500)}`);
+        // command failed (binary missing, not a repo/workspace, bad args) — surface stderr, capped with a
+        // marker so a huge error isn't silently cut.
+        const e = stderr || "no output";
+        return err(`${bin} ${argv.join(" ")} failed (exit ${code}):\n${e.length > 1500 ? e.slice(0, 1500) + "\n…(stderr truncated)" : e}`);
       }
       const compactFn = name === "vts_git" ? compactGit : compactP4;
       const body = compactFn(sub, raw, max);


### PR DESCRIPTION
Patch — `fix:` only (PATCH per gitflow).

- vts_git/vts_p4 run in **CWD**, not the configured PROJECT_PATH (the QA surprise where `vts git status` in repo B showed repo A). --projectPath still overrides.
- stderr truncation marker on failures; p4-changes desc/*pending* parse; dedup summary 'unique line(s)' (critic minors #7/#10/#12).

## Verify
`node eval/run.mjs` → EVAL PASSED (**44/44**); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)