### PR TITLE
feat: v2.2 — honor find <dir> in rewrite (correctness fix) + block concrete code-file Globs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,11 +115,17 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   (UE type/symbol enumeration). KEPT as warn (false-positive-safe): freeform single tokens, AND keyword
   alternations (`TODO|FIXME`/`GET|POST` — ALL-CAPS, no lower→upper transition, so no CamelCase signal). The
   reroute is search_text (same regex, token-capped) → no wrong/missing results, just friction. `VTS_GREP_BLOCK=0`
-  reverts all of it to warn-only. Measured: v2 block ~172k tok/30d; v2.1 adds ~319k (CamelCase alternation). GLOB/Search TOOL (filename search): warn-only
-  nudge → `find_files` (a different tool, can't updatedInput-rewrite), source-signal-gated (`isCodeGlobTool`);
-  the built-in Glob has no cap + times out on a giant UE tree. find_files/search_text are walk-BOUNDED:
-  shared `SKIP_DIRS` (node_modules/Intermediate/Binaries/Saved/build/… ) + a 4s time box so a huge tree can't
-  hang them. `vts discover` now also counts the Glob tool as a find_files bypass. `VTS_REWRITE=0` → block
+  reverts all of it to warn-only. Measured: v2 block ~172k tok/30d; v2.1 adds ~319k (CamelCase alternation).
+  GLOB/Search TOOL (filename search) **v2.2**: a CONCRETE code-file glob (`*.cpp` / `Foo.h` / `**/Bar.*` per
+  `isBlockableGlob`) is BLOCKED → `find_files` (which is a DIFFERENT tool — can't updatedInput-rewrite a Glob —
+  so it's a block with a ready-to-use `find_files q=… projectPath=<dir hint from the glob/path>`); a bare
+  `*`/`**/*` or code-DIR glob stays a warn. The warn alone was IGNORED — the model kept Glob-ing a giant UE tree
+  and narrowing the path instead of switching (live dogfood). find_files/search_text are walk-BOUNDED: shared
+  `SKIP_DIRS` (node_modules/Intermediate/Binaries/Saved/build/… ) + a 4s time box so a huge tree can't hang them.
+  FIND-DIR FIX (v2.2): a Bash `find <dir> -name X` rewrite now HONORS `<dir>` as the find_files root
+  (`extractFindDir`) — it was dropped, so `find /abs/UE/path -name X` searched the configured vts repo and falsely
+  reported "No files" (a live correctness bug on a UE worktree). `vts discover` also counts the Glob tool as a
+  find_files bypass. `VTS_REWRITE=0` → block
   instead of rewrite; `excludeCommands` (config) / `VTS_EXCLUDE_COMMANDS` (csv) opt a command out; escape hatch
   `VTS_ENFORCE=0`. Messages i18n'd (`uiLang()`: Korean when `VTS_LANG`/config `lang`=`ko` OR OS locale `ko-*`,
   else English; `VTS_LANG=en|ko` forces). Copy is AGENT-DIRECTED — the actionable part instructs the assistant

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -922,17 +922,19 @@ delete process.env.VTS_COMPACT_RESULTS;
 const capToggleOk = !rOff.isError && /@ .*Foo\.cpp:42/.test(rOff.text); // classic "  @ path:line" restored
 const capResultsOk = capV2Ok && capSingleOk && capToggleOk;
 
-// 49) Glob-tool nudge + find_files walk bound: the built-in Glob/Search tool (filename search) now gets a
-// warn-only nudge toward find_files (token-capped + walk-bounded), with a ready-to-use call; a doc/asset
-// glob is NOT nudged. And find_files SKIPS heavy build/dep dirs (node_modules/Intermediate/Binaries/…) so a
-// giant UE tree can't time it out like the built-in Glob did.
-const hGlobCode = nudgeCtx(runHook({ tool_name: "Glob", tool_input: { pattern: "**/*.cpp" } }));
-const hGlobFile = nudgeCtx(runHook({ tool_name: "Glob", tool_input: { pattern: "**/FooManager.*" } }));
-const hGlobDoc = runHook({ tool_name: "Glob", tool_input: { pattern: "**/*.md" } });
+// 49) Glob-tool steering + find_files walk bound: a CONCRETE code-file Glob (v2.2) is BLOCKED → find_files
+// (token-capped + walk-bounded); a code-DIR glob with no extension stays a warn nudge; a doc/asset glob is
+// left alone. And find_files SKIPS heavy build/dep dirs (node_modules/Intermediate/Binaries/…) so a giant UE
+// tree can't time it out like the built-in Glob did.
+const hGlobCode = runHook({ tool_name: "Glob", tool_input: { pattern: "**/*.cpp" } });        // concrete extension → block
+const hGlobFile = runHook({ tool_name: "Glob", tool_input: { pattern: "**/FooManager.*" } }); // specific source file → block
+const hGlobWarn = nudgeCtx(runHook({ tool_name: "Glob", tool_input: { pattern: "*", path: "src/lib" } })); // code dir, no ext → warn
+const hGlobDoc = runHook({ tool_name: "Glob", tool_input: { pattern: "**/*.md" } });          // doc → neither
 const globNudgeOk =
-  /find_files q="\*\.cpp"/.test(hGlobCode) && /Glob/.test(hGlobCode) &&            // code glob → find_files nudge
-  /find_files q="FooManager\.\*"/.test(hGlobFile) &&                                // specific source file → nudged
-  hGlobDoc.status === 0 && !/find_files/.test(nudgeCtx(hGlobDoc));                 // doc glob → no nudge
+  hGlobCode.status === 2 && /find_files q="\*\.cpp"/.test(hGlobCode.err) &&        // concrete code glob → block → find_files
+  hGlobFile.status === 2 && /find_files q="FooManager\.\*"/.test(hGlobFile.err) && // specific source file → block
+  /find_files q=/.test(hGlobWarn) &&                                               // code-dir glob (no ext) → warn nudge
+  hGlobDoc.status === 0 && !/find_files/.test(nudgeCtx(hGlobDoc));                 // doc glob → no block, no nudge
 const skipRoot = path.join(os.tmpdir(), `vts-eval-${process.pid}-skip`);
 fs.mkdirSync(path.join(skipRoot, "src"), { recursive: true });
 fs.mkdirSync(path.join(skipRoot, "Intermediate"), { recursive: true });
@@ -976,6 +978,18 @@ delete process.env.VTS_CLAUDE_PROJECTS;
 const globDiscOk = !discGlob.isError && /Glob×\d/.test(discGlob.text); // discover groups bypasses by tool → "Glob×1"
 try { fs.rmSync(glProj, { recursive: true, force: true }); } catch { /* ignore */ }
 const enforceAndDiscoverOk = enforceV2Ok && globDiscOk;
+
+// 51) v2.2: (A) a Bash `find <dir> -name X` rewrite HONORS <dir> as the search root — dropping it made
+// find_files search the configured root and falsely report "No files" (live dogfood bug on a UE worktree).
+// (B) a CONCRETE code-file Glob (`*.cpp` / `Name.h`) is BLOCKED → find_files with a projectPath hint; a
+// bare `**/*` stays allowed.
+const hFindDir = parseRw(runHook({ tool_name: "Bash", tool_input: { command: 'find "/abs/widget/src/lib" -name "FooThing.h" 2>/dev/null' } }));
+const findDirOk = /files --q "FooThing\.h" --projectPath "\/abs\/widget\/src\/lib"/.test(hFindDir.updatedInput?.command || ""); // dir honored, not the configured root
+const hGlobBlk = runHook({ tool_name: "Glob", tool_input: { pattern: "src/lib/**/FooThing.cpp", path: "/abs/widget" } });
+const globBlkOk = hGlobBlk.status === 2 && /find_files q="FooThing\.cpp" projectPath="\/abs\/widget"/.test(hGlobBlk.err); // block + path hint
+const hGlobConcrete = runHook({ tool_name: "Glob", tool_input: { pattern: "**/*.cpp" } });   // concrete extension → block
+const hGlobBare = runHook({ tool_name: "Glob", tool_input: { pattern: "**/*" } });            // no extension → allowed
+const v22Ok = findDirOk && globBlkOk && hGlobConcrete.status === 2 && hGlobBare.status === 0;
 
 await disposeClients();
 // 48) clean teardown (no orphaned child): disposeClients must terminate EVERY spawned language-server
@@ -1046,6 +1060,7 @@ const rows = [
   ["clean teardown: no orphaned LSP child after disposeClients", teardownOk, "true", teardownOk],
   ["Glob-tool nudge → find_files + find_files skips heavy dirs", globAndWalkOk, "true", globAndWalkOk],
   ["enforce v2: symbol-hunt Grep blocks, freeform warns + discover counts Glob", enforceAndDiscoverOk, "true", enforceAndDiscoverOk],
+  ["v2.2: find <dir> honored in rewrite + concrete-code Glob blocks → find_files", v22Ok, "true", v22Ok],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -150,6 +150,14 @@ function extractFindName(segment) {
   const m = segment.match(/\s-name\s+("([^"]+)"|'([^']+)'|(\S+))/);
   return m ? (m[2] || m[3] || m[4] || "") : null;
 }
+// `find [path] -name X` — the FIRST operand (before any `-predicate`) is the search directory. Honor it so
+// the rewrite searches the tree the command names, not the configured root — dropping it made a
+// `find /abs/UE/path -name X` rewrite search the vts repo and falsely report "No files" (live dogfood bug).
+function extractFindDir(segment) {
+  const t = segment.trim().split(/\s+/)[1]; // token after `find`
+  if (!t || t.startsWith("-") || t.startsWith("(") || t.startsWith("!")) return null; // no path operand → cwd
+  return stripQuotes(t);
+}
 // Shell-safe pattern: alnum/_/./:/- plus the regex chars `|` `^` `#` (alternations like `FooA|FooB` and
 // anchors like `^#include` are the most-bypassed real queries, and search_text takes a regex). The rewrite
 // always double-quotes the -q arg, and these chars are literal inside double quotes in bash AND cmd.exe.
@@ -173,7 +181,9 @@ function buildRewrite(segment) {
   if (exec === "find") {
     const glob = extractFindName(segment);
     if (!glob || !SAFE_GLOB.test(glob)) return null;
-    return { cmd: `node ${quote(CLI_PATH)} files --q ${quote(glob)} --projectPath ${quote(root)}`, tool: "find_files", q: glob };
+    const dir = extractFindDir(segment); // honor `find <dir>` — else find_files searches the wrong tree (configured root)
+    const searchRoot = dir && SAFE_PATH.test(dir) ? dir : root; // unsafe/absent dir → fall back to the configured root
+    return { cmd: `node ${quote(CLI_PATH)} files --q ${quote(glob)} --projectPath ${quote(searchRoot)}`, tool: "find_files", q: glob };
   }
   const isGit = exec === "git";
   if (!isGit && !SEARCH_EXECS.has(exec)) return null;
@@ -355,6 +365,36 @@ function globNudgeFor(ti) {
       "equivalent (skips Intermediate/Binaries/node_modules, time-boxed) — it won't time out on a giant tree " +
       "(UE)." + call + " On a small tree a quick Glob is fine. Disable: VTS_ENFORCE=0.";
 }
+// v2.2: a Glob naming a CONCRETE code file/extension (`*.cpp`, `Foo.h`, `**/Bar.*`) is BLOCKED → find_files,
+// which is walk-bounded (won't time out on a giant UE tree) and token-capped, so it's strictly better. A bare
+// `*` / `**/*` (no extension) stays a warn — genuinely ambiguous. The warn was ignored: the model kept
+// Glob-ing a huge tree and narrowing the path instead of switching tools (live dogfood). VTS_GREP_BLOCK=0 reverts.
+function isBlockableGlob(ti) {
+  if (!isCodeGlobTool(ti)) return false;
+  const base = globBasename(ti.pattern).toLowerCase();
+  return CODE_EXT_RE.test(base) || /[a-z0-9_]\.[a-z0-9*]+$/.test(base); // concrete extension or Name.* — not a bare *
+}
+// Root hint for the reroute: the explicit `path`, else the literal directory prefix of the glob (everything
+// before the first wildcard, minus the trailing filename) — so the model narrows the giant tree.
+function globRootHint(ti) {
+  if (ti.path) return String(ti.path).replace(/\\/g, "/");
+  const dir = String(ti.pattern || "").replace(/\\/g, "/").split(/[*?]/)[0].replace(/\/[^/]*$/, "");
+  return dir.includes("/") ? dir : "";
+}
+function globBlockMsg(ti) {
+  const base = globBasename(ti.pattern);
+  const hint = globRootHint(ti);
+  const call = `find_files q="${base}"${hint ? ` projectPath="${hint}"` : ""}`;
+  return KO
+    ? "✨ vs-token-safer가 파일명 검색을 가로챘어요 — 고장이 아니라 의도된 동작이고, 거대 트리 타임아웃을 막아줍니다. 🎉\n" +
+      "(빨간 박스는 \"잠깐\"의 신호일 뿐, 실패가 아니에요.) find_files는 walk-bound(Intermediate/Binaries/node_modules " +
+      "스킵 + 시간박스)라 UE 트리에서도 안 멈춰요.\n어시스턴트는 이렇게 다시 실행하세요: " + call +
+      " (루트를 좁힐수록 빠름). 끄기: VTS_GREP_BLOCK=0 / VTS_ENFORCE=0."
+    : "✨ vs-token-safer caught a filename search — intended, not broken; it avoids a giant-tree timeout. 🎉\n" +
+      "(The red box is just a \"hold on\", not a failure.) find_files is walk-bounded (skips Intermediate/Binaries/" +
+      "node_modules + time-boxed) so it won't hang on a UE tree.\nAssistant: re-run as: " + call +
+      " (narrow the root for speed). Disable: VTS_GREP_BLOCK=0 / VTS_ENFORCE=0.";
+}
 const LOG_NUDGE = KO
   ? "[vs-token-safer] 이 검색은 LOG가 대상입니다. 언어 서버 인덱스는 소스 코드만 다뤄요 — 로그 분석은 grep 대신 " +
     "gamedev-log를 쓰세요 (/gamedev-log-analyzer:logs, 또는 gamedev-log CLI: summary / search / locate / fields / diff). 끄기: VTS_ENFORCE=0."
@@ -427,10 +467,15 @@ process.stdin.on("end", () => {
     process.exit(0);
   }
 
-  // Glob / Search TOOL — warn-only nudge toward find_files (token-capped + walk-bounded). Never block —
-  // a quick filename glob on a small tree is fine; the point is to steer the big/UE case off a timeout.
+  // Glob / Search TOOL — v2.2: a CONCRETE code-file glob (`*.cpp`, `Foo.h`, `**/Bar.*`) is BLOCKED → find_files
+  // (walk-bounded, won't time out on a giant tree); a bare `*` / code-dir glob stays a warn. The warn alone was
+  // ignored — the model kept Glob-ing a huge UE tree instead of switching. VTS_GREP_BLOCK=0 reverts to warn-only.
   if (toolName === "Glob") {
-    if (isCodeGlobTool(ti)) emitWarn(globNudgeFor(ti) + setup);
+    if (grepBlockOn() && isBlockableGlob(ti)) {
+      process.stderr.write(globBlockMsg(ti) + setup + "\n");
+      process.exit(2); // block — route the concrete code-file glob to find_files
+    }
+    else if (isCodeGlobTool(ti)) emitWarn(globNudgeFor(ti) + setup);
     process.exit(0);
   }
 


### PR DESCRIPTION
Two live-dogfood findings on a real UE worktree (Glob/find filename search flailing).

## 1. CORRECTNESS BUG — find <dir> dropped
A Bash `find <dir> -name X` rewrite dropped the directory operand and searched the **configured root**, so `find /abs/UE/.../X.h -name X.h` rewrote to find_files under the vts repo → false **"No files"** (a wrong, misleading negative). `extractFindDir` now passes the first path operand as `--projectPath`.

## 2. Glob warn → block
The Glob/Search tool was warn-ONLY and the warn was **ignored** — the model kept Glob-ing a giant UE tree (times out) and narrowing the path by hand instead of switching. A CONCRETE code-file glob (`*.cpp`/`Foo.h`/`**/Bar.*`) is now **BLOCKED → find_files** with a ready-to-use call carrying a **projectPath hint** (explicit path, else the glob's literal dir prefix). A bare `*`/`**/*` or code-DIR glob stays warn. find_files is walk-bounded (SKIP_DIRS + 4s) so it's strictly better. `VTS_GREP_BLOCK=0` reverts.

## Review points
- **find-dir** — spaced/quoted dirs fall back to the configured root (split-on-space limitation); the common no-space absolute UE path works.
- **Glob block scope** — only concrete-extension globs block; bare `*` warns. Reroute (find_files) is never worse.
- Path hint best-effort from the glob's literal prefix.

## Verification
eval **52/52** (guard 51 new: find <dir> honored + concrete-code Glob blocks with path hint; guard 49 updated). lint clean, synthetic names only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)