### PR TITLE
fix: outline object-key noise + benign p4 empty-state

### DIFF
--- a/eval/_mock-lsp.mjs
+++ b/eval/_mock-lsp.mjs
@@ -55,9 +55,15 @@ process.stdin.on("data", (d) => {
             { name: "realInner", kind: 12, range: rng, selectionRange: sel },
           ] },
           { name: "localTmp", kind: 13, range: rng, selectionRange: sel },
+          // object-literal property key (kind 7) under a FUNCTION → data, hidden by default.
+          { name: "noiseKey", kind: 7, range: rng, selectionRange: sel },
         ] },
         // a top-level symbol literally named "callback" — a real declaration, must be KEPT (depth-0).
         { name: "callback", kind: 12, range: rng, selectionRange: sel },
+        // a CLASS whose property (kind 7) IS structure → must be KEPT (parent is class-like).
+        { name: "Cls", kind: 5, range: rng, selectionRange: sel, children: [
+          { name: "keepProp", kind: 7, range: rng, selectionRange: sel },
+        ] },
       ] });
     } else if (msg.method === "textDocument/rename") {
       const uri = msg.params.textDocument.uri, p = msg.params.position;

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -147,8 +147,10 @@ const docSymOk =
   /realInner/.test(ds.text) &&                   // real decl inside a hidden wrapper NOT orphaned
   /func callback {2}@/.test(ds.text) &&          // top-level symbol named 'callback' kept (depth-0, not noise)
   !/map\(\) callback/.test(ds.text) && !/localTmp/.test(ds.text) && // anonymous + nested local hidden
+  !/noiseKey/.test(ds.text) &&                   // object-literal prop key (kind 7 under a func) hidden
+  /keepProp/.test(ds.text) && /Cls/.test(ds.text) && // but a class property (kind 7 under a class) is KEPT
   /local\/anonymous hidden/.test(ds.text) &&     // the hidden-count note
-  /map\(\) callback/.test(dsRaw.text) && /localTmp/.test(dsRaw.text); // VTS_OUTLINE_RAW=1 shows everything
+  /map\(\) callback/.test(dsRaw.text) && /localTmp/.test(dsRaw.text) && /noiseKey/.test(dsRaw.text); // RAW shows all
 const tdir = path.join(os.tmpdir(), `vts-files-${process.pid}`);
 fs.mkdirSync(tdir, { recursive: true });
 fs.writeFileSync(path.join(tdir, "Widget.cpp"), "int NEEDLE_TOKEN = 1;\n");
@@ -811,7 +813,11 @@ const p4ch = compactP4("changes", "Change 42 on 2026/01/02 by alice@ws *pending*
 const p4ChangesOk = /42 2026\/01\/02 alice@ws \*pending\* rework combat/.test(p4ch) && /41 .*bob@ws tidy/.test(p4ch);
 const dedupOut = compactGit("unknownsub", Array.from({ length: 10 }, (_, i) => `uline${i}`).join("\n"), 3);
 const dedupWordOk = /more unique line\(s\)/.test(dedupOut);
-const polishOk = gitCwdOk && p4ChangesOk && dedupWordOk;
+// benign empty-state stderr (p4 "File(s) not opened" + nonzero) is an empty result, not a failure.
+const { isBenignEmpty } = await import("../server/core.js");
+const benignOk = isBenignEmpty("File(s) not opened on this client.") && isBenignEmpty("No files to reconcile.") &&
+  !isBenignEmpty("fatal: not a git repository") && !isBenignEmpty("");
+const polishOk = gitCwdOk && p4ChangesOk && dedupWordOk && benignOk;
 
 await disposeClients();
 try { fs.rmSync(QH, { force: true }); } catch { /* ignore */ }

--- a/server/core.js
+++ b/server/core.js
@@ -613,24 +613,29 @@ function fmtDocSymbols(syms, max, file) {
   const maxDepth = envInt("VTS_OUTLINE_DEPTH", 4);
   const rows = [];
   let dropped = 0;
-  const walk = (arr, parent, depth) => {
+  // Class-like containers whose members (properties/fields) ARE structure worth keeping. Under anything else
+  // (a function, a const/var holding an object literal) a kind-7 property is just a DATA key — `COMMANDS::git`,
+  // `STATUS::M`, `_internals::compactGit` — and floods the outline. Hide those; keep class members.
+  const CLASSLIKE = new Set([5, 10, 11, 23]); // class, enum, interface, struct
+  const walk = (arr, parent, depth, parentKind) => {
     for (const s of arr || []) {
-      // Noise only when NESTED: a synthetic callback / angle-name, or a var/const/key local (not a decl).
-      // Still DESCEND into a hidden node's children (passing the hidden node's PARENT) so a real
-      // declaration inside a filtered wrapper isn't orphaned — only the wrapper row is dropped.
-      if (!raw && depth > 0 && (OUTLINE_NOISE.test(s.name || "") || s.kind === 13 || s.kind === 14 || s.kind === 20)) {
+      // Noise only when NESTED: a synthetic callback / angle-name, a var/const/key local, or an object-literal
+      // property key (kind 7 under a non-class parent). Still DESCEND into a hidden node's children (passing
+      // the hidden node's PARENT) so a real declaration inside a filtered wrapper isn't orphaned.
+      const objKey = s.kind === 7 && !CLASSLIKE.has(parentKind);
+      if (!raw && depth > 0 && (OUTLINE_NOISE.test(s.name || "") || s.kind === 13 || s.kind === 14 || s.kind === 20 || objKey)) {
         dropped++;
-        if (s.children && depth < maxDepth) walk(s.children, parent, depth + 1);
+        if (s.children && depth < maxDepth) walk(s.children, parent, depth + 1, parentKind);
         continue;
       }
       const r = s.range || (s.location && s.location.range);
       const ln = r ? r.start.line + 1 : 1;
       const loc = s.location ? fromUri(s.location.uri).replace(/\\/g, "/") : file;
       rows.push(`${SYMBOL_KIND[s.kind] || `k${s.kind}`} ${parent ? parent + "::" : ""}${s.name}  @ ${loc}:${ln}`);
-      if (s.children && depth < maxDepth) walk(s.children, (parent ? parent + "::" : "") + s.name, depth + 1);
+      if (s.children && depth < maxDepth) walk(s.children, (parent ? parent + "::" : "") + s.name, depth + 1, s.kind);
     }
   };
-  walk(syms, "", 0);
+  walk(syms, "", 0, 0);
   const shown = rows.slice(0, max);
   const note = dropped && !raw ? ` (${dropped} local/anonymous hidden; VTS_OUTLINE_RAW=1 to show)` : "";
   return `${rows.length} symbol(s)${note}:\n` + shown.join("\n") + (rows.length > shown.length ? `\n… ${rows.length - shown.length} more.` : "");
@@ -770,6 +775,11 @@ function toArgv(a) {
 // is read-only ONLY with -n, so it's forced to preview below.
 const GIT_READONLY = new Set(["status", "log", "diff", "show", "blame", "shortlog", "ls-files", "ls-tree", "describe", "rev-parse", "rev-list", "cat-file", "name-rev", "whatchanged", "reflog", "grep", "diff-tree", "cherry", "count-objects"]);
 const P4_READONLY = new Set(["opened", "status", "changes", "describe", "filelog", "fstat", "files", "print", "dirs", "diff", "diff2", "where", "info", "annotate", "sizes", "cstat", "reconcile", "have"]);
+// p4 (and occasionally git) write a "nothing here" message to STDERR and exit non-zero — e.g. `p4 opened`
+// with nothing open prints "File(s) not opened on this client." That's an EMPTY RESULT, not a failure;
+// surfacing it as an error is wrong. Recognize the benign shapes so the wrapper returns a clean result.
+const BENIGN_EMPTY = /not opened|no file\(s\)|no files? to|up-to-date|nothing (?:opened|to)|no such file|no changes/i;
+export const isBenignEmpty = (s) => !!s && BENIGN_EMPTY.test(String(s));
 
 // ---- single dispatcher (async) ----
 export async function runTool(name, a = {}) {
@@ -947,7 +957,10 @@ export async function runTool(name, a = {}) {
       const { out: stdout, err: stderr, code } = runExternal(bin, argv, root);
       const raw = stdout || stderr || "";
       if (!stdout && (code !== 0 || stderr)) {
-        // command failed (binary missing, not a repo/workspace, bad args) — surface stderr, capped with a
+        // A benign "nothing here" message (p4 writes these to stderr + nonzero) is an empty result, not a
+        // failure — return it cleanly so the agent doesn't read an error where there's simply no work.
+        if (isBenignEmpty(stderr)) return finishOut("", `${bin} ${argv.join(" ")}: ${stderr.trim().slice(0, 200)}`);
+        // genuine failure (binary missing, not a repo/workspace, bad args) — surface stderr, capped with a
         // marker so a huge error isn't silently cut.
         const e = stderr || "no output";
         return err(`${bin} ${argv.join(" ")} failed (exit ${code}):\n${e.length > 1500 ? e.slice(0, 1500) + "\n…(stderr truncated)" : e}`);


### PR DESCRIPTION
Dogfound by running `document_symbols`/`hover` on our own .js and `vts_p4` against a **real Perforce server**.

- **document_symbols noise.** Object-literal property keys (`COMMANDS::git`, `STATUS::M`, `_internals::compactGit`, `dedupCap::lines`) flooded the outline — tsserver reports them as kind 7 (property), which the depth>0 noise filter (13/14/20) missed. Now a kind-7 property under a **non-class** parent is hidden; class members are kept. **Live: compact.js 34→12 symbols, 86.8%→97.6% (8×→41×).**
- **benign p4 empty-state.** `p4 opened` with nothing open prints "File(s) not opened on this client." to stderr + exits non-zero — vts_p4 surfaced it as a **failure**. `isBenignEmpty()` now treats these "nothing here" messages as a clean empty result.

## Verify
`node eval/run.mjs` → EVAL PASSED (**44/44**; outline guard extended: kind-7-under-func hidden / under-class kept; isBenignEmpty pure). Lint clean. hover live-verified (`function compactGit(...): string`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)