### PR TITLE
feat: enforcement v2.1 — block CamelCase/snake symbol-alternation Greps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,11 +108,14 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   `vts discover`) rewrite to `vts text` (regex); inside double quotes `\"` is an escaped literal; SAFE_TEXT
   allows `| ^ #` (always double-quoted; `$`/space/backslash still rejected). `grepNudgeFor` embeds a
   READY-TO-USE equivalent call (identifier→search_symbol, regex→search_text) in every Grep nudge/block.
-  GREP-TOOL enforcement v2 (A+): a clear SYMBOL HUNT — a bare identifier OR a regex with a code-structural
-  cue (`::` / a literal `(` / `void·class·struct·enum·template`) per `isSymbolHuntGrep` — is BLOCKED (exit 2)
-  and routed to search_symbol/search_text; freeform text AND bare identifier-alternation (`TODO|FIXME`) stay
-  WARN (no false-positive block). `VTS_GREP_BLOCK=0` reverts the escalation to warn-only. Measured: symbol
-  hunts ≈ 64% of Grep-tool result tokens; freeform left alone. GLOB/Search TOOL (filename search): warn-only
+  GREP-TOOL enforcement v2 (A+) + v2.1: a clear SYMBOL HUNT is BLOCKED (exit 2) and routed to search_symbol/
+  search_text per `isSymbolHuntGrep` — (1) a bare identifier, (2) a regex with a code-structural cue (`::` /
+  literal `(` / `void·class·struct·enum·template`), OR (3) **v2.1** an ALTERNATION (`A|B|C`) carrying a
+  CamelCase/snake identifier (`MaxWalkSpeed|MaxExcessSpeed`, `get_value|set_value`) — the top measured bypass
+  (UE type/symbol enumeration). KEPT as warn (false-positive-safe): freeform single tokens, AND keyword
+  alternations (`TODO|FIXME`/`GET|POST` — ALL-CAPS, no lower→upper transition, so no CamelCase signal). The
+  reroute is search_text (same regex, token-capped) → no wrong/missing results, just friction. `VTS_GREP_BLOCK=0`
+  reverts all of it to warn-only. Measured: v2 block ~172k tok/30d; v2.1 adds ~319k (CamelCase alternation). GLOB/Search TOOL (filename search): warn-only
   nudge → `find_files` (a different tool, can't updatedInput-rewrite), source-signal-gated (`isCodeGlobTool`);
   the built-in Glob has no cap + times out on a giant UE tree. find_files/search_text are walk-BOUNDED:
   shared `SKIP_DIRS` (node_modules/Intermediate/Binaries/Saved/build/… ) + a 4s time box so a huge tree can't

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -543,10 +543,10 @@ const nudgeCtx = (r) => { try { return JSON.parse(r.out || "{}").hookSpecificOut
 // A bare identifier is now BLOCKED (enforcement v2 A+), so its concrete nudge lands in the block stderr;
 // a non-symbol-hunt alternation still WARNS (additionalContext). Read each from where it now lives.
 const nIdent = runHook({ tool_name: "Grep", tool_input: { pattern: "Foo", glob: "*.ts" } }).err;
-const nRegex = nudgeCtx(runHook({ tool_name: "Grep", tool_input: { pattern: "FooA|FooB", glob: "*.cpp" } }));
+const nRegex = runHook({ tool_name: "Grep", tool_input: { pattern: "FooA|FooB", glob: "*.cpp" } }).err; // CamelCase alternation → blocked (v2.1); nudge in the block stderr
 const nudgeOk =
   /find_references symbol="Foo"/.test(nIdent) && /search_symbol q="Foo"/.test(nIdent) && // identifier → usages + decl (in the block msg)
-  /search_text q="FooA\|FooB"/.test(nRegex); // regex (no structural cue) → warn with a text suggestion
+  /search_text q="FooA\|FooB"/.test(nRegex); // CamelCase alternation → block, with the search_text call embedded
 const alRoot = path.join(os.tmpdir(), `vts-eval-${process.pid}-alproj`);
 fs.mkdirSync(path.join(alRoot, "P--x"), { recursive: true });
 fs.writeFileSync(path.join(alRoot, "P--x", "s.jsonl"), [
@@ -945,20 +945,23 @@ const skipOk = !ffSkip.isError && /Real\.cpp/.test(ffSkip.text) && !/Gen\.cpp/.t
 try { fs.rmSync(skipRoot, { recursive: true, force: true }); } catch { /* ignore */ }
 const globAndWalkOk = globNudgeOk && skipOk;
 
-// 50) enforcement v2 (A+): a SYMBOL-HUNT Grep is BLOCKED (exit 2 → search_symbol/search_text); a bare
-// identifier blocks; freeform text (TODO|FIXME) and bare identifier-alternation (FooBar|BazQux) stay WARN
-// (no false-positive block); VTS_GREP_BLOCK=0 reverts to warn; a doc-target (*.md) isn't blocked. Plus
-// discover now counts the built-in Glob/Search tool as a find_files bypass.
+// 50) enforcement v2 (A+ / v2.1): a SYMBOL-HUNT Grep is BLOCKED (exit 2 → search_symbol/search_text) — a
+// bare identifier, a structural-cue regex, OR a CamelCase/snake ALTERNATION (FooBar|BazQux, the top measured
+// bypass shape — UE type enumeration). Keyword alternations (TODO|FIXME, GET|POST — ALL-CAPS, no lower→upper
+// transition) and freeform single tokens stay WARN (no false-positive block). VTS_GREP_BLOCK=0 reverts; a
+// doc-target (*.md) isn't blocked. Plus discover counts the built-in Glob/Search tool as a find_files bypass.
 const hSymHunt = runHook({ tool_name: "Grep", tool_input: { pattern: "::FooWidget\\b|void.*FooWidget\\(", path: "src/lib" } });
 const hIdentBlk = runHook({ tool_name: "Grep", tool_input: { pattern: "FooWidget", path: "src/lib" } });
-const hFreeform = runHook({ tool_name: "Grep", tool_input: { pattern: "TODO|FIXME", path: "src/lib" } });
-const hAltern = runHook({ tool_name: "Grep", tool_input: { pattern: "BarA|BarB", path: "src/lib" } });
+const hCamelAlt = runHook({ tool_name: "Grep", tool_input: { pattern: "FooBar|BazQux", path: "src/lib" } }); // CamelCase symbol enumeration → block (v2.1)
+const hFreeform = runHook({ tool_name: "Grep", tool_input: { pattern: "TODO|FIXME", path: "src/lib" } });    // ALL-CAPS keyword alternation → warn
+const hKwAlt = runHook({ tool_name: "Grep", tool_input: { pattern: "GET|POST|HEAD", path: "src/lib" } });    // ALL-CAPS keyword alternation → warn
 const hSymOff = runHook({ tool_name: "Grep", tool_input: { pattern: "void.*FooWidget\\(", path: "src/lib" } }, { VTS_GREP_BLOCK: "0" });
 const hSymDoc = runHook({ tool_name: "Grep", tool_input: { pattern: "FooWidget", glob: "*.md" } });
 const enforceV2Ok =
   hSymHunt.status === 2 && /search_text q="/.test(hSymHunt.err) && /caught a SYMBOL/.test(hSymHunt.err) && // structural-cue regex → block
   hIdentBlk.status === 2 && /find_references symbol="FooWidget"/.test(hIdentBlk.err) &&                    // bare identifier → block
-  hFreeform.status === 0 && hAltern.status === 0 &&    // freeform text + bare alternation → NOT blocked (warn)
+  hCamelAlt.status === 2 && /search_text q="/.test(hCamelAlt.err) &&                                       // CamelCase alternation → block (v2.1)
+  hFreeform.status === 0 && hKwAlt.status === 0 &&     // keyword alternations (no CamelCase) → NOT blocked (warn)
   hSymOff.status === 0 &&                              // VTS_GREP_BLOCK=0 → reverts to warn
   hSymDoc.status === 0;                                // doc target (*.md) → not blocked
 const glProj = path.join(os.tmpdir(), `vts-eval-${process.pid}-globdisc`);

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -286,20 +286,24 @@ function grepNudgeFor(ti) {
       "code-locator subagent." + concrete + " For a JUST-edited / unindexed file or a quick literal peek, " +
       "Grep is fine — carry on. Disable: VTS_ENFORCE=0.";
 }
-// enforcement v2 (A+): a Grep-TOOL pattern HUNTING A NAMED SYMBOL is escalated from warn to BLOCK — a
-// semantic tool is strictly better there (smaller, exact, no regex false positives — `void.*Foo\(` also
-// matches `SetActiveFoo`). A symbol hunt that we BLOCK = a bare identifier, OR a regex carrying a ≥4-char
-// identifier AND a code-structural cue (:: , a literal `(` call, or a C++/decl keyword). Those cues don't
-// occur in prose or keyword greps, so the block is false-positive-safe. NOT blocked (stays warn): freeform
-// text (message fragments) AND bare identifier-alternation — `TODO|FIXME` / `ERROR|WARN` look like symbol
-// alternations but are legit keyword greps, so alternation alone never blocks (the model can still take the
-// warn's search_text). A `::Foo\b|void.*Foo\(` pattern carries `::` + `(` → blocked; a `TODO|FIXME` doesn't.
+// enforcement v2 (A+) + v2.1: a Grep-TOOL pattern HUNTING A NAMED SYMBOL is escalated from warn to BLOCK —
+// a semantic tool is strictly better (smaller, exact, no regex false positives — `void.*Foo\(` also matches
+// `SetActiveFoo`), and the reroute is search_text/search_symbol (same regex, token-capped → no wrong/missing
+// results, just friction). A symbol hunt that we BLOCK = (1) a bare identifier; (2) a regex with a ≥4-char
+// identifier AND a code-structural cue (`::`, a literal `(`, a C++/decl keyword); or (3) v2.1 — an ALTERNATION
+// (`A|B|C`) carrying a CamelCase or snake_case identifier (`MaxWalkSpeed|MaxExcessSpeed`, `get_value|set_value`).
+// (3) is the top measured bypass (UE type/symbol enumeration). KEPT as warn (false-positive-safe): freeform
+// single-token text, AND keyword alternations — `TODO|FIXME` / `ERROR|WARN` / `GET|POST` are ALL-CAPS with no
+// lower→upper transition, so they carry no CamelCase/snake signal and never match (3). A `TODO|FIXME` doesn't
+// block; a `MaxWalkSpeed|MaxExcessSpeed` does. VTS_GREP_BLOCK=0 reverts all of this to warn-only.
 function isSymbolHuntGrep(ti) {
   const pat = String(ti.pattern || "");
   if (!pat || pat.length > 200) return false;
-  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(pat)) return true;                       // bare identifier → search_symbol
+  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(pat)) return true;                       // (1) bare identifier → search_symbol
   if (!/[A-Za-z_][A-Za-z0-9_]{3,}/.test(pat)) return false;                    // no real identifier token → not a symbol hunt
-  return /::|\\\(|\bvoid\b|\bclass\b|\bstruct\b|\benum\b|\btemplate\b/.test(pat); // code-structural cue only (no alternation)
+  if (/::|\\\(|\bvoid\b|\bclass\b|\bstruct\b|\benum\b|\btemplate\b/.test(pat)) return true; // (2) code-structural cue
+  if (pat.includes("|") && /[a-z][A-Z]|[a-z][a-z0-9]*_[a-z]/.test(pat)) return true;        // (3) CamelCase/snake alternation
+  return false;
 }
 // Don't block a search explicitly aimed at non-code (a doc/asset glob or path) even if the pattern looks
 // symbol-ish — the symbol may legitimately be referenced in a .md/.json.


### PR DESCRIPTION
Follow-up to v0.20.0. discover (now counting v0.20.0 data) showed the top remaining Grep-tool bypasses are **CamelCase identifier alternations** — UE type/symbol enumeration searches. v0.20.0 left ALL alternations as warn (to avoid `TODO|FIXME` false positives), which also let the real symbol-alternations through.

## Change
`isSymbolHuntGrep` now also blocks an ALTERNATION (`A|B|C`) carrying a CamelCase (`[a-z][A-Z]`) or snake_case identifier. The discriminator separates symbol enumerations from keyword greps:
- `MaxWalkSpeed|MaxExcessSpeed` — lower→upper transition → **block**
- `TODO|FIXME` / `GET|POST` — ALL-CAPS, no transition → **stay warn**

The reroute is search_text (identical regex, token-capped), so over-capture is safe — same results, just capped + one extra step. `VTS_GREP_BLOCK=0` reverts all of it.

## Measured (30-day transcript scan)
CamelCase-alternation = **771 calls / ~319k tokens** — larger than the whole v2 block (172k). User chose the loose discriminator after confirming the only downside is friction (not token cost or correctness).

## Review points
- **Aggressiveness** — combined block (v2 172k + v2.1 319k ≈ 491k) approaches the "Option B" the user earlier declined, BUT freeform single-token peeks still warn, and the reroute (search_text) returns identical results. Friction-only.
- **Discriminator** — `[a-z][A-Z]` / snake. Keyword alternations untouched (verified TODO|FIXME, GET|POST stay warn).

## Verification
eval **51/51** (guard 50 extended: CamelCase alternation blocks, keyword alternations warn; guard 32 updated). lint clean, synthetic names only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)