### PR TITLE
feat: global multi-repo server v2 — per-call roots + bounded backend pool + refs output compaction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   pyproject/*.py→pyright; strongest build-artifact first). Override via `VTS_CLANGD_CMD/ARGS`,
   `VTS_ROSLYN_CMD/ARGS`, `VTS_TS_CMD/ARGS`, `VTS_PY_CMD/ARGS`. `winShell` flag spawns the npm `.cmd`
   shims (ts/pyright) through a shell on Windows. `langIdForPath` (lsp.js) maps file ext → LSP languageId.
+  `findProjectRoot(start)` — bounded walk UP from a file to the nearest project marker (compile_commands/
+  *.uproject/.sln/.csproj/tsconfig/package.json/pyproject/…/.git as the repo-boundary fallback; nearest
+  dir wins, never climbs past a `.git`). Feeds `resolveRoot` (core.js) so a per-call `path` pins the right
+  repo on a globally-installed server.
 - `server/core.js` — `runTool()` dispatch, token-cap formatters, savings ledger. Tools: `search_symbol`,
   `find_references` (accepts EITHER a 0-based `path`+`line`+`character` position OR a `symbol` NAME — the
   code-modification primitive: by-name resolves the decl via `c.symbol` [exact-name-then-`path`-endsWith
@@ -70,7 +74,20 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
 - `server/compact.js` — PURE output-compaction fns (`compactGit`/`compactP4`, string→string, no spawn) for the
   `vts_git`/`vts_p4` wrappers. Eval exercises them on canned input (deterministic). (No grep compaction here —
   grep reroutes to search_text, which scans + token-caps itself; there is no raw grep output to compact.)
-- `server/cli.js` — `vts <cmd>`. `server/index.js` — MCP server (async handler → `await runTool`).
+- `server/cli.js` — `vts <cmd>`. `server/index.js` — MCP server (async handler → `await runTool`). PER-CALL
+  ROOT: `resolveRoot(a)` (core.js) replaces the old single-pin `a.projectPath || PROJECT_PATH || cwd` for
+  every query — precedence: explicit `projectPath` > a `path`'s enclosing project (`findProjectRoot`, only
+  when OUTSIDE every known root so an inside-path keeps clangd's compile-DB rooting) > an MCP workspace root
+  > `PROJECT_PATH` > cwd. `resolveCwdRoot(a)` for git/p4 (MCP root beats server cwd; pin still ignored). One
+  global server now serves every repo a session touches, not just the pinned one. index.js does the MCP
+  `roots` handshake (`getClientCapabilities`→`listRoots`→`setMcpRoots`, re-fetched on `roots/list_changed`,
+  undefined-safe on old SDKs); no roots advertised → collapses to the old `PROJECT_PATH || cwd`. Boot
+  prewarm/auto-learn use `PROJECT_PATH || first MCP root` so a config-less install warms the current
+  workspace (ONE root only). BACKEND POOL (memory guard for dynamic roots): the `clients` map is BOUNDED —
+  `VTS_MAX_BACKENDS` (2) LRU-evicts the least-recently-used idle client past the cap, `VTS_BACKEND_IDLE_MS`
+  (300000, 0=off) reaps idle clients via an unref'd sweep; a client with an in-flight request (`pending.size`)
+  is never evicted/reaped. Steady state ≈ 1 warm backend; bouncing 2 repos keeps both warm; a 3rd evicts LRU.
+  `__pool` test surface + eval guards 45 (pool) / 46 (root resolution).
 - `server/sdk.js` — createRequire MCP-SDK resolution. `server/ensure-deps.mjs` — SessionStart installer.
 - `server/warmset.js` — prewarm ORDERING: `orderForWarm` (query-history > working-now [`git status` /
   `p4 opened`] > git-log recency > include-centrality [adaptive: prefix-read + `VTS_CENTRALITY_BUDGET_MS`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,13 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   locals (kinds 13/14/20 at depth>0) — keeping the declaration structure (classes/functions/methods/
   fields/types). A `(N local/anonymous hidden …)` note shows the count; `VTS_OUTLINE_RAW=1` shows all,
   `VTS_OUTLINE_DEPTH` caps nesting (default 4). Live: a 105-symbol warmset.js outline → 32. Token + clarity win.
+- **output cap v2 — collapse repetition (caveman-inspired).** `fmtLocations` (find_references + any
+  multi-location result) no longer prints one line PER location — a refs-heavy result repeats the same long
+  path on every row. `compactLocationLines` groups by FILE (one row, all line numbers joined/deduped/sorted:
+  `Foo.cpp:42,88,120`) then `commonDirPrefix` factors the shared directory tree out once (`under <prefix>/`
+  + relative tails). Every location preserved + recoverable (full path = prefix + tail). Est. ~4× (coalesce)
+  → ~10× (prefix) on a deep UE refs result. `VTS_COMPACT_RESULTS=0` restores the classic `  @ path:line`.
+  fmtSymbols/search_text keep per-row (distinct payload each). eval guard 47.
 - **ts/py search_symbol fallback (dogfood-found).** tsserver/pyright answer `workspace/symbol` from
   OPEN/indexed files, so a symbol whose file the warm-up didn't open (or a non-exported local) returns 0.
   `search_symbol` then falls back to a bounded literal text search (`scanTextUnder`, labeled "Literal text

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -830,6 +830,40 @@ const i18nOk =
   /Grep 툴로 코드 검색/.test(hKoNudge) &&
   hEnBlock.status === 2 && /caught a code search/.test(hEnBlock.err); // en explicit still English
 
+// 45) backend pool lifecycle (memory guard): the live language-server pool is BOUNDED so a session that
+// touches many repos can't spawn an unbounded number of persistent clangd/Roslyn processes. evictLRU shuts
+// down the least-recently-used SETTLED+idle client at the cap; an in-flight request (pending.size>0)
+// protects its client from both eviction and the idle sweep; sweepIdle reaps clients idle past the TTL;
+// idleMs=0 disables reaping. Seeded with FAKE clients (no real LSP spawn) so the checks are deterministic.
+const { __pool } = await import("../server/core.js");
+const shut = [];
+const mk = (k, pending = 0) => ({ _k: k, pending: new Map(Array.from({ length: pending }, (_, i) => [i, 1])), async shutdown() { shut.push(this._k); } });
+process.env.VTS_MAX_BACKENDS = "2"; // cap = 2
+__pool.clear();
+__pool.seed("clangd|A", mk("A"), 100); __pool.seed("clangd|B", mk("B"), 200); __pool.seed("clangd|C", mk("C"), 300);
+const evicted = __pool.evictLRU(); // over cap → drop the oldest (smallest lastUsed)
+await new Promise((r) => setTimeout(r, 0)); // flush the async shutdown microtask
+const lruEvictOk = evicted === "clangd|A" && shut.includes("A") && !__pool.clients.has("clangd|A") && __pool.clients.size === 2;
+shut.length = 0; __pool.clear();
+__pool.seed("clangd|busy", mk("busy", 1), 50); __pool.seed("clangd|idle", mk("idle"), 150); __pool.seed("clangd|warm", mk("warm"), 250);
+const evicted2 = __pool.evictLRU(); // oldest is BUSY → skipped, next-oldest idle dropped
+const busyProtectedOk = evicted2 === "clangd|idle" && __pool.clients.has("clangd|busy");
+__pool.clear(); __pool.seed("clangd|solo", mk("solo"), 100);
+const noEvictOk = __pool.evictLRU() === null && __pool.clients.size === 1; // under cap → no eviction
+shut.length = 0; process.env.VTS_BACKEND_IDLE_MS = "1000"; __pool.clear();
+const T = 1_000_000;
+__pool.seed("clangd|old", mk("old"), T - 5000);        // idle 5s > 1s TTL → reaped
+__pool.seed("clangd|fresh", mk("fresh"), T - 100);     // idle 0.1s < TTL → kept
+__pool.seed("clangd|oldbusy", mk("oldbusy", 1), T - 9000); // old but busy → kept
+const reaped = __pool.sweepIdle(T);
+await new Promise((r) => setTimeout(r, 0));
+const idleSweepOk = reaped.length === 1 && reaped[0] === "clangd|old" && shut.includes("old") &&
+  __pool.clients.has("clangd|fresh") && __pool.clients.has("clangd|oldbusy");
+process.env.VTS_BACKEND_IDLE_MS = "0";
+const sweepDisabledOk = __pool.sweepIdle(T).length === 0; // TTL 0 → reaping disabled
+delete process.env.VTS_MAX_BACKENDS; delete process.env.VTS_BACKEND_IDLE_MS; __pool.clear();
+const poolLifecycleOk = lruEvictOk && busyProtectedOk && noEvictOk && idleSweepOk && sweepDisabledOk;
+
 await disposeClients();
 try { fs.rmSync(QH, { force: true }); } catch { /* ignore */ }
 try { fs.rmSync(IG, { force: true }); } catch { /* ignore */ }
