### PR TITLE
feat: enforcement v2 — block clear symbol-hunt Greps; discover counts Glob; agent-directed copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,13 +106,23 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   `server/shell-split.js`, SHARED with `vts discover` so enforcement and measurement agree): a `|` inside
   quotes is pattern, not pipeline — so `grep "FooA|FooB"` / `grep "^#include"` (the top bypass shapes per
   `vts discover`) rewrite to `vts text` (regex); inside double quotes `\"` is an escaped literal; SAFE_TEXT
-  allows `| ^ #` (always double-quoted; `$`/space/backslash still rejected). The Grep TOOL stays warn-only but `grepNudgeFor` embeds a
-  READY-TO-USE equivalent call (identifier→search_symbol, regex→search_text) in the nudge. `VTS_REWRITE=0`
-  → block instead of rewrite; `excludeCommands` (config) / `VTS_EXCLUDE_COMMANDS` (csv) opt a command out;
-  escape hatch `VTS_ENFORCE=0`. The human-facing block/nudge/log messages are i18n'd: `uiLang()` picks
-  Korean when `VTS_LANG`/config `lang` is `ko` OR the OS locale (Intl) is `ko-*`, else English — and the
-  block copy is deliberately REASSURING (a red box is just the hook saying "hold on", not a failure) + leads
-  with the token-savings win. `VTS_LANG=en|ko` forces it.
+  allows `| ^ #` (always double-quoted; `$`/space/backslash still rejected). `grepNudgeFor` embeds a
+  READY-TO-USE equivalent call (identifier→search_symbol, regex→search_text) in every Grep nudge/block.
+  GREP-TOOL enforcement v2 (A+): a clear SYMBOL HUNT — a bare identifier OR a regex with a code-structural
+  cue (`::` / a literal `(` / `void·class·struct·enum·template`) per `isSymbolHuntGrep` — is BLOCKED (exit 2)
+  and routed to search_symbol/search_text; freeform text AND bare identifier-alternation (`TODO|FIXME`) stay
+  WARN (no false-positive block). `VTS_GREP_BLOCK=0` reverts the escalation to warn-only. Measured: symbol
+  hunts ≈ 64% of Grep-tool result tokens; freeform left alone. GLOB/Search TOOL (filename search): warn-only
+  nudge → `find_files` (a different tool, can't updatedInput-rewrite), source-signal-gated (`isCodeGlobTool`);
+  the built-in Glob has no cap + times out on a giant UE tree. find_files/search_text are walk-BOUNDED:
+  shared `SKIP_DIRS` (node_modules/Intermediate/Binaries/Saved/build/… ) + a 4s time box so a huge tree can't
+  hang them. `vts discover` now also counts the Glob tool as a find_files bypass. `VTS_REWRITE=0` → block
+  instead of rewrite; `excludeCommands` (config) / `VTS_EXCLUDE_COMMANDS` (csv) opt a command out; escape hatch
+  `VTS_ENFORCE=0`. Messages i18n'd (`uiLang()`: Korean when `VTS_LANG`/config `lang`=`ko` OR OS locale `ko-*`,
+  else English; `VTS_LANG=en|ko` forces). Copy is AGENT-DIRECTED — the actionable part instructs the assistant
+  ("re-run with the vts tool matching the intent" + the concrete call), with a brief human-facing reassurance
+  that the red box is a redirect ("hold on"), not a failure — the hook output is consumed by the MODEL, which
+  is the one that re-runs, not a human picking from a menu.
 - `skills/vs-search/SKILL.md` — routing. `commands/{setup,savings}.md`.
 - `eval/run.mjs` + `eval/_mock-lsp.mjs` — mock-LSP eval (no toolchain). Add a guard for every new path.
 - Config dir `~/.vs-token-safer`, env prefix `VTS_`. MCP server name `vs-search`.

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -246,7 +246,7 @@ const runHook = (payload, env) => {
 const hCode = runHook({ tool_name: "Bash", tool_input: { command: "grep -rn Foo src/Thing.cpp" } });
 const hCodeBlock = runHook({ tool_name: "Bash", tool_input: { command: "grep -rn Foo src/Thing.cpp" } }, { VTS_REWRITE: "0" });
 const hLog = runHook({ tool_name: "Bash", tool_input: { command: "grep Error Saved/Logs/run.log" } });
-const hGrep = runHook({ tool_name: "Grep", tool_input: { pattern: "Foo", glob: "*.ts" } });
+const hGrep = runHook({ tool_name: "Grep", tool_input: { pattern: "return null", glob: "*.ts" } }); // freeform code text → warns (not a symbol hunt)
 const hGrepLog = runHook({ tool_name: "Grep", tool_input: { pattern: "Error", path: "Saved/Logs" } }); // bare Logs dir
 let hCodeJson = {}; try { hCodeJson = JSON.parse(hCode.out || "{}"); } catch { /* ignore */ }
 const rwOut = hCodeJson.hookSpecificOutput || {};
@@ -540,11 +540,13 @@ try { fs.rmSync(nobeDir, { recursive: true, force: true }); } catch { /* ignore 
 // autoLearn() — the boot-time hook — harvests bypassed-search result files into the warm-set with no
 // human in the loop (same write as discover --learn).
 const nudgeCtx = (r) => { try { return JSON.parse(r.out || "{}").hookSpecificOutput?.additionalContext || ""; } catch { return ""; } };
-const nIdent = nudgeCtx(runHook({ tool_name: "Grep", tool_input: { pattern: "Foo", glob: "*.ts" } }));
+// A bare identifier is now BLOCKED (enforcement v2 A+), so its concrete nudge lands in the block stderr;
+// a non-symbol-hunt alternation still WARNS (additionalContext). Read each from where it now lives.
+const nIdent = runHook({ tool_name: "Grep", tool_input: { pattern: "Foo", glob: "*.ts" } }).err;
 const nRegex = nudgeCtx(runHook({ tool_name: "Grep", tool_input: { pattern: "FooA|FooB", glob: "*.cpp" } }));
 const nudgeOk =
-  /find_references symbol="Foo"/.test(nIdent) && /search_symbol q="Foo"/.test(nIdent) && // identifier → usages + decl
-  /search_text q="FooA\|FooB"/.test(nRegex); // regex → text suggestion
+  /find_references symbol="Foo"/.test(nIdent) && /search_symbol q="Foo"/.test(nIdent) && // identifier → usages + decl (in the block msg)
+  /search_text q="FooA\|FooB"/.test(nRegex); // regex (no structural cue) → warn with a text suggestion
 const alRoot = path.join(os.tmpdir(), `vts-eval-${process.pid}-alproj`);
 fs.mkdirSync(path.join(alRoot, "P--x"), { recursive: true });
 fs.writeFileSync(path.join(alRoot, "P--x", "s.jsonl"), [
@@ -823,7 +825,7 @@ const polishOk = gitCwdOk && p4ChangesOk && dedupWordOk && benignOk;
 // 44) i18n: VTS_LANG=ko renders the block + Grep nudge in Korean; en stays English (forced en above keeps
 // every other assertion deterministic). A Korean user (ko-KR locale) auto-gets Korean.
 const hKoBlock = runHook({ tool_name: "Bash", tool_input: { command: "grep -rn Foo src/Thing.cpp" } }, { VTS_REWRITE: "0", VTS_LANG: "ko" });
-const hKoNudge = nudgeCtx(runHook({ tool_name: "Grep", tool_input: { pattern: "Foo", glob: "*.ts" } }, { VTS_LANG: "ko" }));
+const hKoNudge = runHook({ tool_name: "Grep", tool_input: { pattern: "Foo", glob: "*.ts" } }, { VTS_LANG: "ko" }).err; // identifier → blocked; KO nudge is in the block stderr
 const hEnBlock = runHook({ tool_name: "Bash", tool_input: { command: "grep -rn Foo src/Thing.cpp" } }, { VTS_REWRITE: "0", VTS_LANG: "en" });
 const i18nOk =
   hKoBlock.status === 2 && /코드 검색을 가로챘어요/.test(hKoBlock.err) && /find_references symbol="Foo"/.test(hKoNudge) &&
@@ -925,11 +927,11 @@ const capResultsOk = capV2Ok && capSingleOk && capToggleOk;
 // glob is NOT nudged. And find_files SKIPS heavy build/dep dirs (node_modules/Intermediate/Binaries/…) so a
 // giant UE tree can't time it out like the built-in Glob did.
 const hGlobCode = nudgeCtx(runHook({ tool_name: "Glob", tool_input: { pattern: "**/*.cpp" } }));
-const hGlobFile = nudgeCtx(runHook({ tool_name: "Glob", tool_input: { pattern: "**/TSCheatManager.*" } }));
+const hGlobFile = nudgeCtx(runHook({ tool_name: "Glob", tool_input: { pattern: "**/FooManager.*" } }));
 const hGlobDoc = runHook({ tool_name: "Glob", tool_input: { pattern: "**/*.md" } });
 const globNudgeOk =
   /find_files q="\*\.cpp"/.test(hGlobCode) && /Glob/.test(hGlobCode) &&            // code glob → find_files nudge
-  /find_files q="TSCheatManager\.\*"/.test(hGlobFile) &&                           // specific source file → nudged
+  /find_files q="FooManager\.\*"/.test(hGlobFile) &&                                // specific source file → nudged
   hGlobDoc.status === 0 && !/find_files/.test(nudgeCtx(hGlobDoc));                 // doc glob → no nudge
 const skipRoot = path.join(os.tmpdir(), `vts-eval-${process.pid}-skip`);
 fs.mkdirSync(path.join(skipRoot, "src"), { recursive: true });
@@ -942,6 +944,35 @@ const ffSkip = await runTool("find_files", { q: "*.cpp", projectPath: skipRoot }
 const skipOk = !ffSkip.isError && /Real\.cpp/.test(ffSkip.text) && !/Gen\.cpp/.test(ffSkip.text) && !/Dep\.cpp/.test(ffSkip.text);
 try { fs.rmSync(skipRoot, { recursive: true, force: true }); } catch { /* ignore */ }
 const globAndWalkOk = globNudgeOk && skipOk;
+
+// 50) enforcement v2 (A+): a SYMBOL-HUNT Grep is BLOCKED (exit 2 → search_symbol/search_text); a bare
+// identifier blocks; freeform text (TODO|FIXME) and bare identifier-alternation (FooBar|BazQux) stay WARN
+// (no false-positive block); VTS_GREP_BLOCK=0 reverts to warn; a doc-target (*.md) isn't blocked. Plus
+// discover now counts the built-in Glob/Search tool as a find_files bypass.
+const hSymHunt = runHook({ tool_name: "Grep", tool_input: { pattern: "::FooWidget\\b|void.*FooWidget\\(", path: "src/lib" } });
+const hIdentBlk = runHook({ tool_name: "Grep", tool_input: { pattern: "FooWidget", path: "src/lib" } });
+const hFreeform = runHook({ tool_name: "Grep", tool_input: { pattern: "TODO|FIXME", path: "src/lib" } });
+const hAltern = runHook({ tool_name: "Grep", tool_input: { pattern: "BarA|BarB", path: "src/lib" } });
+const hSymOff = runHook({ tool_name: "Grep", tool_input: { pattern: "void.*FooWidget\\(", path: "src/lib" } }, { VTS_GREP_BLOCK: "0" });
+const hSymDoc = runHook({ tool_name: "Grep", tool_input: { pattern: "FooWidget", glob: "*.md" } });
+const enforceV2Ok =
+  hSymHunt.status === 2 && /search_text q="/.test(hSymHunt.err) && /caught a SYMBOL/.test(hSymHunt.err) && // structural-cue regex → block
+  hIdentBlk.status === 2 && /find_references symbol="FooWidget"/.test(hIdentBlk.err) &&                    // bare identifier → block
+  hFreeform.status === 0 && hAltern.status === 0 &&    // freeform text + bare alternation → NOT blocked (warn)
+  hSymOff.status === 0 &&                              // VTS_GREP_BLOCK=0 → reverts to warn
+  hSymDoc.status === 0;                                // doc target (*.md) → not blocked
+const glProj = path.join(os.tmpdir(), `vts-eval-${process.pid}-globdisc`);
+fs.mkdirSync(path.join(glProj, "G--proj"), { recursive: true });
+const GNOW = new Date().toISOString();
+fs.writeFileSync(path.join(glProj, "G--proj", "t.jsonl"),
+  JSON.stringify({ type: "assistant", cwd: glProj, timestamp: GNOW, message: { role: "assistant", content: [{ type: "tool_use", id: "g1", name: "Glob", input: { pattern: "**/*Manager.cpp" } }] } }) + "\n" +
+  JSON.stringify({ type: "user", cwd: glProj, timestamp: GNOW, message: { role: "user", content: [{ type: "tool_result", tool_use_id: "g1", content: "a.cpp\nb.cpp\n".repeat(40) }] } }) + "\n");
+process.env.VTS_CLAUDE_PROJECTS = glProj;
+const discGlob = await runTool("vts_discover", { since: 7 });
+delete process.env.VTS_CLAUDE_PROJECTS;
+const globDiscOk = !discGlob.isError && /Glob×\d/.test(discGlob.text); // discover groups bypasses by tool → "Glob×1"
+try { fs.rmSync(glProj, { recursive: true, force: true }); } catch { /* ignore */ }
+const enforceAndDiscoverOk = enforceV2Ok && globDiscOk;
 
 await disposeClients();
 // 48) clean teardown (no orphaned child): disposeClients must terminate EVERY spawned language-server
@@ -1011,6 +1042,7 @@ const rows = [
   ["output cap v2: refs collapse per-file + common-prefix factor (toggle)", capResultsOk, "true", capResultsOk],
   ["clean teardown: no orphaned LSP child after disposeClients", teardownOk, "true", teardownOk],
   ["Glob-tool nudge → find_files + find_files skips heavy dirs", globAndWalkOk, "true", globAndWalkOk],
+  ["enforce v2: symbol-hunt Grep blocks, freeform warns + discover counts Glob", enforceAndDiscoverOk, "true", enforceAndDiscoverOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -286,6 +286,41 @@ function grepNudgeFor(ti) {
       "code-locator subagent." + concrete + " For a JUST-edited / unindexed file or a quick literal peek, " +
       "Grep is fine — carry on. Disable: VTS_ENFORCE=0.";
 }
+// enforcement v2 (A+): a Grep-TOOL pattern HUNTING A NAMED SYMBOL is escalated from warn to BLOCK — a
+// semantic tool is strictly better there (smaller, exact, no regex false positives — `void.*Foo\(` also
+// matches `SetActiveFoo`). A symbol hunt that we BLOCK = a bare identifier, OR a regex carrying a ≥4-char
+// identifier AND a code-structural cue (:: , a literal `(` call, or a C++/decl keyword). Those cues don't
+// occur in prose or keyword greps, so the block is false-positive-safe. NOT blocked (stays warn): freeform
+// text (message fragments) AND bare identifier-alternation — `TODO|FIXME` / `ERROR|WARN` look like symbol
+// alternations but are legit keyword greps, so alternation alone never blocks (the model can still take the
+// warn's search_text). A `::Foo\b|void.*Foo\(` pattern carries `::` + `(` → blocked; a `TODO|FIXME` doesn't.
+function isSymbolHuntGrep(ti) {
+  const pat = String(ti.pattern || "");
+  if (!pat || pat.length > 200) return false;
+  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(pat)) return true;                       // bare identifier → search_symbol
+  if (!/[A-Za-z_][A-Za-z0-9_]{3,}/.test(pat)) return false;                    // no real identifier token → not a symbol hunt
+  return /::|\\\(|\bvoid\b|\bclass\b|\bstruct\b|\benum\b|\btemplate\b/.test(pat); // code-structural cue only (no alternation)
+}
+// Don't block a search explicitly aimed at non-code (a doc/asset glob or path) even if the pattern looks
+// symbol-ish — the symbol may legitimately be referenced in a .md/.json.
+function notTextLogTarget(ti) {
+  const glob = String(ti.glob || ""); const p = String(ti.path || "");
+  return !(TEXT_TARGET_RE.test(glob.toLowerCase()) || TEXT_TARGET_RE.test(p.toLowerCase()) || LOG_TARGET_RE.test(glob) || LOG_TARGET_RE.test(p));
+}
+// Block default-ON; VTS_GREP_BLOCK=0/false/off reverts the symbol-hunt escalation to warn-only.
+const grepBlockOn = () => !/^(0|false|off|no)$/i.test(String(process.env.VTS_GREP_BLOCK ?? "1"));
+// Reassuring block copy for a symbol-hunt Grep — leads with the win (tokens + accuracy), frames the red box
+// as a friendly "hold on", and embeds the READY-TO-USE search_symbol/search_text call (grepNudgeFor).
+function grepBlockMsg(ti) {
+  const head = KO
+    ? "✨ vs-token-safer가 심볼 검색을 가로챘어요 — 고장이 아니라 의도된 동작이고, 토큰 절약 + 정확도↑입니다. 🎉\n" +
+      "(빨간 박스는 훅이 \"잠깐\"이라고 말하는 신호일 뿐, 실패가 아니에요.)\n" +
+      "이 패턴은 '심볼 사냥'이라 시맨틱 도구가 더 작고 정확합니다 (정규식 거짓양성 없음 — `void.*Foo\\(`는 `SetActiveFoo`도 긁어요):\n"
+    : "✨ vs-token-safer caught a SYMBOL search — intended, not broken; it saves tokens AND improves accuracy. 🎉\n" +
+      "(The red box is just the hook saying \"hold on\" — not a failure.)\n" +
+      "This pattern is a symbol hunt → a semantic tool is smaller + exact (no regex false positives — `void.*Foo\\(` also catches `SetActiveFoo`):\n";
+  return head + grepNudgeFor(ti) + (KO ? "\nwarn-only로 되돌리려면: VTS_GREP_BLOCK=0." : "\nPrefer warn-only? VTS_GREP_BLOCK=0.");
+}
 // Glob / Search TOOL — the built-in filename search. vts's find_files is the token-capped, walk-bounded
 // equivalent (skips Intermediate/Binaries/node_modules, time-boxed) — the built-in Glob has no result cap
 // and times out on a giant tree (a real UE dead-end: the model gave up on file search entirely). Warn-only
@@ -327,13 +362,13 @@ const BLOCK_MSG = KO
   ? "✨ vs-token-safer가 코드 검색을 가로챘어요 — 고장난 게 아니라 의도된 동작이고, 토큰을 왕창 아꼈습니다. 🎉\n" +
     "(빨간 박스는 훅이 \"잠깐\"이라고 말하는 유일한 방법이에요 — 실패가 아니라 친절한 안내입니다.)\n" +
     "같은 검색을 언어 서버 인덱스로 하면 file:line으로 토큰캡되어 보통 ~90% 작고(큰 repo면 20~60배),\n" +
-    "grep의 거짓 양성(주석·문자열·유사명)도 없습니다. 맞는 도구를 골라 더 작고 정확한 결과를 누리세요:\n" +
+    "grep의 거짓 양성(주석·문자열·유사명)도 없습니다. 어시스턴트는 이 검색을 의도에 맞는 vts 도구로 다시 실행하세요:\n" +
     "  - 심볼 / 클래스 / 함수 / 타입   → search_symbol   (q, projectPath, backend, maxResults)\n" +
     "  - 참조 / 사용처                 → find_references (symbol — 이름만; 코드수정 primitive)\n" +
     "  - 정의로 이동                   → goto_definition (path, line, character — 0-based)\n" +
     "  - 원시 텍스트 / 문자열 / 주석   → search_text     (q, projectPath) — 토큰캡 grep\n" +
     "  - 파일명 검색                   → find_files      (q, projectPath) — glob 또는 부분일치\n" +
-    "또는 컨텍스트 격리 `code-locator` 서브에이전트에 통째로 위임하세요.\n" +
+    "또는 컨텍스트 격리 `code-locator` 서브에이전트에 위임할 수 있습니다.\n" +
     "CLI(비-MCP): `vts symbol --q <이름> --projectPath <루트>` (vts text / files / hover 도).\n" +
     "백엔드는 루트에서 자동 감지(compile_commands.json→clangd, .sln/.csproj→roslyn, tsconfig/package.json→typescript, pyproject/*.py→pyright).\n" +
     "팁: 단순한 grep 하나는 자동 변환됩니다(빨간 박스 없음) — 이번 건 여러 부분이라 차단됐으니 위 중 하나를 실행하세요. " +
@@ -342,7 +377,7 @@ const BLOCK_MSG = KO
     "purpose, and it just saved you a pile of tokens. 🎉 (A red box is the only way a hook can say\n" +
     "\"hold on\" — it's a friendly redirect, not a failure.) The very same lookup through the language-server\n" +
     "index comes back token-capped to file:line, usually ~90% smaller (often 20–60× on a big repo), and\n" +
-    "WITHOUT grep's false positives. Pick the matching tool and enjoy the smaller, sharper result:\n" +
+    "WITHOUT grep's false positives. The assistant should re-run this lookup with the vts tool matching the intent:\n" +
     "  - symbol / class / function / type → search_symbol  (args: q, projectPath, backend, maxResults)\n" +
     "  - references / usages of a symbol  → find_references (args: symbol — just the name; the edit primitive)\n" +
     "  - definition of a symbol           → goto_definition (args: path, line, character — 0-based)\n" +
@@ -376,9 +411,14 @@ process.stdin.on("end", () => {
   // message we emit (the user is already mid-grep, exactly when configuring helps).
   const setup = notSetUp() ? SETUP_LINE : "";
 
-  // Grep TOOL — warn-only, never block (Grep is the sanctioned fallback).
+  // Grep TOOL — enforcement v2 (A+): a clear SYMBOL HUNT is BLOCKED (semantic tool is strictly better);
+  // everything else stays warn-only (Grep is the sanctioned fallback for freeform text / just-edited files).
   if (toolName === "Grep") {
     if (isLogGrepTool(ti)) emitWarn(LOG_NUDGE + setup);
+    else if (grepBlockOn() && isSymbolHuntGrep(ti) && notTextLogTarget(ti)) {
+      process.stderr.write(grepBlockMsg(ti) + setup + "\n");
+      process.exit(2); // block — route the symbol hunt to search_symbol / search_text
+    }
     else if (isCodeGrepTool(ti)) emitWarn(grepNudgeFor(ti) + setup);
     process.exit(0);
   }

--- a/server/core.js
+++ b/server/core.js
@@ -291,6 +291,18 @@ function matchBypass(name, input) {
       return { tool: "Grep", q: cleanQ(String(input.pattern || "")) };
     }
   }
+  if (name === "Glob") {
+    // The built-in Glob/Search tool is a FILENAME search — a bypass of find_files (token-capped + walk-
+    // bounded). Count it when it targets source (code-ext glob, code dir, or a specific Name.* form); a
+    // doc/asset/log glob is skipped (find_files isn't the better tool there).
+    const pat = String(input.pattern || "");
+    const base = (pat.replace(/\\/g, "/").split("/").pop() || "").toLowerCase();
+    const p = String(input.path || "").replace(/\\/g, "/").toLowerCase();
+    if (DISCOVER_TEXT_TGT.test(base) || DISCOVER_TEXT_TGT.test(p)) return null;
+    if (DISCOVER_CODE_EXT.test(base) || DISCOVER_CODE_DIR.test(p) || /[a-z0-9_]\.[*a-z0-9]+$/.test(base)) {
+      return { tool: "Glob", q: cleanQ(pat) };
+    }
+  }
   return null;
 }
 // Shared transcript scan: find bypassed code searches and (always, cheaply) harvest the source-file


### PR DESCRIPTION
Dogfooding showed the **Grep TOOL** is the dominant bypass — measured **1653 calls / ~596k result tokens / 30 days**, all warn-only and largely ignored (a warn has no forcing function). The v0.19 per-call-root fix made search_symbol actually work on any repo, so the missing piece was steering.

## Measured distribution (30d Grep tool)
| class | calls | tok | |
|---|---|---|---|
| bare identifier | 216 | 70k | → search_symbol (block-safe) |
| regex, symbol-hunt (`::Foo`, `void.*Bar(`) | 834 | 313k | → search_text/symbol |
| regex, freeform (`TODO\|FIXME`) | 487 | 172k | legit grep (warn) |
| log/text | 116 | 41k | gamedev-log |

## Changes
- **Enforcement v2 (A+, user-approved):** a clear SYMBOL HUNT (bare identifier OR a regex with a code-structural cue `::`/`(`/void·class·struct·enum·template, via `isSymbolHuntGrep`) is **BLOCKED** (exit 2) and routed to search_symbol/search_text. Freeform text + bare identifier-alternation stay WARN (false-positive-safe). `VTS_GREP_BLOCK=0` reverts to warn-only.
- **discover counts the Glob tool** as a find_files bypass (was invisible).
- **Agent-directed copy:** hook output is consumed by the MODEL (which re-runs the search), not a human picking a menu — actionable text now instructs the assistant; a brief human reassurance about the red box stays.
- Sanitized synthetic eval names.

## Review points
- **Block scope** — only structural-cue regex + bare identifiers block; alternation (`TODO|FIXME`) deliberately does NOT (would false-positive). Is the structural-cue set right?
- **VTS_GREP_BLOCK default ON** — first behavior change from warn→block for the Grep tool. Reassuring copy + easy opt-out mitigate the earlier "scary red box" concern.
- search_symbol now works cross-repo (v0.19), so a block routes to a working tool.

## Verification
eval **51/51** (guard 50 new; guards 17/32/44 updated for block-identifier). lint clean. No real project symbols in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)