### PR TITLE
fix: discover no longer counts our own BLOCKED searches as bypasses

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -501,6 +501,10 @@ const transcript = [
   // MISSED it; the shared quote-aware splitter must count it as one bypassed grep.
   { type: "assistant", cwd: learnRoot, timestamp: NOW, message: { role: "assistant", content: [{ type: "tool_use", id: "tu4", name: "Bash", input: { command: 'grep -rn "QAlpha|QBeta" src/Quoted.cpp' } }] } },
   { type: "user", cwd: learnRoot, timestamp: NOW, message: { role: "user", content: [{ type: "tool_result", tool_use_id: "tu4", content: "src/Quoted.cpp:3:QAlpha\n".repeat(40) }] } },
+  // a grep our OWN hook BLOCKED — its tool_result IS the block message ("✨ vs-token-safer … 가로챘"), so it
+  // was CAUGHT, not bypassed; discover must NOT count it (nor the long block copy as raw tokens).
+  { type: "assistant", cwd: learnRoot, timestamp: NOW, message: { role: "assistant", content: [{ type: "tool_use", id: "tu7", name: "Bash", input: { command: "grep -rn BLOCKEDONE src/Blk.cpp" } }] } },
+  { type: "user", cwd: learnRoot, timestamp: NOW, message: { role: "user", content: [{ type: "tool_result", tool_use_id: "tu7", content: "✨ vs-token-safer가 코드 검색을 가로챘어요 — 의도된 동작입니다.\n".repeat(20) }] } },
   // 30-day-old entry in a still-fresh transcript: counted by --all, EXCLUDED by the since window
   // (entry-level timestamps — file mtime alone would recount this forever).
   { type: "assistant", cwd: learnRoot, timestamp: OLD, message: { role: "assistant", content: [{ type: "tool_use", id: "tu5", name: "Bash", input: { command: "grep -rn STALEONE src/Old.cpp" } }] } },
@@ -520,6 +524,7 @@ const discoverOk =
   /grep×3/.test(disc.text) && /Grep×1/.test(disc.text) &&
   /SpawnActor/.test(disc.text) && /QAlpha\|QBeta/.test(disc.text) && // quote-aware: counted, not dissolved
   !/OTHERGREP/.test(disc.text) && /scoped to/.test(disc.text) &&    // projectPath scope excludes the other root
+  !/BLOCKEDONE/.test(disc.text) &&                  // a hook-BLOCKED grep (block-message result) is NOT a bypass
   /catch-rate:/.test(disc.text) &&                  // synergy C: caught-vs-bypassing
   /learned \d+ file\(s\) into the warm-set/.test(disc.text) && // synergy B: learn line
   /foo\.cpp/i.test(qhAfter) && !/other\.cpp/i.test(qhAfter) && // attribution: learnRoot files only

--- a/server/core.js
+++ b/server/core.js
@@ -362,6 +362,12 @@ function scanBypasses(a = {}) {
         else if (b && b.type === "tool_result" && cand.has(b.tool_use_id)) {
           const meta = cand.get(b.tool_use_id); cand.delete(b.tool_use_id);
           const o = typeof b.content === "string" ? b.content : JSON.stringify(b.content || "");
+          // A search our OWN hook BLOCKED (exit 2) has the block message as its tool_result — it was CAUGHT,
+          // not bypassed, so counting it (and the long block copy as "raw tokens") over-reports bypasses and
+          // under-reports the catch-rate. Skip it. (A WARNED Grep still ran and returned real matches — no
+          // block header — so it stays counted, correctly.) Rewritten Bash greps already don't reach here
+          // (their tool_use is the vts command, which matchBypass doesn't flag).
+          if (/✨ vs-token-safer/.test(o)) continue;
           const rt = tok(o); rawTokTotal += rt; missed.push({ ...meta, rawTok: rt });
           // resolve relative hits against the ENTRY's cwd (the project the search actually ran in) —
           // recordQueryResults would otherwise resolve them against the scanner's cwd, mis-attributing.


### PR DESCRIPTION
Dogfood (`discover since:1`) found a self-contradiction: a Bash grep our OWN hook BLOCKED (exit 2) was reported as a "bypass", with the long block message counted as its raw bypassed tokens (~1.1k for the Korean copy). A blocked search was CAUGHT, not bypassed → over-reports bypasses, under-reports catch-rate.

## Fix
`scanBypasses` skips a tool_result whose content is our block message (signature `✨ vs-token-safer`). A WARNED Grep still ran + returned real matches (no block header) → stays counted. Rewritten Bash greps never reach here (tool_use is the vts command). Net: honest bypass list + catch-rate (rises).

## Verification
eval guard 30 extended — a blocked grep (tool_result = block message) is NOT counted (bypass count stays 4 / grep×3, `BLOCKEDONE` absent). 52/52 green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)