@@ -883,6 +917,7 @@ const rows = [
   ["hardening: ro-allowlist + path-confine + rename/binary/budget/trunc", hardeningOk, "true", hardeningOk],
   ["polish: git/p4 run in cwd + p4-changes parse + dedup wording", polishOk, "true", polishOk],
   ["i18n: VTS_LANG=ko Korean block+nudge / en English", i18nOk, "true", i18nOk],
+  ["backend pool: LRU evict + idle reap + in-flight protect", poolLifecycleOk, "true", poolLifecycleOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -895,6 +895,31 @@ const rootsRoundtripOk = (() => { setMcpRoots([repoCC, repoGit]); const g = getM
 try { fs.rmSync(rootBase, { recursive: true, force: true }); } catch { /* ignore */ }
 const rootResolveOk = findRootOk && rrExplicit && rrInsideKept && rrOutside && rrNoPathRoot && rrFallback && rootsRoundtripOk;
 
+// 47) output cap v2 (caveman "collapse repetition"): a refs-heavy result collapses to one line per FILE
+// (all line numbers joined, deduped, sorted) with a common DIRECTORY prefix factored out once — every
+// location preserved + recoverable. VTS_COMPACT_RESULTS=0 restores the classic "  @ path:line" shape.
+const { compactLocationLines, commonDirPrefix } = await import("../server/core.js");
+const cl = compactLocationLines([
+  "G:/proj/Source/Game/Private/Combat/Damage.cpp:120",
+  "G:/proj/Source/Game/Private/Combat/Damage.cpp:42",
+  "G:/proj/Source/Game/Private/Combat/Damage.cpp:42",   // dup → deduped
+  "G:/proj/Source/Game/Private/AI/Enemy.cpp:55",
+]);
+const capV2Ok =
+  commonDirPrefix(["a/b/c/x.cpp", "a/b/d/y.cpp"]) === "a/b" &&      // dir prefix, filename segment excluded
+  commonDirPrefix(["a/x.cpp"]) === "" &&                            // single path → no prefix
+  /under G:\/proj\/Source\/Game\/Private\//.test(cl) &&             // common prefix factored once
+  /Combat\/Damage\.cpp:42,120/.test(cl) &&                          // same-file lines coalesced, deduped, sorted
+  /AI\/Enemy\.cpp:55/.test(cl) &&
+  (cl.match(/Damage\.cpp/g) || []).length === 1;                    // path printed once, not per location
+const clSingle = compactLocationLines(["G:/proj/only/A.cpp:9", "G:/proj/only/A.cpp:3"]); // one file → no prefix header
+const capSingleOk = !/under /.test(clSingle) && /A\.cpp:3,9/.test(clSingle);
+process.env.VTS_COMPACT_RESULTS = "0";
+const rOff = await runTool("find_references", { symbol: "Spawn", projectPath: process.cwd(), backend: "clangd" });
+delete process.env.VTS_COMPACT_RESULTS;
+const capToggleOk = !rOff.isError && /@ .*Foo\.cpp:42/.test(rOff.text); // classic "  @ path:line" restored
+const capResultsOk = capV2Ok && capSingleOk && capToggleOk;
+
 await disposeClients();
 try { fs.rmSync(QH, { force: true }); } catch { /* ignore */ }
 try { fs.rmSync(IG, { force: true }); } catch { /* ignore */ }
@@ -950,6 +975,7 @@ const rows = [
   ["i18n: VTS_LANG=ko Korean block+nudge / en English", i18nOk, "true", i18nOk],
   ["backend pool: LRU evict + idle reap + in-flight protect", poolLifecycleOk, "true", poolLifecycleOk],
   ["per-call root: findProjectRoot walk-up + resolveRoot precedence + MCP roots", rootResolveOk, "true", rootResolveOk],
+  ["output cap v2: refs collapse per-file + common-prefix factor (toggle)", capResultsOk, "true", capResultsOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -864,6 +864,37 @@ const sweepDisabledOk = __pool.sweepIdle(T).length === 0; // TTL 0 → reaping d
 delete process.env.VTS_MAX_BACKENDS; delete process.env.VTS_BACKEND_IDLE_MS; __pool.clear();
 const poolLifecycleOk = lruEvictOk && busyProtectedOk && noEvictOk && idleSweepOk && sweepDisabledOk;
 
+// 46) per-call root resolution (A1/A2): findProjectRoot walks UP to the nearest project marker so a `path`
+// argument pins the correct repo; resolveRoot precedence = explicit projectPath > a path's enclosing
+// project (only when OUTSIDE every known root, so an inside-path keeps its root and clangd rooting is
+// preserved) > an MCP workspace root (over the stale config pin) > PROJECT_PATH > cwd. setMcpRoots holds
+// the client-advertised workspace folders. (Config is empty in the eval, so PROJECT_PATH === "".)
+const { resolveRoot, setMcpRoots, getMcpRoots } = await import("../server/core.js");
+const { findProjectRoot } = await import("../server/backends/index.js");
+const rootBase = path.join(os.tmpdir(), `vts-eval-${process.pid}-roots`);
+const repoCC = path.join(rootBase, "withcc"); const deepCC = path.join(repoCC, "a", "b");
+fs.mkdirSync(deepCC, { recursive: true });
+fs.writeFileSync(path.join(repoCC, "compile_commands.json"), "[]"); fs.writeFileSync(path.join(deepCC, "x.cpp"), "int x;\n");
+const repoGit = path.join(rootBase, "withgit"); const deepGit = path.join(repoGit, "src");
+fs.mkdirSync(path.join(repoGit, ".git"), { recursive: true }); fs.mkdirSync(deepGit, { recursive: true });
+fs.writeFileSync(path.join(deepGit, "y.cpp"), "int y;\n");
+const rl = (p) => path.resolve(p);
+const findRootOk =
+  rl(findProjectRoot(path.join(deepCC, "x.cpp"))) === rl(repoCC) &&    // climbs to the compile_commands dir
+  rl(findProjectRoot(path.join(deepGit, "y.cpp"))) === rl(repoGit) &&  // stops at the .git repo boundary
+  rl(findProjectRoot(repoCC)) === rl(repoCC);                          // a directory arg resolves to itself
+setMcpRoots([]);
+const rrExplicit = rl(resolveRoot({ projectPath: repoGit, path: path.join(deepCC, "x.cpp") })) === rl(repoGit); // explicit wins over path
+setMcpRoots([repoCC]);                                                 // repoCC is now a "known" workspace root
+const rrInsideKept = rl(resolveRoot({ path: path.join(deepCC, "x.cpp") })) === rl(repoCC); // inside known → keep root
+const rrOutside = rl(resolveRoot({ path: path.join(deepGit, "y.cpp") })) === rl(repoGit);  // outside known → its real project
+const rrNoPathRoot = rl(resolveRoot({})) === rl(repoCC);              // no path → the MCP workspace root
+setMcpRoots([]);
+const rrFallback = rl(resolveRoot({})) === rl(process.cwd());         // no roots + empty PROJECT_PATH → cwd
+const rootsRoundtripOk = (() => { setMcpRoots([repoCC, repoGit]); const g = getMcpRoots(); setMcpRoots([]); return g.length === 2 && rl(g[0]) === rl(repoCC); })();
+try { fs.rmSync(rootBase, { recursive: true, force: true }); } catch { /* ignore */ }
+const rootResolveOk = findRootOk && rrExplicit && rrInsideKept && rrOutside && rrNoPathRoot && rrFallback && rootsRoundtripOk;
+
 await disposeClients();
 try { fs.rmSync(QH, { force: true }); } catch { /* ignore */ }
 try { fs.rmSync(IG, { force: true }); } catch { /* ignore */ }
@@ -918,6 +949,7 @@ const rows = [
   ["polish: git/p4 run in cwd + p4-changes parse + dedup wording", polishOk, "true", polishOk],
   ["i18n: VTS_LANG=ko Korean block+nudge / en English", i18nOk, "true", i18nOk],
   ["backend pool: LRU evict + idle reap + in-flight protect", poolLifecycleOk, "true", poolLifecycleOk],
+  ["per-call root: findProjectRoot walk-up + resolveRoot precedence + MCP roots", rootResolveOk, "true", rootResolveOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -921,6 +921,16 @@ const capToggleOk = !rOff.isError && /@ .*Foo\.cpp:42/.test(rOff.text); // class
 const capResultsOk = capV2Ok && capSingleOk && capToggleOk;
 
 await disposeClients();
+// 48) clean teardown (no orphaned child): disposeClients must terminate EVERY spawned language-server
+// child — evicted, swept, mid-warmup, or key-overwritten — via the master registry. A surviving child
+// holds the event loop open (the process hangs after PASS → the CI test step never exits). Assert no mock
+// LSP child handle is still alive shortly after teardown. (process._getActiveHandles is internal but
+// stable across the CI Node versions; the guard is the regression net for the orphan that caused this.)
+await new Promise((r) => setTimeout(r, 300)); // let killed children reap (Windows TerminateProcess + 'exit')
+const liveChildren = (process._getActiveHandles?.() || [])
+  .filter((h) => h && h.constructor && h.constructor.name === "ChildProcess" && (h.spawnargs || []).some((a) => /_mock-lsp/.test(String(a)))).length;
+const teardownOk = liveChildren === 0;
+
 try { fs.rmSync(QH, { force: true }); } catch { /* ignore */ }
 try { fs.rmSync(IG, { force: true }); } catch { /* ignore */ }
 try { fs.rmSync(CF, { force: true }); } catch { /* ignore */ }
@@ -976,6 +986,7 @@ const rows = [
   ["backend pool: LRU evict + idle reap + in-flight protect", poolLifecycleOk, "true", poolLifecycleOk],
   ["per-call root: findProjectRoot walk-up + resolveRoot precedence + MCP roots", rootResolveOk, "true", rootResolveOk],
   ["output cap v2: refs collapse per-file + common-prefix factor (toggle)", capResultsOk, "true", capResultsOk],
+  ["clean teardown: no orphaned LSP child after disposeClients", teardownOk, "true", teardownOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -305,3 +305,37 @@ export function pickBackend(root) {
   }
   return "";
 }
+
+// Walk UP from a file (or dir) to the nearest enclosing project root — the directory holding a build /
+// project marker. This lets a per-call `path` argument pin the CORRECT repo even on a globally-installed
+// server: a deep UE `.cpp` resolves to its own `.uproject`/compile_commands root, not whatever single
+// projectPath the config happens to be pinned to. Any one marker wins; the NEAREST dir going up is the
+// root (so a nested sub-package or submodule resolves to itself, and we never cross a repo boundary by
+// climbing past a `.git`). Returns the absolute root dir, or null if nothing is found before the FS root.
+const ROOT_FILE_MARKERS = [
+  "compile_commands.json", "tsconfig.json", "jsconfig.json", "package.json",
+  "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile",
+];
+const ROOT_GLOB_MARKERS = [/\.uproject$/i, /\.sln$/i, /\.csproj$/i];
+export function findProjectRoot(startPath) {
+  if (!startPath) return null;
+  let dir;
+  try { dir = fs.statSync(startPath).isDirectory() ? startPath : path.dirname(startPath); }
+  catch { dir = path.dirname(startPath); } // nonexistent path → still climb its parent chain
+  dir = path.resolve(dir);
+  for (let i = 0; i < 64; i++) { // bounded walk — can't loop past the FS root
+    let ents;
+    try { ents = fs.readdirSync(dir, { withFileTypes: true }); } catch { ents = null; }
+    if (ents) {
+      const files = ents.filter((e) => e.isFile()).map((e) => e.name);
+      const fileSet = new Set(files);
+      if (ROOT_FILE_MARKERS.some((m) => fileSet.has(m))) return dir;
+      if (files.some((n) => ROOT_GLOB_MARKERS.some((re) => re.test(n)))) return dir;
+      if (ents.some((e) => e.name === ".git")) return dir; // weakest marker, but a repo boundary — stop here
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}

--- a/server/core.js
+++ b/server/core.js
@@ -373,28 +373,101 @@ function discoverReport(a = {}) {
     `  Fix: rewrite is on by default (Bash grep auto-reroutes to vts); for the Grep tool, prefer the vs-search MCP tools (search_symbol / search_text / find_files).${learnLine}`;
 }
 
-// ---- LSP client cache (one per root+backend; reused across calls in a process) ----
-// key -> Promise<LspClient>. We cache the PROMISE (not the resolved client) so a boot-time pre-warm
-// racing the first real query share ONE clangd instead of spawning two (the warmup is expensive).
+// ---- LSP client pool (one per root+backend; reused across calls in a process) ----
+// key -> { p: Promise<LspClient>, client: LspClient|null, lastUsed: ms }. We cache the PROMISE (not just
+// the resolved client) so a boot-time pre-warm racing the first real query share ONE clangd instead of
+// spawning two (the warmup is expensive).
+//
+// BACKEND POOL LIFECYCLE (memory guard). The MCP server is long-lived, and once the root is resolved
+// PER-CALL (a path's enclosing project / the MCP workspace root) a session that touches several repos
+// would otherwise spawn a PERSISTENT language server per root and never reap them — N repos × a UE-sized
+// clangd index = memory blow-up. So the pool is BOUNDED two ways: at most `maxBackends()` live clients
+// (the least-recently-used idle one is shut down past the cap), and any client idle past `idleMs()` is
+// reaped by a background sweep. Steady state ≈ 1 warm backend; bouncing between two repos keeps both warm
+// (no re-index); a third evicts the LRU. An evicted clangd reloads fast from its persisted on-disk index
+// (symbolReady polls the shards back in), so reaping is cheap. A client with an in-flight request is
+// NEVER evicted (pending.size guards it) — eviction/idle only ever touch settled, quiescent clients.
 const clients = new Map();
+const nowMs = () => Date.now();
+const maxBackends = () => Math.max(1, envInt("VTS_MAX_BACKENDS", 2));
+const idleMs = () => { const v = parseInt(process.env.VTS_BACKEND_IDLE_MS, 10); return Number.isFinite(v) && v >= 0 ? v : 300000; }; // 5 min; 0 disables idle reaping
+
+// Settled clients with no in-flight request, oldest-used first — the only ones safe to reap.
+function evictableEntries() {
+  return [...clients.entries()]
+    .filter(([, e]) => e.client && e.client.pending && e.client.pending.size === 0)
+    .sort((a, b) => a[1].lastUsed - b[1].lastUsed);
+}
+// Make room for one new backend: at/over the cap, shut down the least-recently-used idle client. If every
+// client is busy or still warming, allow a transient over-cap rather than block a live query.
+function evictLRU() {
+  if (clients.size < maxBackends()) return null;
+  const ev = evictableEntries();
+  if (!ev.length) return null;
+  const [key, e] = ev[0];
+  clients.delete(key);
+  Promise.resolve(e.client).then((c) => c && c.shutdown()).catch(() => {});
+  return key;
+}
+// Background reaper: shut down any client idle past idleMs (in-flight requests protected).
+function sweepIdle(now = nowMs()) {
+  const ttl = idleMs();
+  if (!ttl) return [];
+  const cut = now - ttl;
+  const reaped = [];
+  for (const [key, e] of clients) {
+    if (e.client && e.client.pending && e.client.pending.size === 0 && e.lastUsed < cut) {
+      clients.delete(key);
+      reaped.push(key);
+      Promise.resolve(e.client).then((c) => c && c.shutdown()).catch(() => {});
+    }
+  }
+  return reaped;
+}
+let _sweeper = null;
+function ensureSweeper() {
+  if (_sweeper || !idleMs()) return;
+  // unref'd so the timer never keeps the process (or the eval) alive.
+  _sweeper = setInterval(() => sweepIdle(), Math.min(idleMs(), 60000));
+  _sweeper.unref?.();
+}
 function getClient(root, backendName) {
   const key = `${backendName}|${root}`;
-  if (clients.has(key)) return clients.get(key);
+  const hit = clients.get(key);
+  if (hit) { hit.lastUsed = nowMs(); return hit.p; }
+  evictLRU();      // bound the pool BEFORE adding another backend
+  ensureSweeper();
   const b = BACKENDS[backendName];
-  const p = (async () => {
+  const entry = { p: null, client: null, lastUsed: nowMs() };
+  entry.p = (async () => {
     const c = new LspClient(b.cmd, b.args(root), { cwd: root, shell: process.platform === "win32" && !!b.winShell });
     await c.initialize(root);
     if (typeof b.afterInit === "function") await b.afterInit(c, root); // e.g. Roslyn solution/open + load wait
+    entry.client = c;
+    entry.lastUsed = nowMs();
     return c;
   })();
-  clients.set(key, p);
-  p.catch(() => clients.delete(key)); // a failed warmup shouldn't poison the cache — allow a retry
-  return p;
+  clients.set(key, entry);
+  entry.p.catch(() => clients.delete(key)); // a failed warmup shouldn't poison the cache — allow a retry
+  return entry.p;
 }
 export async function disposeClients() {
-  for (const p of clients.values()) { try { (await p).shutdown(); } catch { /* ignore */ } }
+  const entries = [...clients.values()];
   clients.clear();
+  if (_sweeper) { clearInterval(_sweeper); _sweeper = null; }
+  for (const e of entries) { try { (await e.p).shutdown(); } catch { /* ignore */ } }
 }
+// Test surface for the eval — deterministic pool checks (LRU eviction, idle sweep, pending protection)
+// without spawning a real language server.
+export const __pool = {
+  clients,
+  evictLRU,
+  sweepIdle,
+  maxBackends,
+  idleMs,
+  seed(key, client, lastUsed) { clients.set(key, { p: Promise.resolve(client), client, lastUsed }); },
+  clear() { clients.clear(); },
+};
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 // Return-when-found query for clangd with a PERSISTED index that's still loading: afterInit no longer
 // blocks on the full re-index, so the first workspace/symbol can land while shards are still loading and

--- a/server/core.js
+++ b/server/core.js
@@ -427,6 +427,13 @@ function discoverReport(a = {}) {
 // (symbolReady polls the shards back in), so reaping is cheap. A client with an in-flight request is
 // NEVER evicted (pending.size guards it) — eviction/idle only ever touch settled, quiescent clients.
 const clients = new Map();
+// Master registry of EVERY spawned client, independent of the `clients` map. The map can lose a reference
+// via several paths (evict, idle sweep, failed-warmup catch, key overwrite); this set is the single source
+// of truth for teardown, so disposeClients can guarantee NO orphaned child survives (a live child holds
+// the event loop open — it hung the eval after PASS and the CI test step never exited). killClient is the
+// one place a client is torn down: drop it from both the registry and shut it down (idempotent).
+const allClients = new Set();
+function killClient(c) { if (!c) return undefined; allClients.delete(c); try { return c.shutdown(); } catch { return undefined; } }
 const nowMs = () => Date.now();
 const maxBackends = () => Math.max(1, envInt("VTS_MAX_BACKENDS", 2));
 const idleMs = () => { const v = parseInt(process.env.VTS_BACKEND_IDLE_MS, 10); return Number.isFinite(v) && v >= 0 ? v : 300000; }; // 5 min; 0 disables idle reaping
@@ -445,7 +452,7 @@ function evictLRU() {
   if (!ev.length) return null;
   const [key, e] = ev[0];
   clients.delete(key);
-  Promise.resolve(e.client).then((c) => c && c.shutdown()).catch(() => {});
+  killClient(e.client);
   return key;
 }
 // Background reaper: shut down any client idle past idleMs (in-flight requests protected).
@@ -458,7 +465,7 @@ function sweepIdle(now = nowMs()) {
     if (e.client && e.client.pending && e.client.pending.size === 0 && e.lastUsed < cut) {
       clients.delete(key);
       reaped.push(key);
-      Promise.resolve(e.client).then((c) => c && c.shutdown()).catch(() => {});
+      killClient(e.client);
     }
   }
   return reaped;
@@ -478,8 +485,16 @@ function getClient(root, backendName) {
   ensureSweeper();
   const b = BACKENDS[backendName];
   const entry = { p: null, client: null, lastUsed: nowMs() };
+  // `spawned` captures the client the INSTANT it's constructed (its child is alive from initialize on), so
+  // a warmup that throws can still tear the child down. entry.client is set only on SUCCESS, so a
+  // still-warming client is never treated as evictable (no mid-warmup eviction). Without the failure-path
+  // shutdown a failed warmup deleted the cache entry but ORPHANED its child — a killed=false zombie that
+  // held the event loop open (the eval hung after PASS / the CI test step never exited).
+  let spawned = null;
   entry.p = (async () => {
     const c = new LspClient(b.cmd, b.args(root), { cwd: root, shell: process.platform === "win32" && !!b.winShell });
+    spawned = c;
+    allClients.add(c); // register the INSTANT it's constructed (child alive from initialize on) → never orphanable
     await c.initialize(root);
     if (typeof b.afterInit === "function") await b.afterInit(c, root); // e.g. Roslyn solution/open + load wait
     entry.client = c;
@@ -487,14 +502,17 @@ function getClient(root, backendName) {
     return c;
   })();
   clients.set(key, entry);
-  entry.p.catch(() => clients.delete(key)); // a failed warmup shouldn't poison the cache — allow a retry
+  entry.p.catch(() => { clients.delete(key); killClient(spawned); }); // failed warmup: drop the cache entry AND kill the spawned child
   return entry.p;
 }
 export async function disposeClients() {
-  const entries = [...clients.values()];
   clients.clear();
   if (_sweeper) { clearInterval(_sweeper); _sweeper = null; }
-  for (const e of entries) { try { (await e.p).shutdown(); } catch { /* ignore */ } }
+  // Tear down EVERY spawned client from the master registry (not just the map's current entries) so no
+  // child — evicted, swept, mid-warmup, or key-overwritten — is ever left running. shutdown is synchronous
+  // + idempotent, so a client already torn down is a harmless no-op.
+  for (const c of [...allClients]) { try { c.shutdown(); } catch { /* ignore */ } }
+  allClients.clear();
 }
 // Test surface for the eval — deterministic pool checks (LRU eviction, idle sweep, pending protection)
 // without spawning a real language server.

--- a/server/core.js
+++ b/server/core.js
@@ -693,13 +693,51 @@ function fmtSymbols(syms, max) {
   const more = syms.length - shown.length;
   return body + (more > 0 ? `\n… ${more} more (raise maxResults or narrow the query).` : "");
 }
+// Output-cap v2 (caveman "collapse repetition"): a refs-heavy result repeats the same long path on every
+// line. Collapse it — one line per FILE with all its line numbers joined, then factor a common DIRECTORY
+// prefix so a deep shared tree is printed ONCE. Every location is preserved and recoverable (full path =
+// prefix + "/" + tail; lines are the comma list). Biggest win on find_references (the code-mod primitive)
+// and any multi-location result. VTS_COMPACT_RESULTS=0 restores the classic one-location-per-line shape.
+const compactResults = () => { const v = process.env.VTS_COMPACT_RESULTS; return v === undefined || v === "" ? true : !/^(0|false|off|no)$/i.test(v); };
+function splitPathLine(s) { const i = s.lastIndexOf(":"); return i > 1 ? { p: s.slice(0, i), ln: s.slice(i + 1) } : { p: s, ln: "" }; }
+// Longest common DIRECTORY prefix across paths (the filename segment never counts), or "" if <2 paths /
+// no shared dir. Returns a slash-joined prefix with no trailing slash.
+function commonDirPrefix(paths) {
+  if (paths.length < 2) return "";
+  const split = paths.map((p) => p.split("/"));
+  const minLen = Math.min(...split.map((s) => s.length));
+  let i = 0;
+  while (i < minLen - 1 && split.every((s) => s[i] === split[0][i])) i++;
+  return i > 0 ? split[0].slice(0, i).join("/") : "";
+}
+// items: "path:line" strings (path uses "/"). → grouped, deduped, prefix-factored block.
+function compactLocationLines(items) {
+  const byFile = new Map();
+  for (const it of items) {
+    const { p, ln } = splitPathLine(it);
+    if (!byFile.has(p)) byFile.set(p, []);
+    if (ln) byFile.get(p).push(ln);
+  }
+  const files = [...byFile.keys()];
+  const linesOf = (p) => [...new Set(byFile.get(p))].sort((a, b) => Number(a) - Number(b)).join(",");
+  const suffix = (p) => (linesOf(p) ? `:${linesOf(p)}` : "");
+  const prefix = commonDirPrefix(files);
+  if (prefix && files.length > 1) {
+    return `  under ${prefix}/\n` + files.map((p) => `    ${p.slice(prefix.length + 1)}${suffix(p)}`).join("\n");
+  }
+  return files.map((p) => `  ${p}${suffix(p)}`).join("\n");
+}
 function fmtLocations(locs, max, label) {
   const arr = Array.isArray(locs) ? locs : locs ? [locs] : [];
   const shown = arr.slice(0, max);
-  const body = shown.map((l) => `  @ ${locLine(l.uri, l.range)}`).join("\n");
   const more = arr.length - shown.length;
-  return `${arr.length} ${label}:\n${body}${more > 0 ? `\n… ${more} more.` : ""}`;
+  const tail = more > 0 ? `\n… ${more} more.` : "";
+  const body = compactResults()
+    ? compactLocationLines(shown.map((l) => locLine(l.uri, l.range)))
+    : shown.map((l) => `  @ ${locLine(l.uri, l.range)}`).join("\n");
+  return `${arr.length} ${label}:\n${body}${tail}`;
 }
+export { compactLocationLines, commonDirPrefix };
 // hover MarkupContent → a few plaintext lines (signature/type), no fenced code, no walls of text.
 function fmtHover(h) {
   if (!h || !h.contents) return "(no hover info)";

--- a/server/core.js
+++ b/server/core.js
@@ -11,7 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync, execSync } from "node:child_process";
 import { LspClient, fromUri, langIdForPath, envInt } from "./lsp.js";
-import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex } from "./backends/index.js";
+import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot } from "./backends/index.js";
 import { recordQueryResults, languageCensus } from "./warmset.js";
 import { splitSegments } from "./shell-split.js";
 import { compactGit, compactP4 } from "./compact.js";
@@ -32,6 +32,45 @@ export const BACKEND = cfg("VTS_BACKEND", "backend", ""); // "clangd" | "roslyn"
 export const MAX_RESULTS = parseInt(cfg("VTS_MAX_RESULTS", "maxResults", "60"), 10) || 60;
 export const PREWARM_BACKENDS = cfg("VTS_PREWARM_BACKENDS", "prewarmBackends", ""); // "" | auto | all | comma-list
 const CONFIG_KEYS = ["projectPath", "backend", "maxResults", "prewarmBackends", "tee", "excludeCommands", "usdPerMtok"];
+
+// ---- per-call project root resolution ----
+// The MCP server is ONE long-lived process serving every repo a session touches, so a single configured
+// projectPath can't be right for all of them. Resolve the root PER CALL instead, preferring the most
+// specific signal available. MCP_ROOTS is the workspace folder(s) the client (Claude Code) advertises via
+// the `roots` capability — set by the index.js handshake; empty when the client doesn't support roots, in
+// which case behavior collapses to exactly the old `PROJECT_PATH || cwd`.
+let MCP_ROOTS = [];
+export function setMcpRoots(paths) { MCP_ROOTS = (Array.isArray(paths) ? paths : []).filter((p) => typeof p === "string" && p); }
+export function getMcpRoots() { return MCP_ROOTS.slice(); }
+function isInside(root, target) {
+  try {
+    const rel = path.relative(path.resolve(root), path.resolve(target));
+    return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+  } catch { return false; }
+}
+// Root for an LSP/filesystem query. Precedence: (1) explicit a.projectPath; (2) the enclosing project of a
+// `path` argument — but only walk UP to a NEW root when the path falls OUTSIDE every known root (config pin
+// + MCP roots); a path INSIDE a known root keeps that root so clangd's compile-DB rooting is preserved;
+// (3) an MCP workspace root (current project) over the stale config pin; (4) PROJECT_PATH; (5) cwd.
+export function resolveRoot(a = {}) {
+  if (a.projectPath) return a.projectPath;
+  const known = [PROJECT_PATH, ...MCP_ROOTS].filter(Boolean);
+  const p = a.path || (Array.isArray(a.paths) ? a.paths.find((x) => typeof x === "string") : null);
+  if (p) {
+    const abs = path.isAbsolute(p) ? p : path.resolve(MCP_ROOTS[0] || PROJECT_PATH || process.cwd(), p);
+    const enclosing = known.find((r) => isInside(r, abs));
+    if (enclosing) return enclosing;                 // inside a known root → keep it (preserve rooting)
+    const found = findProjectRoot(abs);
+    if (found) return found;                          // outside all known roots → its real project
+  }
+  if (MCP_ROOTS.length) {
+    return MCP_ROOTS.find((r) => isInside(r, process.cwd())) || MCP_ROOTS[0];
+  }
+  return PROJECT_PATH || process.cwd();
+}
+// Root for a CWD-relative external command (git/p4): never the config pin (the user/agent runs these where
+// they ARE), but an MCP workspace root beats the long-lived server's own process.cwd().
+export function resolveCwdRoot(a = {}) { return a.projectPath || MCP_ROOTS[0] || process.cwd(); }
 
 const tok = (s) => Math.round(Buffer.byteLength(String(s), "utf8") / 4);
 // The token size of the RAW alternative a tool replaces. A STRING raw (vts_git/vts_p4 stdout) is exactly
@@ -344,7 +383,7 @@ function discoverReport(a = {}) {
   const { missed, rawTokTotal, learned, filesCount: fc, all, since } = r;
   const files = { length: fc };
   const learn = a.learn === true || a.learn === "true";
-  const learnRoot = a.projectPath || PROJECT_PATH || process.cwd();
+  const learnRoot = resolveRoot(a);
   const scope = (all ? "all time" : `last ${since} day(s)`) + (a.projectPath ? `, scoped to ${a.projectPath}` : "");
   // Synergy B: feed the files those bypassed searches actually hit into the warm-set's query-history, so
   // prewarm front-loads them next time — vts learns from the greps it didn't run.
@@ -898,7 +937,7 @@ export async function runTool(name, a = {}) {
     if (name === "vts_savings_reset") { try { fs.writeFileSync(SAVINGS_FILE, "{}"); } catch { /* ignore */ } return out("Savings ledger cleared."); }
     if (name === "vts_discover") return out(discoverReport(a));
     if (name === "vts_warmup") {
-      const root = a.projectPath || PROJECT_PATH || process.cwd();
+      const root = resolveRoot(a);
       const backendName = a.backend || BACKEND || pickBackend(root);
       if (!backendName) return err(`No backend to warm. Pass backend=clangd|roslyn or ensure ${root} has compile_commands.json / a .sln.`);
       const t0 = Date.now();
@@ -908,7 +947,7 @@ export async function runTool(name, a = {}) {
     if (name === "vts_gen_compile_db") {
       // The user's choice: run UBT GenerateClangDatabase for full semantic clangd, OR don't and stay in
       // no-DB text mode. DRY RUN by default (prints the exact command); apply=true runs it (minutes).
-      const root = a.projectPath || PROJECT_PATH || process.cwd();
+      const root = resolveRoot(a);
       const plan = genCompileDbPlan(root, a);
       if (plan.error) return err(plan.error);
       const apply = a.apply === true || a.apply === "true";
@@ -962,7 +1001,7 @@ export async function runTool(name, a = {}) {
     // is set, and are the sanctioned, token-capped replacements for `find -name` / `grep`.
     if (name === "find_files") {
       if (!a.q) return err("find_files needs q (a filename substring or glob like *Manager.cpp).");
-      const root = a.projectPath || PROJECT_PATH || process.cwd();
+      const root = resolveRoot(a);
       const max = Number(a.maxResults) || MAX_RESULTS;
       const files = findFilesUnder(root, String(a.q), max);
       if (!files.length) return finishOut([], `No files matching "${a.q}" under ${root}.` + LOG_EMPTY_HINT);
@@ -972,7 +1011,7 @@ export async function runTool(name, a = {}) {
     }
     if (name === "search_text") {
       if (!a.q) return err("search_text needs q (a string or regex to find in code).");
-      const root = a.projectPath || PROJECT_PATH || process.cwd();
+      const root = resolveRoot(a);
       const max = Number(a.maxResults) || MAX_RESULTS;
       // Target selection — naming a file/glob auto-includes WHATEVER extension it is (no docs flag needed):
       //   path=README.md  → search that one file (any ext)
@@ -1010,7 +1049,7 @@ export async function runTool(name, a = {}) {
     if (name === "vts_git" || name === "vts_p4") {
       // git/p4 are cwd-relative — run where the user/agent IS, not the configured PROJECT_PATH (which would
       // surprise: `vts git status` in repo B showing the configured repo A). Explicit projectPath still wins.
-      const root = a.projectPath || process.cwd();
+      const root = resolveCwdRoot(a);
       const max = Number(a.maxResults) || MAX_RESULTS;
       const bin = name === "vts_git" ? "git" : "p4";
       const argv = toArgv(a);
@@ -1043,7 +1082,7 @@ export async function runTool(name, a = {}) {
       return finishOut(raw, `${bin} ${argv.join(" ")} (compacted):\n${body}`);
     }
 
-    const root = a.projectPath || PROJECT_PATH || process.cwd();
+    const root = resolveRoot(a);
     const backendName = a.backend || BACKEND || pickBackend(root);
     // search_symbol degrades gracefully when NO backend resolves (text fallback) instead of hard-erroring —
     // so the grep-rewrite hook can always route an identifier to `vts symbol` (semantic when a backend

--- a/server/index.js
+++ b/server/index.js
@@ -9,9 +9,10 @@
  * async); the handler awaits it. Each LSP backend is spawned lazily and cached for the process — we
  * dispose clients on shutdown so no language-server child is left running.
  */
-import { Server, StdioServerTransport, ListToolsRequestSchema, CallToolRequestSchema } from "./sdk.js";
-import { runTool, disposeClients, prewarm, autoLearn, PROJECT_PATH, BACKEND, PREWARM_BACKENDS } from "./core.js";
+import { Server, StdioServerTransport, ListToolsRequestSchema, CallToolRequestSchema, RootsListChangedNotificationSchema } from "./sdk.js";
+import { runTool, disposeClients, prewarm, autoLearn, setMcpRoots, getMcpRoots, PROJECT_PATH, BACKEND, PREWARM_BACKENDS } from "./core.js";
 import { pickBackend } from "./backends/index.js";
+import { fromUri } from "./lsp.js";
 import { prewarmBackends } from "./warmset.js";
 
 const log = (...a) => console.error("[vs-token-safer]", ...a);
@@ -257,35 +258,58 @@ for (const sig of ["SIGINT", "SIGTERM"]) {
   process.on(sig, async () => { try { await disposeClients(); } catch { /* ignore */ } process.exit(0); });
 }
 
+// MCP roots handshake: the client (Claude Code) advertises its workspace folder(s) via the `roots`
+// capability. Used to resolve a per-call project root, so ONE globally-installed server serves every repo
+// a session touches instead of being pinned to a single configured projectPath (resolveRoot in core.js).
+// Degrades silently to "no roots" (→ PROJECT_PATH || cwd, the old behavior) when the client doesn't
+// advertise roots. Re-fetched on roots/list_changed so switching the workspace updates the resolution.
+async function refreshRoots() {
+  try {
+    const caps = server.getClientCapabilities?.();
+    if (!caps || !caps.roots) return;
+    const res = await server.listRoots();
+    const paths = (res?.roots || []).map((r) => { try { return fromUri(r.uri); } catch { return null; } }).filter(Boolean);
+    setMcpRoots(paths);
+    if (paths.length) log(`workspace roots: ${paths.join(", ")}`);
+  } catch (e) { log(`roots query failed: ${e.message}`); }
+}
+if (RootsListChangedNotificationSchema) {
+  try { server.setNotificationHandler(RootsListChangedNotificationSchema, () => refreshRoots()); } catch { /* client/SDK without roots — ignore */ }
+}
+
 await server.connect(new StdioServerTransport());
 log("ready on stdio.");
+await refreshRoots(); // populate MCP_ROOTS before prewarm so a config-less install warms the current workspace
 
-// IDE-style background pre-warm: when a project root is configured, spawn + index the backend now so
-// the user's first search reuses an already-warming/warm client instead of paying cold warmup inline.
-// Default on when projectPath is set; disable with VTS_PREWARM=0 (fire-and-forget — never blocks boot).
-if (PROJECT_PATH && envBool("VTS_PREWARM", true)) {
+// IDE-style background pre-warm: spawn + index the backend now so the user's first search reuses an
+// already-warming/warm client instead of paying cold warmup inline. The warm root is the configured
+// projectPath, or — for a config-less global install — the first MCP workspace root. Only ONE root is
+// prewarmed (never every advertised root — that would defeat the backend-pool memory guard). Default on;
+// disable with VTS_PREWARM=0 (fire-and-forget — never blocks boot).
+const warmRoot = PROJECT_PATH || getMcpRoots()[0] || "";
+if (warmRoot && envBool("VTS_PREWARM", true)) {
   // Single dominant backend by default; VTS_PREWARM_BACKENDS=all (or a comma list) warms every detected
   // language, each with its language-proportional adaptive cap (warmCap). Fire-and-forget — never blocks boot.
-  const picked = BACKEND || pickBackend(PROJECT_PATH);
-  const backends = prewarmBackends(PROJECT_PATH, picked, process.env.VTS_PREWARM_BACKENDS || PREWARM_BACKENDS);
+  const picked = BACKEND || pickBackend(warmRoot);
+  const backends = prewarmBackends(warmRoot, picked, process.env.VTS_PREWARM_BACKENDS || PREWARM_BACKENDS);
   for (const backend of backends) {
-    log(`pre-warming ${backend} index for ${PROJECT_PATH} …`);
-    prewarm(PROJECT_PATH, backend).then(
+    log(`pre-warming ${backend} index for ${warmRoot} …`);
+    prewarm(warmRoot, backend).then(
       (c) => { if (c) log(`index warm (${backend}).`); },
       (e) => log(`pre-warm failed (${backend}): ${e.message}`),
     );
   }
 }
 
-// Boot-time self-improvement (VTS_AUTO_LEARN, default on when projectPath is set): harvest the files
+// Boot-time self-improvement (VTS_AUTO_LEARN, default on when a warm root exists): harvest the files
 // that recent BYPASSED code searches actually hit (local transcript scan, bounded, read-only) into the
 // warm-set query-history — the same write `vts discover --learn` does, with no human in the loop. The
 // next warm-up front-loads what past sessions really searched for. Deferred so boot/prewarm goes first.
-if (PROJECT_PATH && envBool("VTS_AUTO_LEARN", true)) {
+if (warmRoot && envBool("VTS_AUTO_LEARN", true)) {
   setTimeout(() => {
     try {
-      const n = autoLearn(PROJECT_PATH, 7);
-      if (n) log(`auto-learn: ${n} file(s) from recent bypassed searches → warm-set for ${PROJECT_PATH}.`);
+      const n = autoLearn(warmRoot, 7);
+      if (n) log(`auto-learn: ${n} file(s) from recent bypassed searches → warm-set for ${warmRoot}.`);
     } catch { /* best-effort — never disturb the server */ }
   }, 3000).unref?.();
 }

--- a/server/lsp.js
+++ b/server/lsp.js
@@ -281,7 +281,16 @@ export class LspClient {
     });
   }
   async shutdown() {
-    try { await this.request("shutdown", null, 3000); this.notify("exit", null); } catch { /* ignore */ }
+    // Teardown must RELIABLY release the child + all its handles — the backend-pool memory guard depends
+    // on an evicted client actually freeing its process (else the LRU/idle reap leaves zombies and memory
+    // never drops). A graceful LSP shutdown round-trip is skipped on purpose: it queued a WriteWrap to a
+    // child that may have stopped reading and a 3s pending request, both of which kept the event loop
+    // alive after teardown (eval hung post-PASS; CI never exited the test step). Kill decisively, reject
+    // any pending requests so their timeout timers clear, and destroy the stdio pipes so no queued write
+    // lingers. clangd/roslyn handle SIGTERM/TerminateProcess fine (shards are written atomically).
     try { this.proc && this.proc.kill(); } catch { /* ignore */ }
+    try { this._failAll(new Error("client shut down")); } catch { /* ignore */ }
+    try { this.proc?.stdin?.destroy(); this.proc?.stdout?.destroy(); this.proc?.stderr?.destroy(); } catch { /* ignore */ }
+    this.proc = null;
   }
 }

--- a/server/sdk.js
+++ b/server/sdk.js
@@ -90,4 +90,6 @@ const load = (sub) => import(pathToFileURL(req.resolve("@modelcontextprotocol/sd
 
 export const { Server } = await load("server/index.js");
 export const { StdioServerTransport } = await load("server/stdio.js");
-export const { ListToolsRequestSchema, CallToolRequestSchema } = await load("types.js");
+// RootsListChangedNotificationSchema may be absent on very old SDKs — destructuring then yields undefined,
+// which index.js guards before use (the roots handshake degrades to "no roots" gracefully).
+export const { ListToolsRequestSchema, CallToolRequestSchema, RootsListChangedNotificationSchema } = await load("types.js");


### PR DESCRIPTION
One coherent theme: make a single globally-installed vs-token-safer server actually useful across **every** repo a session touches, bound its memory, and squeeze the most repetitive output.

`vts discover` surfaced the problem: with the server pinned to one configured `projectPath`, a search on any OTHER repo returned 0 → the model abandoned vts and fell back to the Grep tool (223 of 283 recent bypasses; the live ledger went idle for 3 days while a UE project was worked on). The server was dead weight everywhere except the pinned project.

## What changed

**A1+A2 — per-call project root (`62ad903`)**
- `resolveRoot(a)` replaces the single-pin `a.projectPath || PROJECT_PATH || cwd` for every query. Precedence: explicit `projectPath` > a `path`'s enclosing project (`findProjectRoot` walk-up, only when OUTSIDE every known root so an inside-path keeps clangd's compile-DB rooting) > an MCP workspace root > `PROJECT_PATH` > cwd.
- `findProjectRoot(start)` (backends): bounded walk UP to the nearest marker (compile_commands / *.uproject / .sln / .csproj / tsconfig / package.json / pyproject / … / `.git` as the repo boundary).
- MCP `roots` handshake in index.js (`getClientCapabilities`→`listRoots`→`setMcpRoots`, re-fetched on `roots/list_changed`). No roots advertised → collapses to the old `PROJECT_PATH || cwd` (zero behavior change for single-project use).
- git/p4 use `resolveCwdRoot` (MCP root beats the server's own cwd). Boot prewarm/auto-learn warm `PROJECT_PATH || first MCP root`.

**A3 — bounded backend pool (`afbea78`)** — the memory guard that makes dynamic roots safe.
- `VTS_MAX_BACKENDS` (2): LRU-evict the least-recently-used idle client past the cap.
- `VTS_BACKEND_IDLE_MS` (300000, 0=off): unref'd sweep reaps idle clients.
- A client with an in-flight request (`pending.size`) is never evicted/reaped. Steady state ≈ 1 warm backend; bouncing 2 repos keeps both warm; a 3rd evicts LRU.

**Output cap v2 — collapse refs repetition (`a6068aa`)**
- `find_references` (the code-mod primitive) collapsed: one row per FILE (line numbers joined/deduped/sorted: `Foo.cpp:42,88,120`) + a common directory prefix factored out once (`under <prefix>/`). Every location preserved + recoverable. Est. ~4× (coalesce) → ~10× (prefix) on a deep UE refs result. `VTS_COMPACT_RESULTS=0` restores the classic shape.

## Review points
- **`resolveRoot` precedence** — is "inside a known root keeps that root, only walk-up when OUTSIDE" the right call to preserve clangd compile-DB rooting? (core.js)
- **Pool eviction safety** — `pending.size` is the only in-flight guard; a client mid-warmup (promise unresolved, `client===null`) is counted toward the cap but not evictable → transient over-cap. Acceptable?
- **MCP roots runtime** — `server.listRoots()` is fully try/catch-guarded; verified by graceful-degrade logic, but live boot of this index.js path is only confirmable post-reinstall (the running server is the published plugin).
- **Output shape change** — `path:42,88` instead of `@ path:42` per line; any consumer regexing `@ ` per-row? (none in-repo; code-locator agent reads the block, not per-line.)

## Verification
- eval **48/48** (3 new guards: 45 pool LRU/idle/in-flight, 46 root resolution precedence, 47 output-cap v2 + toggle). lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)