### PR TITLE
feat: Serena-parity symbol-level editing + lean README refresh

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
     {
       "name": "gamedev-log-analyzer",
       "source": "./gamedev-log-analyzer",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "category": "development",
       "description": "Token-efficient game-engine & build log analysis (Unreal/Unity/Godot/MSVC-UBT-MSBuild + JSONL traces), CLI-first: parse, dedup, classify, diff runs, locate file:line, and extract decisive scalar fields over a time window. Also on npm. No IDE required."
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,15 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   ranking], `didOpen`s it, queries references at `location.range.start`; no indexed decl → `scanTextUnder`
   literal-usage fallback. Discover showed name-driven usage hunts = the top bypass; this collapses the
   locate→position→refs dance that pushed the model to grep), `goto_definition`, `hover`, `document_symbols`,
-  `rename` (LSP; rename = preview by default, `apply=true` writes — the only mutating tool); `find_files`,
-  `search_text`
+  `rename` (LSP; preview by default, `apply=true` writes); SYMBOL-LEVEL EDITING (Serena-parity, the mutating
+  set — all preview-by-default, `apply=true` writes): `replace_symbol_body` / `insert_after_symbol` /
+  `insert_before_symbol` / `safe_delete` — `resolveSymbolForEdit` (core.js) resolves a declaration by NAME via
+  the LSP outline (`documentSymbol`'s `.range` = whole body, `.selectionRange` = name; `path` pins the file
+  else the index resolves it, optional `line` disambiguates), then splices text at the span via
+  `applyEditsToText` (`symbolEditResult` shared preview/apply, reuses the rename read-only/Perforce note).
+  `safe_delete` refuses while the symbol is still referenced (refs at the name) unless `force=true`. Token win:
+  edit by naming a symbol instead of Read-ing the whole file + line-counting for an exact-match Edit. Eval guard
+  52; `find_files`, `search_text`
   (filesystem — sanctioned `find`/`grep` replacements, no backend needed; `search_text` TARGETING: `path=<file>`
   searches one named file / `glob=<pat>` matching files — naming it AUTO-INCLUDES that extension (a `.md` etc),
   no docs flag; `docs=true` (no path/glob) widens the project-wide sweep to README/docs/config exts — default

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,133 +9,89 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/JSungMin/vs-token-safer/pulls)
 [![Stars](https://img.shields.io/github/stars/JSungMin/vs-token-safer?style=social)](https://github.com/JSungMin/vs-token-safer/stargazers)
 
-> 대형 Unreal C++ · Visual Studio · .NET 프로젝트용 Claude Code 플러그인 두 개. 코드베이스는 `grep`
-> 대신 공식 언어 서버 인덱스(clangd / Roslyn)로 검색하고, 수십 MB짜리 에디터 로그는 대화에 통째로
-> 쏟지 않고 읽습니다. 둘 다 토큰을 약 99% 적게 씁니다. **로컬 전용, IDE 불필요.**
+> **거대한 Unreal C++ / Visual Studio / .NET 코드베이스를 `grep` 대신 공식 언어 서버 인덱스
+> (clangd / Roslyn / tsserver / pyright)로 검색하고 편집합니다.** 결과는 소스 본문 없이 `file:line`으로만,
+> 토큰 상한이 걸린 채 돌아옵니다. 여기에 수십 MB짜리 에디터 로그를 대화에 쏟아붓지 않고 읽어 주는 형제
+> 플러그인이 따라옵니다. 둘 다 단순 방식보다 토큰을 약 99% 덜 씁니다. **로컬 전용, IDE 불필요.**
 
-### 실제 모습
 ```text
-# Claude가 코드를 grep 시도 → 훅이 그 자리에서 인덱스 쿼리로 재작성:
+# Claude가 코드를 grep하려 하면 → 훅이 그 자리에서 인덱스 질의로 바꿔치기:
 $ grep -rn "SpawnActor" Source/**/*.cpp
-↻ [vs-token-safer] 재라우팅 → search_symbol "SpawnActor"   # 텍스트 매치가 아닌 의미 기반
+↻ [vs-token-safer] 우회 → search_symbol "SpawnActor"          # 텍스트 매치가 아니라 시맨틱
   func SpawnActor (in AGameMode)   @ Source/GameMode.cpp:142   (+2 more)
-  → ~120 토큰   (grep이면 수천 줄 덤프)
-# 막다른 길 없음: 검색은 인덱스를 통해 그대로 실행됨. 차단을 원하면 VTS_REWRITE=0.
+  → ~120 토큰   (grep이었다면 수천 줄을 쏟아냈을 것)
 
-# 1MB 에디터 로그 → 파싱·dedup·분류 (동봉된 gamedev-log-analyzer):
-▶ /gamedev-log-analyzer:logs
-  41,233줄 · 에러 7 · 경고 312
-  ERROR   [LogStreaming] Failed to load asset <addr>         (×128)   @ AssetManager.cpp:210
-  WARNING [LogPhysics]   Penetration depth <n> exceeds limit (×4,051) @ MyComponent.cpp:88
-  → ~130 토큰   (raw 로그 ≈ 267,000)
+# 그 심볼을 고친다면? 파일을 통째로 읽지도, 줄 번호를 세지도 않고 이름만 지정:
+$ replace_symbol_body symbol="SpawnActor" body="…"           # 기본 미리보기, apply=true면 기록
+  replace_symbol_body "SpawnActor" — PREVIEW at Source/GameMode.cpp:142-160
 ```
-<sub>공개 Unreal Engine 심볼을 쓴 예시 출력.</sub>
+<sub>공개된 Unreal Engine 심볼로 만든 예시 출력. `VTS_REWRITE=0`이면 바꿔치기 대신 차단합니다.</sub>
 
-### 이런 경험 있나요?
-- 🔍 거대 Unreal C++ / .NET repo에서 `grep`이 컨텍스트를 폭발시킴 → clangd/Roslyn 인덱스로 검색하면 토큰 상한 (**~97–99% 절감**, [벤치마크](#성능-실측)).
-- 🪵 50MB 에디터 로그는 그대로는 못 읽음 → 파싱하고 dedup하고 분류하면 수백 토큰으로 줄어듦.
-- 🤖 Claude가 자꾸 코드를 `grep`으로 뒤질 때, 훅이 막기만 하는 게 아니라 그 자리에서 인덱스 쿼리로 바꿔 줍니다. 검색은 그대로 돌아가고 작업 흐름도 끊기지 않습니다.
-- 📊 grep이 얼마나 새어 나가는지 안 보일 때는 `vts discover`를 쓰면 됩니다. 최근 세션을 읽어 인덱스를 우회한 검색과 그 토큰 비용을 정확히 짚어 줍니다.
-- 🖥️ IDE 프록시 방식과 달리 언어 서버를 헤드리스로 실행하니 에디터를 열 필요가 없음.
+## 왜 쓰나
 
-### 목차
-- [마켓플레이스 — 2개 플러그인](#마켓플레이스--2개-플러그인) · [합산 절감](#합산-토큰-절감-실측) · [두 플러그인 함께 쓰기](#두-플러그인-함께-쓰기)
-- [무엇을 하나](#무엇을-하나) · [성능](#성능-실측) · [사전 인덱싱과 hit-rate](#사전-인덱싱pre-warm과-hit-rate)
-- [사전 요구사항](#사전-요구사항) · [설치](#설치) · [설정](#설정-명령어) · [업데이트](#새-버전으로-업데이트)
-- [설정 항목](#설정-항목-env) · [문제 해결](#문제-해결) · [상태 / 주의](#상태--주의) · [기여](#기여) · [Releases](https://github.com/JSungMin/vs-token-safer/releases)
+- 큰 Unreal C++ / .NET 레포에서 `grep`은 컨텍스트를 잠식합니다. clangd/Roslyn 인덱스는 토큰 상한이 걸려 약 97~99% 작습니다 ([벤치마크](#성능)).
+- Claude는 자꾸 `grep`으로 손이 갑니다. 훅은 단순히 막지 않고 **그 자리에서 명령을 인덱스 질의로 다시 씁니다.** 검색은 그대로 실행되고 흐름이 끊기지 않습니다.
+- **줄이 아니라 심볼 단위로 편집합니다.** 선언을 *이름으로* 지정해 교체/앞뒤 삽입/삭제 — 인덱스가 범위를 알려 주므로 파일을 통째로 컨텍스트에 읽어 들일 필요가 없습니다.
+- grep이 얼마나 새 나가는지 알기 어렵습니다. `vts discover`가 최근 세션을 읽어 어떤 검색이 인덱스를 우회했고 토큰을 얼마나 썼는지 짚어 줍니다.
+- 언어 서버는 **헤드리스**로 돕니다 — IDE 프록시 방식과 달리 에디터를 띄울 필요가 없습니다.
 
----
+## 빠른 시작
 
-심볼 검색, 참조 찾기, 정의로 이동, hover, 아웃라인, 프로젝트 전역 rename이 전부 Bash `grep` 대신 공식
-언어 서버 인덱스 — **clangd**(C/C++), **Roslyn**(C#/.NET), **tsserver**(JS/TS), **pyright**(Python) — 를
-거쳐, 간결하고 상한이 걸린 `file:line` 목록(소스 본문 없음)으로 돌아옵니다. `grep`이 느리고 컨텍스트를
-잡아먹는 대형 Unreal C++ / .NET 코드베이스를 위해 만들었습니다.
-[rider-mcp-enforcer](https://github.com/JSungMin/rider-mcp-enforcer)의 IDE 비종속 형제로, 목표는 같지만
-IDE를 프록시하지 않고 언어 서버를 헤드리스로 실행합니다 — 에디터를 열 필요가 없습니다.
-
-## 마켓플레이스 — 2개 플러그인
-
-이 repo는 **"큰 것을 싸게 읽는다"** 는 한 가지 목표를 공유하는 플러그인 두 개가 든 Claude Code
-플러그인 마켓플레이스입니다:
-
-| 플러그인 | 기능 | 필요 |
-| --- | --- | --- |
-| **vs-token-safer** (이 페이지) | 코드 검색을 grep 대신 clangd/Roslyn/tsserver/pyright 인덱스로 강제(기본 하드 차단, 탈출구 opt-out), `file:line`으로 토큰 캡 | Node + 언어 서버: clangd / Roslyn(직접 설치), JS/TS + Python(자동 설치). IDE 불필요. |
-| **[gamedev-log-analyzer](gamedev-log-analyzer/README.ko.md)** | 거대 Unreal/Unity/Godot/MSVC-UBT-MSBuild 로그 파싱·dedup·분류·검색·diff·locate·스칼라 추출 (CLI 우선) | Node만 (IDE 불필요) |
-
-**한 번에 설치.** `vs-token-safer`가 `gamedev-log-analyzer`를 의존성으로 선언하므로 한 번 설치하면 둘
-다 깔립니다. 각 서버의 `npm install`은 첫 세션에 자동 실행되니 수동 설정은 없습니다:
 ```bash
+# 1) 설치 (형제 플러그인 gamedev-log-analyzer도 함께 설치됨)
 /plugin marketplace add JSungMin/vs-token-safer
-/plugin install vs-token-safer@vs-token-safer        # gamedev-log-analyzer도 자동 설치
-/reload-plugins                                       # 첫 실행 시 둘 다 의존성 자동 설치
+/plugin install vs-token-safer@vs-token-safer
+/reload-plugins        # 첫 실행 때 서버 의존성 자동 설치 (수동 npm 불필요)
+
+# 2) 설정 — 백엔드를 감지하고 프로젝트 경로를 물어 본 뒤 설정을 기록
+/vs-token-safer:setup
 ```
-로그 분석기만 원하면 단독 설치: `/plugin install gamedev-log-analyzer@vs-token-safer`.
 
-### 합산 토큰 절감 (실측)
-| 작업 | Bash / raw | 플러그인 | 절감 |
-| --- | ---: | ---: | ---: |
-| 실제 UE5 repo 심볼 검색 (`FGameplayTag`) | ~282,194 tok | ~2,048 tok | **~99.3% (~138×)** |
-| raw 인덱스 응답 → 캡된 목록 (eval, 심볼 1,000개) | ~57,308 tok | ~1,549 tok | **~97.3%** |
-| ~1MB 에디터 로그 읽기 (`summary`) | ~267,000 tok | ~130 tok | **~99.95%** |
+그다음 **Claude Code 세션을 재시작**하세요 (`vs-search` MCP 서버는 새 세션에서만 뜹니다). 도구가 보이는지,
+`grep src/**/*.cpp`가 인덱스로 우회되는지 확인하면 됩니다. 사전 준비물: **Node ≥ 18**과 언어 서버 —
+clangd(C/C++) / Roslyn(C#)은 직접 설치, JS/TS·Python은 자동 설치됩니다. 자세한 건 아래
+[사전 준비](#사전-준비-자세히)에 있습니다.
 
-### 두 플러그인 함께 쓰기
-로그 분석기는 각 항목의 `file:line`을 출력하고 vs-token-safer는 그 `file:line`을 실제 심볼/소스로
-바꿉니다. 전형적인 흐름은 이렇습니다:
-1. `/gamedev-log-analyzer:logs` → 에러/경고와 그 `file:line` 찾기.
-2. 그 위치를 vs-token-safer의 `goto_definition`/`find_references`(또는 `search_symbol`)에 넘겨 코드를
-   엽니다. raw 로그를 grep하거나 덤프하지 않고요.
+> 로그 분석기만 필요하면: `/plugin install gamedev-log-analyzer@vs-token-safer`.
 
-역방향도 동작합니다: 코드 검색(vs-search 도구나 Bash/Grep 검색)이 로그를 겨냥하면 — `Logs/` 디렉터리나
-`.log`/`.jsonl` 파일 — vs-token-safer가 코드 인덱스에서 빈 결과를 주는 대신 gamedev-log로 안내합니다.
-언어 서버 인덱스는 소스를 다루지 로그를 다루지 않으니까요.
+## 도구
 
-## 무엇을 하나
+검색과 편집은 모두 공식 언어 서버 인덱스 — **clangd**(C/C++), **Roslyn**(C#/.NET), **tsserver**(JS/TS),
+**pyright**(Python) — 를 거쳐, 소스 본문 없이 토큰 상한이 걸린 `file:line` 목록으로 돌아옵니다. MCP 서버
+이름은 `vs-search`이고, `vts` CLI도 같은 도구를 씁니다.
 
-clangd와 Roslyn은 그 자체로 이미 의미 기반 심볼/참조 분석을 합니다. 이 플러그인이 그 위에 더하는 건
-강제, 토큰 캡, 헤드리스 실행 + warm-up입니다. Claude가 grep 대신 인덱스를 실제로 쓰게 만들죠:
+**검색 / 탐색**
 
-| 레이어 | 파일 | 효과 |
+| 도구 | CLI | 하는 일 |
 | --- | --- | --- |
-| **재작성/강제 훅(hook)** | `hooks/block-code-grep.js` | 세 가지 표면을 다룹니다. **Bash** `grep`/`rg`/`ack`/`ag`/`findstr`/`git grep`/`find <dir> -name`이 소스를 겨냥하고 안전한 단일 세그먼트라면 그 자리에서 동등한 `vts` 쿼리로 바꿔 줍니다(식별자는 의미 기반 `search_symbol`, 리터럴은 `search_text`, `find`는 그 `<dir>`을 루트로 한 `find_files`). 안전·완전한 재작성을 못 만들면(파이프라인, 셸 메타문자, 한 번에 못 담는 다중 `-name`/`-o` find) 차단합니다. 내장 **Grep 도구**: 패턴이 명백한 *심볼 사냥*(맨 식별자, `::`/`(`/`void·class`류 정규식, `FooBar|BazQux` 같은 CamelCase alternation)이면 `search_symbol`/`search_text`로 **차단**하고, 자유 텍스트와 대문자 키워드 alternation(`TODO|FIXME`)은 경고만 합니다. 내장 **Glob 도구**: 구체적 코드 파일 패턴(`*.cpp`·`Foo.h`·`**/Bar.*`)이면 `find_files`로 **차단**(거대 트리에서도 안 멈춤)하고, 에셋·맨 글롭(`Foo.png`·`**/*`)은 그대로 둡니다. 메시지는 에이전트 지시형(어시스턴트가 다시 실행할 도구를 콕 집어줌)이고 EN/KO 양쪽을 지원합니다. 원시 텍스트 검색(로그·`.md`/`.json`·설정·build)은 통과시킵니다. `VTS_REWRITE=0`이면 Bash를 재작성 대신 차단, `VTS_GREP_BLOCK=0`이면 Grep/Glob 차단이 경고로 되돌아가고, `excludeCommands`로 특정 명령을 빼며, `VTS_ENFORCE=0`이면 전부 끕니다. |
-| **라우팅 스킬** | `skills/vs-search/SKILL.md` | Claude가 인덱스 도구를 먼저 쓰도록 유도하는 규칙입니다. 심볼/참조/정의 검색은 `search_symbol`/`find_references`/`goto_definition`로 가고, grep은 최후수단입니다. |
-| **토큰 캡 코어** | `server/core.js` | 두 어댑터가 공유하는 `runTool()`. LSP 결과를 `kind name (in container) @ file:line`으로 바꾸고 `maxResults`로 상한을 걸고 `… N more` 푸터를 붙입니다. range/kind/소스 본문은 절대 넣지 않습니다. 참조가 많은 결과는 한 번 더 접습니다 — `find_references`는 파일당 한 줄로 합치고(`Foo.cpp:42,88,120`) 공통 디렉터리 프리픽스를 한 번만 빼내, 깊은 호출 지점 트리도 작게 유지합니다(모든 위치 보존; `VTS_COMPACT_RESULTS=0`이면 한 줄에 하나씩). 잘린 `find_files`/`search_text`는 전체 결과를 복구(tee) 파일로 써서 조용히 누락되지 않게 합니다. |
-| **절감 + discover** | `server/core.js` | 로컬 원장이 검색마다 절감 토큰을 기록하고(`vts savings`의 30일 그래프·일별/이력·추정 가치), `vts discover`는 최근 Claude 세션에서 인덱스를 *우회한* 코드 검색과 그 토큰 비용을 보고합니다 — 성공만이 아니라 catch-rate가 보입니다. |
-| **헤드리스 LSP 클라이언트** | `server/lsp.js` + `server/backends/index.js` | 완전 자체 구현 LSP 클라이언트(JSON-RPC 2.0, `Content-Length` 프레이밍)가 공식 엔진을 stdio로 실행합니다. 실행 설정, `pickBackend(root)` 자동 감지, IDE식 pre-warm(`afterInit`)을 포함합니다. 프로젝트 루트는 **호출마다** 정합니다 — 명시 `projectPath`, 없으면 쿼리에 실린 파일의 소속 프로젝트, 없으면 MCP 워크스페이스 루트 — 그래서 전역 설치 서버 하나가 **세션이 건드리는 모든 repo**에 답합니다(핀 하나에 묶이지 않음). 살아있는 백엔드는 풀로 묶고 상한을 둬서(`VTS_MAX_BACKENDS` + 유휴 회수기), 여러 repo를 건드려도 언어 서버가 무제한으로 뜨지 않습니다. |
-| **VCS 출력 압축** | `server/compact.js` | 인덱스가 `git`/`p4` 출력엔 손대지 못하지만, 원시 덤프는 장황하고 반복적입니다. `vts_git` / `vts_p4`는 **읽기 전용** 명령을 돌려 결과를 그룹·dedup·캡합니다(status는 변경 종류+디렉터리, log는 커밋당 한 줄, diff는 파일별 통계, `p4 opened`는 액션+depot 디렉터리). 같은 절감 원장에 기록되고, 변이 서브커맨드는 거부하며, 훅이 평범한 `git status` / `p4 opened`을 여기로 자동 보냅니다. |
+| `search_symbol` | `vts symbol` | 이름/부분 문자열로 심볼 선언 찾기 (텍스트 아닌 시맨틱). |
+| `find_references` | `vts references` | 심볼의 모든 호출 지점. **이름을 바로** 받습니다(`symbol="FooBar"`) — 함수/타입을 바꿔 모든 사용처를 손봐야 할 때 쓰는 도구. |
+| `goto_definition` | `vts definition` | 위치의 심볼 정의로 이동. |
+| `hover` | `vts hover` | 위치의 타입/시그니처. |
+| `document_symbols` | `vts symbols` | 파일 아웃라인 (클래스/함수/타입을 `file:line`으로). |
+| `find_files` | `vts files` | 이름/glob으로 파일 찾기 — `find -name`의 토큰캡 대체. |
+| `search_text` | `vts text` | 원시 텍스트/정규식 검색 — `grep`의 토큰캡 대체 (`path=`/`glob=`/`docs=true`로 범위 지정). |
 
-> **엔진은 공식, 글루는 우리 것.** 분석은 clangd(LLVM)·Roslyn(Microsoft)이 하고, 이 저장소는
-> LSP↔MCP 글루만 작성합니다. 소스 위에서 서드파티 MCP 서버가 돌지 않습니다.
+**편집 (심볼 단위 — 줄을 세지 말고 이름을 대세요)** — 기본 미리보기, `apply=true`면 기록.
 
-> **쓸수록 좋아집니다.** 각 조각이 하나의 피드백 루프로 맞물리기 때문입니다. 재작성은 식별자를 단순 텍스트
-> grep이 아니라 *의미 기반* `search_symbol`로 넘기고, `vts discover --learn`은 과거 검색이 실제로 맞춘
-> 파일들을 warm-up 세트에 올려 다음 세션이 미리 열도록 합니다. 그리고 `discover`가 catch-rate를 보고해 아직
-> 무엇이 새고 있는지 알려 주죠. 세션을 거듭할수록 인덱스는 더 따뜻해지고 강제는 더 촘촘해집니다.
+| 도구 | CLI | 하는 일 |
+| --- | --- | --- |
+| `rename` | `vts rename` | 시맨틱 프로젝트 전역 이름 변경 (텍스트 sed가 아니라 모든 참조). |
+| `replace_symbol_body` | `vts replace-symbol` | 선언 전체(시그니처+본문)를 이름으로 교체 — 범위는 인덱스가 알려 줍니다. |
+| `insert_after_symbol` | `vts insert-after` | 선언 뒤에 텍스트 삽입 (예: 형제 메서드 추가). |
+| `insert_before_symbol` | `vts insert-before` | 선언 앞에 텍스트 삽입 (예: import/속성). |
+| `safe_delete` | `vts safe-delete` | 선언 삭제 — **참조가 남아 있으면 거부**, `force=true`라야 진행. |
 
-### 명령어 & 도구
-- `/vs-token-safer:setup` — 플러그인 설정 ([설정](#설정-명령어) 참고).
-- `/vs-token-safer:savings` — 누적 토큰 절감량 표시.
-- MCP 도구(서버 `vs-search`): `search_symbol`, `find_references`, `goto_definition`, `hover`,
-  `document_symbols`, `rename`, `find_files`, `search_text`, `vts_git`, `vts_p4`, `vts_warmup`, `vts_setup`,
-  `vts_config`, `vts_savings`, `vts_savings_reset`, `vts_discover`. `find_files`와 `search_text`는 심볼이
-  아니라 파일명이나 raw 텍스트가 필요할 때 쓰는 `find -name`·`grep`의 토큰캡 대체입니다 — `search_text`는
-  파일 하나(`path=`)나 글롭(`glob=`, 그 확장자를 자동 포함)을 겨냥하거나 `docs=true`로 문서까지 넓힐 수
-  있습니다. `vts_git` / `vts_p4`는 **읽기 전용** git/p4 명령을 돌려 그 출력을 압축(그룹·dedup·캡)해 돌려
-  줍니다 — `git status/log/diff`, `p4 opened/status/changes`. 변이 서브커맨드는 거부합니다. `rename`은
-  프로젝트 전역 의미 기반 이름 변경으로, 기본은 미리보기이고 `apply=true`일 때만 편집을 기록합니다.
-  `vts_discover`는 인덱스를 우회한 코드 검색(놓친 절감)을 찾고, `learn=true`면 그 결과 파일을 warm-up
-  세트에 넣습니다.
-- **심볼 이름을 바꾸려는 참인가요?** `find_references`는 위치 좌표 대신 심볼 이름을 그대로 받습니다.
-  `find_references symbol="FooBar"`라고 하면 호출 지점이 전부 나오니 line/column을 따질 필요가 없죠.
-  함수나 타입 하나를 고치고 사용처를 모두 따라가 손봐야 할 때 쓰면 됩니다. 이름으로 grep하면 주석이나 부분
-  일치까지 섞여 들어오지만, 여기서는 의미상 실제 참조만 잡힙니다. 특정 오버로드를 콕 집어야 한다면 `path`와
-  `line`, `character`로 위치를 지정하는 방식도 그대로 쓸 수 있습니다.
-- CLI (`vts`): `symbol`, `references`, `definition`, `hover`, `symbols`, `rename`, `files`, `text`
-  (`--path`/`--glob`/`--docs`), `git`, `p4`(압축·읽기 전용 — 예: `vts git status`, `vts p4 opened`),
-  `warmup`, `setup`, `config`, `savings`(`--graph`/`--daily`/`--history`), `savings-reset`,
-  `discover`(`--since N`/`--all`/`--learn`).
-- "X가 어디 / Y를 누가 호출 / W 파일 찾기" 같은 조회는 `code-locator` 서브에이전트에 통째로 맡기세요.
-  자기 컨텍스트에서 검색하고 `file:line` 표만 돌려줍니다.
+**버전 관리 (출력 압축, 읽기 전용)**
+
+| 도구 | CLI | 하는 일 |
+| --- | --- | --- |
+| `vts_git` | `vts git` | 읽기 전용 `git status/log/diff`를 돌려 출력을 그룹/중복제거/상한. 변경 서브커맨드는 거부. |
+| `vts_p4` | `vts p4` | Perforce `opened/status/changes/reconcile`도 동일. |
+
+이외에 `vts_warmup`, `vts_setup`, `vts_config`, `vts_savings`, `vts_savings_reset`, `vts_discover`,
+`vts_gen_compile_db`가 있습니다. 아니면 "X 어디 있어 / Y 누가 부르나 / 파일 W 찾아" 류의 조회를 통째로
+**`code-locator` 서브에이전트**에 넘겨도 됩니다 — 자기 컨텍스트에서 검색하고 `file:line` 표만 돌려줍니다.
 
 ```
 $ vts symbol --q SpawnActor --projectPath ./MyGame
@@ -147,57 +103,80 @@ func SpawnActorFromClass  @ MyGame/Source/SpawnLib.cpp:31
 ✓ Saved ~4,200 tokens here (96.8% / 31× smaller than the raw index response).
 ```
 
-## 성능 (실측)
+## 동작 방식
 
-대형 Unreal Engine 5 프로젝트에서 공개 엔진 심볼 한 개(`FGameplayTag`)를 Bash grep-and-paste vs 이
-플러그인으로 찾은 실측 A/B입니다. 프로젝트 소스는 공개하지 않고 집계 수치만 씁니다. 방법은
-[BENCHMARK.md](BENCHMARK.md)를 참고하세요.
+clangd와 Roslyn이 시맨틱 분석은 이미 해 줍니다. 이 플러그인이 그 위에 얹는 건 **강제, 토큰 상한, 헤드리스
+스폰 + 워밍업** — Claude가 grep 대신 실제로 인덱스를 쓰게 만드는 부분입니다.
 
-| | Bash grep-and-paste (전체 repo) | **플러그인 (clangd 인덱스, 캡)** |
+| 계층 | 효과 |
+| --- | --- |
+| **바꿔치기/강제 훅** | 세 표면을 다룹니다. **Bash** grep/rg/`find -name`이 소스를 향하면 → 그 자리에서 같은 뜻의 `vts` 질의로 **바꿔치기**(식별자 → `search_symbol`, 리터럴 → `search_text`, `find <dir> -name` → `<dir>`를 루트로 한 `find_files`); 애매하면(파이프라인, 다중 `-name`) 차단. **Grep 도구**의 명백한 심볼 사냥(맨 식별자, `::`/`(`/`void·class` 정규식, `FooBar\|BazQux` 식 CamelCase 교대)은 바로 쓸 수 있는 호출과 함께 **차단**, 자유 텍스트·키워드 교대는 경고만. **Glob 도구**의 구체적 코드 파일(`*.cpp`, `Foo.h`)은 `find_files`로 **차단**. 메시지는 에이전트 대상이고 EN/KO 양쪽. 로그·`.md`·설정은 통과. 스위치: `VTS_REWRITE=0`, `VTS_GREP_BLOCK=0`, `VTS_ENFORCE=0`. |
+| **토큰캡 코어** | LSP 결과를 `kind name @ file:line`으로 바꾸고 상한을 건 뒤 `… N more`를 붙입니다. 참조가 많은 결과는 파일당 한 줄로(`Foo.cpp:42,88,120`) 접고 공통 디렉터리 접두사를 한 번만 빼냅니다(`VTS_COMPACT_RESULTS=0`이면 줄당 복원). 잘린 `find_files`/`search_text`는 전체를 복구 파일로 tee. |
+| **심볼 단위 편집** | `replace_symbol_body`/`insert_*`/`safe_delete`가 아웃라인으로 선언을 이름으로 찾아 정확한 범위에 텍스트를 끼웁니다 — 기본 미리보기, `apply=true`면 기록, `safe_delete`는 참조가 남으면 거부. 파일을 통째로 컨텍스트에 읽지 않습니다. |
+| **헤드리스 LSP 클라이언트** | 직접 만든 LSP 클라이언트가 공식 엔진을 stdio로 띄웁니다. 프로젝트 루트는 **호출마다** 결정됩니다(명시 `projectPath` → 질의한 파일의 소속 프로젝트 → MCP 워크스페이스 루트). 그래서 전역 서버 하나가 **세션이 건드리는 모든 레포**에 답합니다. 살아 있는 백엔드는 풀로 묶여 상한이 걸립니다(`VTS_MAX_BACKENDS` + 유휴 수거기). |
+| **절감 + discover** | 로컬 장부가 검색마다 아낀 토큰을 기록합니다(`vts savings`, 30일 그래프 포함). `vts discover`는 최근 세션에서 인덱스를 **우회한** 검색을 훑어 — 단순 합계가 아니라 포착률을 보여 줍니다. |
+
+> **엔진은 공식, 글루는 우리 것.** clangd(LLVM)와 Roslyn(Microsoft)이 분석을 하고, 이 레포는 LSP↔MCP
+> 글루만 씁니다. 제3자 MCP 서버가 소스 위에서 돌지 않습니다. 로컬 전용, 아무것도 업로드하지 않습니다.
+
+## 두 플러그인
+
+| 플러그인 | 하는 일 | 필요한 것 |
+| --- | --- | --- |
+| **vs-token-safer** (이 페이지) | 코드 검색·편집을 Bash grep 대신 clangd/Roslyn/tsserver/pyright 인덱스로 강제, `file:line`으로 토큰캡 | Node + 언어 서버 (clangd / Roslyn은 직접, JS/TS·Python은 자동). IDE 불필요. |
+| **[gamedev-log-analyzer](gamedev-log-analyzer/README.md)** | 거대한 Unreal/Unity/Godot/MSVC-UBT 로그를 파싱/중복제거/분류, 검색 + diff + 스칼라 추출 | Node만 |
+
+`vs-token-safer`가 `gamedev-log-analyzer`를 의존성으로 선언하므로 한 번 설치로 둘 다 들어옵니다. **함께
+쓰기:** 로그 분석기가 항목마다 `file:line`을 내놓으면 → 그걸 `goto_definition`/`find_references`에 넘겨
+grep이나 원시 로그 덤프 없이 코드를 엽니다. 반대 방향도 됩니다 — 로그(`Logs/`, `.log`/`.jsonl`)를 향한 코드
+검색은 빈 결과 대신 gamedev-log를 가리켜 줍니다.
+
+| 합산 절감 (실측) | Bash / 원시 | 플러그인 | 절감 |
+| --- | ---: | ---: | ---: |
+| 실제 UE5 레포 심볼 검색 (`FGameplayTag`) | ~282,194 토큰 | ~2,048 토큰 | **~99.3% (~138×)** |
+| 원시 인덱스 응답 → 캡 목록 (eval, 심볼 1,000개) | ~57,308 토큰 | ~1,549 토큰 | **~97.3%** |
+| ~1 MB 에디터 로그 읽기 (`summary`) | ~267,000 토큰 | ~130 토큰 | **~99.95%** |
+
+## 성능
+
+대형 Unreal Engine 5 프로젝트에서의 실제 A/B: 공개 엔진 심볼 하나(`FGameplayTag`)를 Bash grep-and-paste로
+찾을 때와 이 플러그인으로 찾을 때. 프로젝트 소스는 재현하지 않고 집계 수치만 씁니다.
+[BENCHMARK.md](BENCHMARK.md) 참고.
+
+| | Bash grep-and-paste (레포 전체) | **플러그인 (clangd 인덱스, 캡)** |
 | --- | ---: | ---: |
-| 모델이 받는 것 | 5,654줄 / 1,010 파일 | 47개 의미 기반 선언 (`file:line`) |
+| 모델이 받는 것 | 5,654줄 / 1,010파일 | 시맨틱 선언 47개 (`file:line`) |
 | 모델로 가는 토큰 | ~282,194 | **~2,048** |
 
-- **토큰: ~99.3% 절감 (~138×).** grep은 매칭 줄의 전체 텍스트를 반환하고, 텍스트로 매칭하니 더 많은
-  줄(주석, 문자열, 무관한 식별자)을 끌어옵니다. 플러그인은 의미 기반 히트당 `file:line` 하나만, 그것도
-  캡해서 반환합니다.
-- 목-LSP eval(`node eval/run.mjs`, 툴체인 불필요)이 매 커밋 응답 정형화 절감을 게이트합니다: raw 인덱스
-  `~57,308 tok` → 캡된 출력 `~1,549 tok` = **97.3%** (체크 52/52).
+**약 99.3% 적음(~138×).** grep은 매칭된 줄의 전체 텍스트를 돌려주고 텍스트로 매칭하니(주석·문자열·무관한
+식별자) 더 많이 잡습니다. 플러그인은 시맨틱 히트마다 `file:line` 하나씩, 상한을 걸어 돌려줍니다. mock-LSP
+eval(`node eval/run.mjs`, 툴체인 불필요)이 커밋마다 이걸 검증합니다: `~57,308 → ~1,549 토큰` = **97.3%**
+(검사 53/53).
 
-### 정확도 차이와 그 이유
-"누가 더 맞다"가 아니라 정밀도/재현율 트레이드오프입니다:
-- **재현율:** 플러그인은 모든 텍스트 occurrence가 아니라 상위 `N`개(cap)만 반환합니다. 빠진 꼬리는
-  대부분 주석, include, 부분문자열 노이즈입니다. 전수가 필요하면 `maxResults`를 올리거나 grep을 쓰세요.
-- **정밀도:** grep은 모든 부분문자열을 매칭하므로(`Foo` 검색이 `FooBar`도 매칭) 과다보고합니다. 인덱스는
-  distinct한 의미 기반 선언을 반환합니다. `search_symbol`은 심볼 인덱스 질의이고
-  `find_references`/`goto_definition`은 텍스트 매치가 아니라 위치의 심볼을 해석합니다.
+<details>
+<summary><b>정확도: 정밀도/재현율 트레이드오프</b></summary>
 
-> 정리하면 탐색(정의 + 대표 사용처) 용도에는 플러그인이 더 정확하고 훨씬 저렴합니다. 전수 감사라면 cap을
-> 올리거나 일부러 grep을 쓰세요.
+- **재현율:** 플러그인은 모든 텍스트 출현이 아니라 상위 `N`개(캡)를 돌려줍니다 — 빠진 꼬리는 대개 주석/include/부분 문자열 잡음입니다. 전수가 필요하면 `maxResults`를 올리거나 grep을 쓰세요.
+- **정밀도:** grep은 모든 부분 문자열을 매칭하지만(`Foo` 질의가 `FooBar`도 잡음), 인덱스는 서로 다른 시맨틱 선언을 돌려줍니다.
 
-## 사전 인덱싱(pre-warm)과 hit-rate
+그래서 탐색(정의 하나 + 대표 사용처)에는 플러그인이 더 정확하면서 훨씬 쌉니다. 전수 출현 감사라면 캡을
+올리거나 일부러 grep으로 떨어뜨리세요.
+</details>
 
-clangd는 비동기로 인덱싱하므로 서버 기동 후 *첫* 검색은 1회 warm-up 비용(엔진 헤더 인덱싱)을 치릅니다.
-vts는 이를 IDE처럼 처리합니다.
+<details>
+<summary><b>프리워밍 &amp; 적중률</b></summary>
 
-- **MCP 서버가 기동 시 pre-warm** (`VTS_PREWARM`, `projectPath` 설정 시 기본 on). 첫 검색 시점엔 이미
-  인덱스가 데워지는 중이고 클라이언트는 서버 수명 동안 캐시됩니다. 그래서 warm-up은 쿼리마다가 아니라
-  **세션당 1회**입니다(이후 검색은 sub-초).
-- **`vts warmup`**. CLI/CI용으로 clangd 온디스크 인덱스(`.cache/clangd`)를 미리 구축합니다.
-- **`VTS_CLANGD_REMOTE`**. clangd를 공유/사전구축 clangd-index-server로 연결하면 개발자별 warm-up이
-  ~0이 됩니다(팀/CI가 사전구축 인덱스 하나를 질의).
+clangd는 비동기로 인덱싱하므로 *첫* 검색은 일회성 워밍업을 치릅니다. vts는 이걸 IDE처럼 다룹니다: MCP
+서버가 **부팅 때 프리워밍**하고(`VTS_PREWARM`, `projectPath`가 있으면 기본 켜짐) 클라이언트를 세션 동안
+캐시하므로 비용은 한 번만 냅니다. `vts warmup`은 디스크 인덱스를 미리 빌드하고(CLI/CI),
+`VTS_CLANGD_REMOTE`는 공유 프리빌드 인덱스 서버를 가리킵니다.
 
-무엇을 먼저 데우느냐가 중요합니다. clangd는 열린 파일의 인덱싱 우선순위를 높이므로 vts는 warm-up
-대상을 곧 검색할 것 우선으로 정렬합니다. 순서는 **쿼리 이력**(과거 검색이 반환한 파일), **지금 편집
-중**(`git status` 수정/미추적 + Perforce `p4 opened`), **git 커밋 최근성**, **include 중심성**(여러
-후보가 `#include`하는 헤더. 적응형이라 영속 include-그래프 캐시를 매 warm-up마다 시간예산만큼 채워
-커버리지가 회차에 걸쳐 늘어남), 그리고 mtime입니다. 거대한 트리에선 일부(언리얼의 수만 TU 중 수백
-개)만 데울 수 있으니, 이 정렬이 warm 윈도가 실제 검색 대상을 포함하게 만드는 핵심입니다. git과
-Perforce 모두 지원합니다.
+순서가 중요합니다. clangd는 연 파일의 우선순위를 올리므로, vts는 **쿼리 이력 우선**으로 워밍합니다 — 그다음
+지금 편집 중인 것(`git status` / `p4 opened`), git-log 최신순, include 중심성, mtime 순. 거대한 트리에서는
+일부만 워밍할 수 있으니, 이 순서가 워밍 창에 실제 검색할 것이 담기게 만듭니다. 실측 향상
+(`node eval/bench-hitrate.mjs`, 2,000파일):
 
-측정된 향상 (`node eval/bench-hitrate.mjs`, 실제 `orderForWarm()`, 현실적 locality 합성 워크로드, 2,000 파일):
-
-| warm-up cap | 임의 순서 | 이력 기반 정렬 | 향상 |
+| 워밍업 캡 | 임의 순서 | 이력 순서 | 향상 |
 | --- | --- | --- | --- |
 | 파일의 3% | 1.5% | **54.3%** | **36×** |
 | 5% | 7.8% | **56.5%** | 7.3× |
@@ -205,311 +184,162 @@ Perforce 모두 지원합니다.
 | 20% | 24.8% | **68.5%** | 2.8× |
 | 50% | 46.3% | **80.5%** | 1.7× |
 
-데울 수 있는 비율이 작을수록 효과가 큽니다. 임의 순서는 거의 못 맞히고, 정렬은 대부분을 맞힙니다.
+워밍할 수 있는 조각이 작을수록 이득이 큽니다.
+</details>
 
-## 얼마나 절약했나? (토큰 절감 명령어)
+<details>
+<summary><b>절감 &amp; discover (포착률)</b></summary>
 
-코어는 검색마다 언어 서버 raw 인덱스 응답 대비 절약한 토큰을 기록합니다. 누적 합계는 이렇게 확인합니다:
+검색마다 원시 인덱스 응답을 그대로 보내는 것 대비 아낀 토큰을 기록합니다. `/vs-token-safer:savings`,
+`vts savings`(`--graph`/`--daily`/`--history`)로 확인하고, `vts savings-reset`으로 초기화합니다.
 
-- **Claude Code에서:** `/vs-token-safer:savings` 실행 (또는 "플러그인이 얼마나 아꼈어?"라고 질문).
-  `vts_savings` MCP 도구를 호출합니다.
-- **셸에서:** `vts savings`
-- **리셋:** `vts_savings_reset` 도구 호출 (또는 `vts savings-reset`).
-
-출력 예시:
 ```
 vs-token-safer savings (local, 1 search(es))
   total saved: ~4,200 tokens vs forwarding raw index responses
   raw → output: 4,340 → 140 tok (~31× smaller)
-  biggest single run: 4,340 → 140 tok
-  est. value: ~$0.01 (@ $3/Mtok — rough, set VTS_USD_PER_MTOK)
+  est. value: ~$0.01 (@ $3/Mtok — set VTS_USD_PER_MTOK)
 ```
-`vts savings --graph`는 30일치 절감 추이를 ASCII 그래프로 그려 주고, `--daily`와 `--history`를 붙이면
-일별·최근 실행별 분석까지 나옵니다. 여기까지가 *잡은* 쪽 이야기입니다. *놓친* 쪽은 `vts discover`가 맡습니다.
-최근 Claude 세션에서 인덱스를 우회한 코드 검색과 그 비용을 훑어 보여 주죠. 둘을 합치면 막연한 총합이 아니라
-catch-rate가 손에 잡힙니다:
+
+이건 *포착한* 쪽입니다. `vts discover`는 최근 세션에서 인덱스를 **우회한** 검색을 훑습니다:
+
 ```
 $ vts discover --since 1
-vs-token-safer discover — missed token savings (local scan, last 1 day(s), 9 transcript(s))
   86 code search(es) bypassed vts (Grep×48, Glob×18, grep×12, find×8)
-  raw tool output ingested: ~28,692 tok — routed through vts most of this is avoidable
   catch-rate: ~770,333 tok caught (via vts) vs ~28,692 still bypassing → 96.4% routed through vts
 ```
-(훅이 차단한 검색은 우회로 세지 않습니다 — 실제로 빠져나간 것만 집계합니다.)
-> 여기서 말하는 "saved"는 언어 서버의 *raw* 인덱스 응답을 기준으로 한 값입니다. Bash grep과 견주면 절감
-> 폭은 보통 이보다 훨씬 큽니다. 자세한 건 [BENCHMARK.md](BENCHMARK.md)를 보세요. `discover`는 로컬에서
-> 읽기 전용으로만 돕니다. 대화 기록 메타데이터와 도구 입출력 크기만 읽을 뿐, 무엇도 밖으로 내보내지 않습니다.
 
-## 사전 요구사항
+(훅이 *차단한* 검색은 우회로 세지 않습니다.) `discover`는 로컬·읽기 전용입니다 — 트랜스크립트 메타데이터와
+도구 입출력 크기만 읽고 어디로도 보내지 않습니다. `--learn`은 과거 검색이 실제로 건드린 파일을 워밍업
+세트에 먹여, 세션마다 인덱스를 더 따뜻하게 둡니다.
+</details>
 
-- PATH에 **Node.js ≥ 18**.
-- 검색할 언어의 언어 서버:
-  - **C/C++ → clangd ≥ 22** ([clangd 릴리스](https://github.com/clangd/clangd/releases)). Visual
-    Studio에 동봉된 clangd 19.1.x(`…/VC/Tools/Llvm/bin/clangd.exe`)는 실제 Unreal TU를 서버 모드에서
-    인덱싱할 때 **데드락**합니다. vts가 오래된 버전을 감지하면 경고합니다. `compile_commands.json`
-    컴파일 DB가 필요합니다.
-  - **C#/.NET → Roslyn LSP.** VS Code C# 확장(`ms-dotnettools.csharp`)을 설치하면 vts가 번들에서
-    `Microsoft.CodeAnalysis.LanguageServer`와 그 전용 .NET 런타임을 자동 감지합니다. 폴백은
-    `dotnet tool install --global csharp-ls`. `.sln`/`.csproj`가 필요합니다.
-  - **JS/TS → typescript-language-server, Python → pyright.** 플러그인 의존성으로 동봉되어 첫 세션에
-    자동 설치됩니다 — 따로 할 일 없습니다. vts가 번들 복사본을 `node`로 실행하니 전역 설치나 PATH 설정이
-    필요 없습니다. 원하면 `VTS_TS_CMD`/`VTS_PY_CMD`로 직접 지정하세요. (참고: 동봉으로 첫 실행 `npm
-    install`에 1회 ~50MB가 추가되고, JS/TS 서버는 **Node 20+**를 권장합니다 — Node 18에서는 건너뛰며
-    나머지 백엔드는 정상 동작합니다.)
-- IDE는 실행 중이지 않아도 됩니다.
+## 사전 준비 (자세히)
 
-clangd는 컴파일 DB(`compile_commands.json`)가 필요합니다:
-- **Unreal Engine:** UBT로 생성합니다. `<UE>/Engine/Build/BatchFiles/RunUBT … -mode=GenerateClangDatabase`.
-  타겟이 clang-cl로 빌드되면 **`-Compiler=VisualCpp`**를 추가하세요. 안 그러면
-  `GenerateClangDatabase`가 clang 툴체인 검증에 실패합니다(`Unable to find valid C++ toolchain for
-  Clang x64`). MSVC-컴파일러 DB도 clangd용 전체 엔진 include 그래프를 해석합니다.
-- **CMake:** `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`로 구성.
+<details>
+<summary><b>언어 서버 &amp; 컴파일 데이터베이스</b></summary>
 
-### compile DB가 아직 없을 때
+- **Node.js ≥ 18**이 PATH에.
+- **C/C++ → clangd ≥ 22** ([릴리스](https://github.com/clangd/clangd/releases)). Visual Studio에 번들된 clangd 19.1.x는 실제 Unreal TU를 서버 모드로 인덱싱할 때 **교착**합니다 — 오래된 게 감지되면 vts가 경고합니다. `compile_commands.json`이 필요합니다.
+- **C#/.NET → Roslyn LSP.** VS Code C# 확장(`ms-dotnettools.csharp`)을 설치하면 vts가 번들에서 `Microsoft.CodeAnalysis.LanguageServer`와 런타임을 자동 감지합니다. 대안: `dotnet tool install --global csharp-ls`. `.sln`/`.csproj`가 필요합니다.
+- **JS/TS → typescript-language-server, Python → pyright.** 플러그인 의존성으로 들어가 첫 세션에 자동 설치됩니다(최초 1회 ~50MB; JS/TS는 Node 20+를 원하고 18에서는 건너뜀).
 
-새로 만든 Unreal 프로젝트에는 대개 `compile_commands.json`이 없습니다. clangd는 이 파일이 없으면 의미
-기반 인덱스를 만들지 못합니다. 그렇다고 플러그인이 말없이 멈추거나 사용자를 막다른 곳에 두지는 않습니다.
+**clangd는 컴파일 데이터베이스가 필요합니다:**
+- **Unreal:** `<UE>/Engine/Build/BatchFiles/RunUBT … -mode=GenerateClangDatabase`. 타깃이 clang-cl로 빌드되면 **`-Compiler=VisualCpp`**를 더하세요 — 아니면 clang 툴체인 검증에 실패합니다.
+- **CMake:** `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.
 
-1. **그래도 결과는 돌아옵니다.** `search_symbol`이 범위를 좁힌 리터럴 텍스트 검색으로 넘어가고, 결과에
-   그 사실을 분명히 표시합니다(`Literal text matches … not a semantic decl`). 해석된 심볼이 아니라
-   텍스트로 찾은 것일 뿐, 이름은 여전히 찾을 수 있습니다.
-2. **원인은 한 번만 알려줍니다.** 첫 clangd 결과에 "compile DB가 없어 인덱스가 비어 있다"는 안내가 한 번
-   붙고, `/vs-token-safer:setup`도 DB가 없는 C++ 프로젝트를 센서스할 때 같은 내용을 미리 경고합니다.
-3. **해결은 명령 하나로 끝나며, 실행 여부는 직접 정합니다.** `vts_gen_compile_db`(CLI는
-   `vts gen-compile-db`)가 프로젝트에 맞는 UBT `GenerateClangDatabase` 명령을 알아서 조립합니다.
-   `.uproject`를 찾고, `<Name>Editor` 타깃을 추론하고, 엔진 위치를 찾고(`VTS_UE_ROOT`나 `engineRoot`
-   인자, 또는 프로젝트에서 상위로 거슬러 올라가며 탐색), clang-cl로 빌드하는 타깃이면
-   `-Compiler=VisualCpp`를 덧붙입니다. 기본 동작은 dry-run이라 명령만 출력하고 아무것도 실행하지
-   않습니다. `apply=true`를 줘야 비로소 UBT를 돌리고(몇 분 걸립니다), 만들어진 DB를 소스 트리 바깥
-   `~/.vs-token-safer/db/<project>`에 둔 다음 clangd를 그 위치에 연결합니다. clangd가 `.cache/`
-   인덱스를 DB 옆에 쓰므로 git에도 `p4 reconcile`에도 산출물이 전혀 잡히지 않습니다. 예전처럼 프로젝트
-   루트에 두고 싶다면 `inTree=true`를 주세요. 그러면 VCS-ignore 가드가 `.gitignore`에 항목을 더하거나,
-   depot 루트까지 올라가며 Perforce ignore 파일을 찾아 처리하고(읽기 전용이면 `p4 edit` 뒤에 넣을 줄을
-   알려줍니다), 어느 모드에서든 엔진 루트에 남은 사본을 지웁니다.
-4. 이후 MCP 서버를 재시작하거나 쿼리를 다시 실행하면 `search_symbol`, `find_references`,
-   `goto_definition`이 엔진 전체 인덱스를 바탕으로 의미 기반 답을 돌려줍니다.
+**아직 컴파일 DB가 없다면?** 그래도 답은 나옵니다 — `search_symbol`이 제한된 리터럴 텍스트 검색으로
+폴백하고(그렇게 라벨됨), 첫 결과에 일회성 안내가 붙습니다. 한 방에 고치려면: `vts_gen_compile_db`(CLI
+`vts gen-compile-db`)가 정확한 UBT 명령을 조립합니다(`.uproject`를 찾고, `<Name>Editor` 타깃을 끌어내고,
+엔진을 찾고, clang-cl 타깃이면 `-Compiler=VisualCpp`를 더함). **기본은 드라이런**이고, `apply=true`면
+UBT를 돌려 DB를 **소스 트리 밖**(`~/.vs-token-safer/db/<project>`, clangd의 `.cache/`도 그 옆)에 두므로
+git이나 `p4 reconcile`이 산출물을 보지 못합니다. `inTree=true`면 VCS 무시 가드로 보호되는 고전적
+프로젝트-루트 배치를 씁니다.
+</details>
 
-빠른 조회만 하면 된다면 DB 없이 텍스트 모드로 두는 것도 충분히 합리적인 선택입니다. 전체 DB가 진짜
-필요해지는 순간은 엔진 include 그래프를 가로질러 참조와 정의를 해석해야 할 때입니다.
+<details>
+<summary><b>독립 CLI (IDE·Claude Code 없이)</b></summary>
 
-## 설치
-
-```bash
-# 1) 마켓플레이스 추가 + 설치 (gamedev-log-analyzer도 자동 설치)
-/plugin marketplace add JSungMin/vs-token-safer
-/plugin install vs-token-safer@vs-token-safer
-/reload-plugins        # 첫 실행 시 서버 의존성 자동 설치 (수동 npm 불필요)
-
-# 2) 설정 — Claude Code 안에서 그냥 실행:
-/vs-token-safer:setup
-#   백엔드를 감지하고, 프로젝트 경로를 물어본 뒤 config를 기록합니다.
-```
-
-`vs-search` MCP 서버와 도구들이 보이는지, `grep src/**/*.cpp`이 인덱스 도구 유도와 함께 차단되는지
-(또는 `VTS_ENFORCE=0`이면 자유롭게 실행되는지) 확인하세요. MCP 서버의 의존성 하나
-(`@modelcontextprotocol/sdk`)는 첫 세션에 플러그인 데이터 디렉터리로 자동 설치됩니다.
-
-### 독립 CLI로 (IDE·Claude Code 불필요)
-
-vs-token-safer는 npm에 배포하지 않으니 `vts` CLI를 클론해서 설치합니다:
+npm에 게시하지 않으므로 클론에서 `vts`를 설치합니다:
 
 ```bash
 git clone https://github.com/JSungMin/vs-token-safer
 cd vs-token-safer/server && npm install && npm link   # `vts` 제공
-# 또는 link 없이 직접 실행:
-node /path/to/vs-token-safer/server/cli.js symbol --q SpawnActor --projectPath /path/to/proj
+# 또는 직접 실행: node /path/to/vs-token-safer/server/cli.js symbol --q SpawnActor --projectPath /path/to/proj
 ```
-
-## 설정 명령어
-
-OS 환경변수를 직접 편집하지 않습니다. 설정은 CLI와 MCP 서버가 시작할 때 읽는 config 파일
-(`~/.vs-token-safer/config.json`)에 저장됩니다. 설정 방법은 다음과 같습니다:
-
-- **Claude Code에서 (권장):** `/vs-token-safer:setup`가 가이드해 줍니다. 현재 설정을 보여주고
-  (`vts_config`), 백엔드를 감지하고, `projectPath`를 물어본 뒤 `vts_setup` 도구로 적용합니다. 그 후
-  `/reload-plugins`.
-- **도구 직접 호출:** Claude에게 `vts_setup { "projectPath": "…", "backend": "clangd" }`를 호출하거나
-  `vts_config`로 유효 설정을 보여달라고 요청하세요.
-- **셸에서:**
-  ```bash
-  vts setup --projectPath <root> --backend clangd
-  vts config
-  ```
-
-백엔드는 루트에서 자동 감지합니다. `compile_commands.json`(또는 `.uproject`)이면 **clangd**,
-`.sln`/`.csproj`이면 **roslyn**. 설정은 시작할 때 읽으니 **변경 후 `/reload-plugins`를 실행하세요**.
-우선순위는 **환경변수(`VTS_*`) > config 파일 > 기본값**이라, 같은 이름 환경변수가 있으면 그게
-이깁니다.
-
-## 새 버전으로 업데이트
-
-Claude Code는 마켓플레이스 repo를 캐시하므로 새 커밋이 **자동으로 받아지지 않습니다**. 새 버전을
-받으려면:
-
-```bash
-# 1) 캐시된 마켓플레이스 카탈로그 갱신
-/plugin marketplace update vs-token-safer
-
-# 2) 설치된 플러그인 업데이트 (확실히 하려면 uninstall 후 install)
-/plugin update vs-token-safer
-#   안 되면: /plugin uninstall vs-token-safer  그 다음  /plugin install vs-token-safer@vs-token-safer
-
-# 3) 훅/명령어/스킬 리로드
-/reload-plugins
-
-# 4) Claude Code 세션 재시작 — 이 단계는 선택이 아니라 필수입니다.
-#    /reload-plugins는 훅·명령어·스킬만 리로드합니다. vs-search MCP 서버는 세션 시작 때 한 번 뜨는
-#    자식 프로세스라, 재시작 전까지 옛 코드를 계속 돌립니다. 그래서 새 버전의 도구(search_symbol,
-#    find_references 등)는 세션을 껐다 켜기 전엔 실제로 바뀌지 않습니다.
-```
-
-> ⚠️ **새 플러그인 버전은 세션을 재시작해야 완전히 적용됩니다.** `/reload-plugins`만으로는 부족합니다 —
-> 돌고 있는 `vs-search` MCP 서버 프로세스는 리로드로 재시작되지 않아, Claude Code를 껐다 켜기 전까지
-> 이전 버전의 도구 코드를 그대로 제공합니다. 훅·명령어·스킬은 리로드로 갱신되지만, MCP 서버(따라서 모든
-> `search_*` / `find_*` 도구)는 재시작에서만 갱신됩니다.
-
-`/plugin`으로 설치 상태와 버전을 확인할 수 있습니다. `/vs-token-safer:setup` 같은 명령이 안 보이면
-설치본이 구버전이니 위 절차로 업데이트하세요.
-
-> 유지보수 참고: `.claude-plugin/plugin.json`(과 마켓플레이스 엔트리)의 `version` 필드가 업데이트
-> 게이트입니다. 클라이언트가 변경을 받게 하려면 버전을 올리세요. 변경이 동봉된 `gamedev-log-analyzer`
-> (자체 독립 semver 유지)에만 있더라도 헤드라인 플러그인을 올려야 합니다(아니면 "already at latest").
-> 버전 히스토리는 README가 아니라 [Releases](https://github.com/JSungMin/vs-token-safer/releases)에
-> 있습니다(각 `v*` 태그마다 자동 생성).
-
-## 설정 항목 (env)
-
-<details>
-<summary><b>전체 환경변수 펼치기</b></summary>
-
-우선순위: **환경변수(`VTS_*`) > `~/.vs-token-safer/config.json` > 기본값.**
-
-| 설정 키 | 환경변수 | 기본값 | 의미 |
-| --- | --- | --- | --- |
-| `projectPath` | `VTS_PROJECT_PATH` | cwd | 프로젝트 루트(컴파일 DB / `.sln` 위치). |
-| `backend` | `VTS_BACKEND` | auto | `clangd` \| `roslyn` (루트에서 자동 감지). |
-| `maxResults` | `VTS_MAX_RESULTS` | `60` | 반환 `file:line` 개수 상한. |
-| — | `VTS_COMPACT_RESULTS` | `1` | `0`이면 한 줄에 위치 하나씩으로 되돌림(`find_references` 파일별+공통 프리픽스 접기 비활성). |
-| — | `VTS_MAX_BACKENDS` | `2` | 동시에 살아있는 언어 서버 최대 수; 상한 초과 시 가장 오래 안 쓴 유휴 백엔드를 회수(멀티-repo 메모리 가드). |
-| — | `VTS_BACKEND_IDLE_MS` | `300000` | 이만큼 유휴한 언어 서버는 백그라운드 회수기가 종료(`0`=비활성). |
-| — | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | clangd 실행 파일/인자 재정의. |
-| — | `VTS_ROSLYN_DLL` | auto | 특정 `Microsoft.CodeAnalysis.LanguageServer.dll` 경로. |
-| — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto(MS 엔진) → `csharp-ls` | C# LSP 실행 파일/인자 재정의. |
-| — | `VTS_TS_CMD` / `VTS_TS_ARGS` | 동봉 `typescript-language-server` | JS/TS LSP 실행 파일/인자 재정의. |
-| — | `VTS_PY_CMD` / `VTS_PY_ARGS` | 동봉 `pyright-langserver` | Python LSP 실행 파일/인자 재정의. |
-| — | `VTS_TS_OPEN_CAP` / `VTS_PY_OPEN_CAP` | `60` | JS/TS · Python warm-up이 서버를 데우려 여는 파일 최대 수. |
-| — | `VTS_LSP_TIMEOUT_MS` | `30000` | 요청당 LSP 타임아웃. 차갑고 큰(예: UE) 인덱스면 올림. |
-| — | `VTS_LSP_INDEX_WAIT_MS` | `120000` | clangd warm-up이 첫 쿼리 전 백그라운드 인덱싱 완료를 기다리는 시간. |
-| — | `VTS_CLANGD_OPEN_CAP` | `100` | warm-up이 clangd 인덱스를 데우려 여는 파일 최대 수(persisted 인덱스 없는 cold 상태). |
-| — | `VTS_CLANGD_WARM_CAP_PERSISTED` | `8` | persisted `.cache/clangd` 인덱스가 있을 때 여는 파일 수 — clangd가 인덱스에서 답하므로 재파싱이 거의 불필요. |
-| — | `VTS_CLANGD_PERSISTED_WAIT_MS` | `60000` | persisted 인덱스가 있을 때, 로딩 중인 인덱스를 쿼리가 폴링하는 상한 — 고정 시각이 아니라 심볼이 잡히는 순간 즉시 반환. |
-| — | `VTS_CLANGD_PERSISTED_FLOOR_MS` | `3000` | persisted 인덱스가 있을 때 첫 쿼리가 폴링을 시작하기 전 warm-up이 기다리는 짧은 바닥 시간. |
-| — | `VTS_CLANGD_INDEX_PRIORITY` | `normal` | clangd 백그라운드 인덱싱 스레드 우선순위. 기본 `normal`은 빠르게 구축, `background`는 유휴 CPU만(느리지만 공용 머신에 양보). |
-| — | `VTS_CLANGD_JOBS` | `코어수-1` | clangd async/인덱스 워커 수(`-j`). |
-| — | `VTS_PREWARM` | on (`projectPath` 설정 시) | MCP 서버가 기동 시 인덱스 pre-warm(IDE식); `0`이면 비활성. |
-| — | `VTS_PREWARM_HOOK` | `0` | SessionStart 훅도 detached `vts warmup`으로 pre-warm(opt-in; 주로 CLI/비-MCP). |
-| — | `VTS_PREWARM_BACKENDS` | auto | pre-warm할 백엔드. `auto`=감지된 단일/우세 백엔드 하나; `all`=repo에 존재하는 모든 언어(각 언어 파일수에 비례해 warm); 또는 `clangd,typescript` 같은 콤마 목록. |
-| — | `VTS_WARM_CAP_RATIO` | `0.1` | 적응형 warm-up: 한 언어 파일의 ~이 비율만큼 open(큰 언어가 더 많이 warm), `[백엔드별 base, VTS_WARM_CAP_MAX]`로 clamp. `VTS_*_OPEN_CAP` 명시 시 그게 우선. |
-| — | `VTS_WARM_CAP_MAX` | `300` | 적응형 백엔드별 warm-up open-cap 상한. |
-| — | `VTS_CLANGD_REMOTE` | — | 공유/사전구축 clangd 인덱스 서버 주소(`--remote-index-address`); 개발자별 warmup ~0. |
-| — | `VTS_QUERY_HISTORY` | `~/.vs-token-safer/query-history.json` | 쿼리 이력 원장 위치(warm-up 세트를 곧-검색-우선으로 정렬하는 데 사용). |
-| — | `VTS_CENTRALITY_MAX` | `20000` | 중심성 스캔이 순회할 후보 상한; `0`이면 중심성 비활성. |
-| — | `VTS_CENTRALITY_BUDGET_MS` | `400` | warm-up당 *신규* include-프리픽스 읽기 예산. 중심성은 적응형이라, 매 warm-up이 예산만큼 새/변경 파일을 영속 include-그래프 캐시(`VTS_INCLUDE_GRAPH`)에 채워 회차마다 커버리지가 늘어남(`0`=캐시만). |
-| — | `VTS_ENFORCE` | `1` | `0`/`false`/`off`이면 Bash 코드 grep 허용(언어 서버 불가 시 탈출구). |
-| — | `VTS_REWRITE` | `1` | `0`이면 Bash 코드 grep을 `vts` 쿼리로 재작성하지 않고 차단합니다. |
-| — | `VTS_GREP_BLOCK` | `1` | `0`이면 **Grep/Glob 도구**의 심볼사냥/코드파일글롭 차단이 경고로 되돌아갑니다. |
-| — | `VTS_EXCLUDE_COMMANDS` | — | 재작성/차단에서 제외할 실행 파일 콤마 목록(예: `rg,find`). config.json의 `excludeCommands`도 가능. |
-| — | `VTS_COMPACT_VCS` | `1` | `0`이면 훅이 읽기 전용 `git status/log/diff` / `p4 opened/…`을 압축 `vts_git`/`vts_p4` 래퍼로 보내지 않습니다. |
-| `lang` | `VTS_LANG` | auto | 훅의 차단/넛지/로그 메시지 언어: `ko` 또는 `en`. OS 로케일에서 한국어를 자동 감지하며, `VTS_LANG`(또는 config `lang`)으로 강제할 수 있습니다. |
-| — | `VTS_TEE` | `truncate` | `truncate`면 잘린 `find_files`/`search_text` 전체 결과를 복구 파일로 씁니다. `off`면 비활성화. 디렉터리: `VTS_TEE_DIR`. |
-| — | `VTS_USD_PER_MTOK` | `3` | `vts savings`/`discover`의 추정 가치 줄에 쓰는 $/Mtok 단가. 참고용. |
-| — | `VTS_CLAUDE_PROJECTS` | `~/.claude/projects` | `vts discover`가 스캔할 대화 기록 위치. |
-| — | `VTS_DB_DIR` | `~/.vs-token-safer/db` | 생성된 compile DB의 트리 밖 보관소(프로젝트별 하위 디렉터리, clangd `.cache/` 인덱스도 함께). |
-
-
 </details>
 
-## 강제(enforcement) 동작 방식
-
-- **훅**은 Bash·Grep·Glob 도구 호출 전마다 실행됩니다.
-  - **Bash** 코드 검색(grep/rg/ack/ag/findstr/`git grep`, 또는 코드 확장자·`src|source|engine|plugins/`를
-    겨냥한 `find <dir> -name`)이 로그·md·json·빌드 경로가 *아닐* 때, 그 자리에서 동등한 `vts` 쿼리로 바꿔
-    줍니다(식별자→의미 기반 `symbol`, 리터럴→`text`, `find`→그 디렉터리를 루트로 한 `files`). 안전·완전한
-    재작성을 못 만들면(파이프라인, 셸 메타문자, 다중 `-name`/`-o` find) 차단합니다.
-  - 내장 **Grep 도구**는 패턴이 명백한 심볼 사냥(맨 식별자, 코드 구조 정규식, CamelCase alternation)이면
-    `search_symbol`/`search_text`로 **차단**하고, 자유 텍스트·대문자 키워드 alternation은 경고만 합니다.
-  - 내장 **Glob 도구**는 구체적 코드 파일(`*.cpp`·`Foo.h`·`**/Bar.*`)이면 `find_files`로 **차단**(walk-bound라
-    거대 트리에서도 안 멈춤)하고, 에셋·맨 글롭은 통과시킵니다.
-  - 스위치: `VTS_REWRITE=0`은 Bash 차단만, `VTS_GREP_BLOCK=0`은 Grep/Glob 차단을 경고로 되돌림,
-    `excludeCommands`/`VTS_EXCLUDE_COMMANDS`로 Bash 명령 제외, `VTS_ENFORCE=0`이면 전부 끔.
-- **스킬**은 Claude가 인덱스 도구를 선제적으로 쓰도록 유도합니다.
-- **코어**는 Claude가 도구를 어떻게 호출하든 토큰 상한을 보장하고, `find_files`나 `search_text` 결과가 잘리면
-  전체 결과를 tee 파일로 남겨 조용히 빠뜨리는 일을 막습니다.
-
-## 문제 해결
+## 설정
 
 <details>
-<summary><b>문제 해결 표 펼치기</b></summary>
+<summary><b>설정 명령 &amp; 업데이트</b></summary>
+
+설정은 `~/.vs-token-safer/config.json`에 있습니다(시작 때 읽음 — 바꾼 뒤 `/reload-plugins`). 방법은
+`/vs-token-safer:setup`(안내형), `vts_setup`/`vts_config` 도구, 또는 `vts setup --projectPath <root>
+--backend clangd`. 백엔드는 루트에서 자동 감지됩니다. 우선순위: **env(`VTS_*`) > 설정 파일 > 기본값.**
+
+**업데이트:** Claude Code가 마켓플레이스를 캐시하므로 새 커밋은 자동으로 안 받아집니다:
+```bash
+/plugin marketplace update vs-token-safer
+/plugin update vs-token-safer
+/reload-plugins
+# 그다음 세션 재시작 — 필수.
+```
+> ⚠️ 새 버전은 **세션 재시작** 후에야 완전히 적용됩니다. `/reload-plugins`는 훅/명령/스킬만 갱신하고,
+> 돌고 있는 `vs-search` MCP 서버는 종료-재실행 전까지 옛 도구 코드를 씁니다. 버전 이력:
+> [Releases](https://github.com/JSungMin/vs-token-safer/releases).
+</details>
+
+<details>
+<summary><b>환경 변수 전체</b></summary>
+
+우선순위: **`VTS_*` env > `~/.vs-token-safer/config.json` > 기본값.**
+
+| 설정 키 | 환경 변수 | 기본값 | 의미 |
+| --- | --- | --- | --- |
+| `projectPath` | `VTS_PROJECT_PATH` | cwd | 프로젝트 루트 (컴파일 DB / `.sln` 위치). |
+| `backend` | `VTS_BACKEND` | auto | `clangd` \| `roslyn` \| `typescript` \| `pyright`. |
+| `maxResults` | `VTS_MAX_RESULTS` | `60` | 반환 `file:line` 위치 상한. |
+| — | `VTS_COMPACT_RESULTS` | `1` | `0`이면 위치당 한 줄 출력으로 복원. |
+| — | `VTS_MAX_BACKENDS` | `2` | 동시에 살아 있는 언어 서버 최대치 (초과분은 LRU 축출). |
+| — | `VTS_BACKEND_IDLE_MS` | `300000` | 이만큼 유휴인 언어 서버는 종료 (`0`이면 끔). |
+| — | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | clangd 실행 파일 / 인자 오버라이드. |
+| — | `VTS_ROSLYN_DLL` | auto | 특정 `Microsoft.CodeAnalysis.LanguageServer.dll` 경로. |
+| — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto → `csharp-ls` | C# LSP 오버라이드. |
+| — | `VTS_TS_CMD` / `VTS_PY_CMD` (+ `_ARGS`) | 번들 | JS/TS · Python LSP 오버라이드. |
+| — | `VTS_TS_OPEN_CAP` / `VTS_PY_OPEN_CAP` | `60` | JS/TS · Python 워밍업이 여는 파일 수. |
+| — | `VTS_LSP_TIMEOUT_MS` | `30000` | LSP 요청별 타임아웃. 차갑고 큰 인덱스면 올리세요. |
+| — | `VTS_LSP_INDEX_WAIT_MS` | `120000` | clangd 워밍업이 백그라운드 인덱스 완료를 기다리는 시간. |
+| — | `VTS_CLANGD_OPEN_CAP` | `100` | 차가운 워밍업이 clangd 준비에 여는 파일 수. |
+| — | `VTS_CLANGD_WARM_CAP_PERSISTED` | `8` | 영속 `.cache/clangd` 인덱스가 있을 때의 오픈 캡. |
+| — | `VTS_CLANGD_PERSISTED_WAIT_MS` | `60000` | 아직 로딩 중인 영속 인덱스를 질의가 폴링하는 상한. |
+| — | `VTS_CLANGD_PERSISTED_FLOOR_MS` | `3000` | 첫 질의가 폴링을 시작하기 전 잠깐의 바닥. |
+| — | `VTS_CLANGD_INDEX_PRIORITY` | `normal` | clangd 백그라운드 인덱스 우선순위 (`background`는 유휴 CPU 전용). |
+| — | `VTS_CLANGD_JOBS` | `cores-1` | clangd 비동기/인덱스 워커 (`-j`). |
+| — | `VTS_PREWARM` | on (`projectPath` 있으면) | MCP 서버가 부팅 때 프리워밍; `0`이면 끔. |
+| — | `VTS_PREWARM_BACKENDS` | auto | `auto` / `all` / 콤마 목록 — 프리워밍할 백엔드. |
+| — | `VTS_WARM_CAP_RATIO` / `VTS_WARM_CAP_MAX` | `0.1` / `300` | 적응형 워밍업 오픈 캡 (언어 파일 수의 비율, 클램프). |
+| — | `VTS_CLANGD_REMOTE` | — | 공유/프리빌드 clangd 인덱스 서버 주소. |
+| — | `VTS_QUERY_HISTORY` / `VTS_INCLUDE_GRAPH` | `~/.vs-token-safer/…` | 워밍업 순서 캐시. |
+| — | `VTS_CENTRALITY_MAX` / `VTS_CENTRALITY_BUDGET_MS` | `20000` / `400` | include 중심성 스캔 한도 (`0`이면 끔 / 캐시 전용). |
+| — | `VTS_ENFORCE` | `1` | `0`이면 Bash 코드-grep 통과 (탈출구). |
+| — | `VTS_REWRITE` | `1` | `0`이면 훅이 바꿔치기 대신 Bash 코드-grep을 차단. |
+| — | `VTS_GREP_BLOCK` | `1` | `0`이면 **Grep/Glob 도구** 격상을 차단에서 경고로 되돌림. |
+| — | `VTS_EXCLUDE_COMMANDS` | — | 면제할 실행 파일 콤마 목록 (설정의 `excludeCommands`도). |
+| — | `VTS_COMPACT_VCS` | `1` | `0`이면 읽기 전용 `git`/`p4`의 압축 래퍼 우회를 멈춤. |
+| `lang` | `VTS_LANG` | auto | 훅 메시지 언어: `ko` / `en` (OS 로케일에서 자동 감지). |
+| — | `VTS_TEE` / `VTS_TEE_DIR` | `truncate` | 잘린 `find_files`/`search_text` 결과의 복구 파일. |
+| — | `VTS_USD_PER_MTOK` | `3` | 추정값 줄의 $/Mtok 단가 (참고용). |
+| — | `VTS_CLAUDE_PROJECTS` | `~/.claude/projects` | `vts discover`가 트랜스크립트를 찾는 곳. |
+| — | `VTS_DB_DIR` | `~/.vs-token-safer/db` | 생성된 컴파일 DB의 소스 트리 밖 보관처. |
+</details>
+
+<details>
+<summary><b>문제 해결</b></summary>
 
 | 증상 | 원인 | 해결 |
 | --- | --- | --- |
-| `/vs-token-safer:setup`가 자동완성에 안 뜸 | 플러그인 미설치(마켓플레이스만 add) 또는 구버전 | `/plugin install vs-token-safer@vs-token-safer` → `/reload-plugins`. `/plugin`에서 버전 확인. |
-| 첫 clangd 쿼리가 매우 느리거나 타임아웃 | 차가운 UE-스케일 인덱스, clangd가 엔진 헤더 인덱싱 중 | pre-warm(`VTS_PREWARM` on, 또는 `vts warmup`); `VTS_LSP_TIMEOUT_MS`/`VTS_LSP_INDEX_WAIT_MS` 올림. MCP 서버를 띄워둬 인덱스를 warm 유지. |
-| 실제 UE 프로젝트에서 clangd 쿼리가 영영 안 돌아옴(hang) | VS 동봉 clangd 19.1.x가 UE TU에서 **데드락** | **clangd ≥ 22** 설치 후 `VTS_CLANGD_CMD`로 지정. 오래된 clangd 감지 시 vts가 버전 경고 출력. |
-| `GenerateClangDatabase` 실패: "Unable to find valid C++ toolchain for Clang x64" | 타겟이 clang-cl 빌드; UBT가 Clang 툴체인 검증 | UBT 명령에 **`-Compiler=VisualCpp`** 추가. MSVC DB도 include 그래프를 해석함. |
-| clangd가 헤더 없는 심볼만 해석 | 컴파일 DB에 include 경로 없음 → 시스템/서드파티 헤더 미해석 | UBT 생성 DB 사용(경로 포함); 수작업 `compile_commands.json`은 include 경로를 명시해야 함. |
-| C# 결과 없음 / "No backend resolved" | Roslyn 엔진 미발견 | VS Code C# 확장(`ms-dotnettools.csharp`) 설치, 또는 `dotnet tool install --global csharp-ls`; 또는 `VTS_ROSLYN_DLL`/`VTS_ROSLYN_CMD` 설정. |
-| JS/TS·Python 결과 없음 | 동봉 LSP 미설치(오프라인 첫 실행, npm 실패) | 세션을 다시 시작해 의존성 재설치, 또는 PATH의 `typescript-language-server`/`pyright-langserver`를 `VTS_TS_CMD`/`VTS_PY_CMD`로 지정. |
-| 원하던 grep인데 코드 검색이 차단됨 | 훅이 인덱스로 유도 중 | `VTS_ENFORCE=0`으로 grep 허용(예: 언어 서버 불가 시). |
-| 잘못된 백엔드 선택됨 | 루트 아래 프로젝트 파일이 여럿 | 고정: `VTS_BACKEND=clangd`(또는 `roslyn`), 또는 호출마다 `backend` 전달. |
-
-
+| `/vs-token-safer:setup`이 자동완성에 없음 | 플러그인 미설치(마켓플레이스만 추가) 또는 오래됨 | `/plugin install vs-token-safer@vs-token-safer` → `/reload-plugins`. |
+| 첫 clangd 질의가 매우 느림 | UE 규모 트리의 스폰당 clangd 비용(차가운 인덱스, 또는 영속 인덱스 재검증) | **MCP 서버**를 계속 띄워 clangd를 한 번만 스폰. `VTS_CLANGD_PERSISTED_WAIT_MS` / `VTS_LSP_INDEX_WAIT_MS` 조정. |
+| clangd 질의가 UE에서 안 돌아옴(멈춤) | VS 번들 clangd 19.1.x가 UE TU에서 **교착** | **clangd ≥ 22** 설치 후 `VTS_CLANGD_CMD`로 지정. |
+| `GenerateClangDatabase` 실패: "Unable to find valid C++ toolchain for Clang x64" | 타깃이 clang-cl로 빌드 | UBT 명령에 **`-Compiler=VisualCpp`** 추가. |
+| clangd가 헤더 없는 심볼만 해석 | 컴파일 DB에 include 경로 없음 | UBT 생성 DB 사용(경로 포함). |
+| C# 결과 없음 / "No backend resolved" | Roslyn 엔진 못 찾음 | VS Code C# 확장 설치, 또는 `csharp-ls`; 또는 `VTS_ROSLYN_DLL` / `VTS_ROSLYN_CMD` 설정. |
+| JS/TS·Python 결과 없음 | 번들 LSP 미설치(오프라인 첫 실행) | 세션 재실행, 또는 `VTS_TS_CMD` / `VTS_PY_CMD` 설정. |
+| 그냥 grep을 원했는데 코드 검색이 차단됨 | 훅이 인덱스로 유도 | `VTS_ENFORCE=0`이면 grep 통과. |
+| 잘못된 백엔드 선택 | 루트에 프로젝트 파일 여럿 | `VTS_BACKEND=clangd`로 고정(또는 호출마다 `backend`). |
 </details>
 
-## 상태 / 주의
+## 상태 &amp; 안전
 
-- **clangd 라이브 검증됨.** `compile_commands.json` 프로젝트 대상 실제 clangd로
-  `search_symbol`/`find_references`/`goto_definition`을 확인했고, **실제 Unreal 5.x 게임 프로젝트
-  end-to-end**도 포함합니다(게임 `UCLASS`와 그 `*.generated.h` 심볼을 반환). 정확한 컴파일 DB(include
-  경로 포함)와 **clangd ≥ 22**가 필요합니다. 오래된 clangd는 실제 UE TU에서 데드락합니다.
-- **Roslyn 라이브 검증됨.** 실제 `.csproj` 대상 **Microsoft.CodeAnalysis.LanguageServer**(VS 실제
-  엔진)로 확인했습니다. VS Code C# 확장 번들에서 자동 감지하며 `csharp-ls`로 폴백합니다.
-- 차가운 UE-스케일 인덱스는 첫 쿼리가 느리니 pre-warm하거나 LSP wait/timeout 환경변수를 올리세요.
-- 절감 원장과 벤치마크 수치는 응답 정형화(raw 인덱스 → 캡) 기준입니다. grep 대비 절감은 더 큽니다.
-  [BENCHMARK.md](BENCHMARK.md)를 참고하세요.
-
-## 권한 & 안전
-
-전부 **로컬**에서 동작하고 아무것도 업로드하지 않습니다:
-
-- **훅**(`PreToolUse` Bash)은 명령 문자열만 검사해 code-grep을 인덱스로 리다이렉트할지 결정합니다. 파일
-  내용을 읽거나 무언가를 실행하지 않습니다. `VTS_ENFORCE=0`을 존중합니다.
-- **언어 서버**는 기기에서 stdio로 실행됩니다. 유일한 외부 네트워크 호출은 첫 실행 시 MCP SDK의
-  `npm install`뿐입니다. 텔레메트리도 소스도 쿼리도 기기를 떠나지 않고, `~/.vs-token-safer/`에 설정과
-  로컬 토큰절감 원장만 기록합니다.
-- **gamedev-log-analyzer**는 지정한 로컬 로그 파일을 읽어 요약만 출력합니다.
-
-[SECURITY.md](SECURITY.md), [PRIVACY.md](PRIVACY.md)를 참고하세요.
-
-## 버전 히스토리
-
-버전별 노트(🚀 Features / 🐛 Bug Fixes / 📝 Documentation / 🔧 Maintenance)는 `v*` 태그마다 PR과 함께
-자동 생성됩니다. 상단 배지가 항상 최신을 가리킵니다. 전체 이력은
-**[Releases](https://github.com/JSungMin/vs-token-safer/releases)** 페이지를 보세요.
+- **clangd와 Roslyn 라이브 검증** — `search_symbol`/`find_references`/`goto_definition`을 실제 clangd(실제 Unreal 5.x 게임 프로젝트 엔드투엔드 포함)와 **Microsoft.CodeAnalysis.LanguageServer**로 확인했습니다. clangd ≥ 22와 올바른 컴파일 DB가 필요합니다.
+- **로컬 전용, 아무것도 업로드 안 함.** 훅은 명령 문자열만 검사하고(`VTS_ENFORCE=0` 존중), 언어 서버는 stdio로 돕니다. 유일한 외부 호출은 첫 실행 때 MCP SDK의 `npm install`뿐입니다. `~/.vs-token-safer/` 아래에 설정과 로컬 절감 장부만 씁니다. [SECURITY.md](SECURITY.md)·[PRIVACY.md](PRIVACY.md) 참고.
+- 절감/벤치 수치는 응답 정형(원시 인덱스 → 캡) 기준입니다. grep 대비 절감은 더 큽니다([BENCHMARK.md](BENCHMARK.md)).
 
 ## 기여
 
-이슈와 PR 환영합니다. 버그 리포트, 새 백엔드/엔진, 언어 매핑 추가, 문서 모두 좋습니다.
-
-이 repo는 AI 보조 리뷰로 유지보수합니다. PR은 diff와 설명과 증거로 판단하니 **작고, 명확히 설명되고,
-증거가 있고, 사내정보(실제 경로·심볼·프로젝트 식별자)가 없게** 올려주세요. 새 코드 경로에는
-`eval/run.mjs`에 eval 가드를 추가하세요. PR 전 **[CONTRIBUTING.md](CONTRIBUTING.md)**를 읽어주세요.
-
-**⭐ 토큰이나 디버깅 시간을 아꼈다면, star가 다른 사람들의 발견을 돕습니다.**
-
-## 개인정보
-
-이 플러그인들은 개인정보를 수집하지 않고 모든 처리를 로컬에서 합니다. [PRIVACY.md](PRIVACY.md)를 참고하세요.
+이슈와 PR 환영합니다 — 버그 신고, 새 백엔드/엔진, 언어 매핑, 문서. PR은 작게, 근거를 붙여, 독점 데이터(실제
+경로/심볼/프로젝트 식별자) 없이 보내 주세요. 새 코드 경로에는 `eval/run.mjs` 가드를 더해 주세요.
+[CONTRIBUTING.md](CONTRIBUTING.md) 참고. 토큰을 아꼈다면 별 하나가 다른 사람에게 도움이 됩니다. ⭐
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -9,137 +9,89 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/JSungMin/vs-token-safer/pulls)
 [![Stars](https://img.shields.io/github/stars/JSungMin/vs-token-safer?style=social)](https://github.com/JSungMin/vs-token-safer/stargazers)
 
-> Two Claude Code plugins for large Unreal C++, Visual Studio, and .NET projects. Search the codebase
-> through an official language server's index (clangd / Roslyn) instead of `grep`, and read tens-of-MB
-> editor logs without dumping them into the conversation. Both cost about 99% fewer tokens than the
-> naive approach. **Local-only. No IDE required.**
+> **Search and edit a large Unreal C++ / Visual Studio / .NET codebase through an official language
+> server's index (clangd / Roslyn / tsserver / pyright) instead of `grep` — token-capped to `file:line`,
+> never source bodies.** Plus a sibling plugin that reads tens-of-MB editor logs without dumping them into
+> the conversation. Both cost ~99% fewer tokens than the naive approach. **Local-only. No IDE required.**
 
-### What it looks like
 ```text
 # Claude tries to grep code → the hook REWRITES it to the indexed query, in place:
 $ grep -rn "SpawnActor" Source/**/*.cpp
-↻ [vs-token-safer] Rerouted → search_symbol "SpawnActor"   # semantic, not a text match
+↻ [vs-token-safer] Rerouted → search_symbol "SpawnActor"      # semantic, not a text match
   func SpawnActor (in AGameMode)   @ Source/GameMode.cpp:142   (+2 more)
   → ~120 tokens   (grep would have dumped thousands of lines)
-# No dead end: the search still runs, just through the index. VTS_REWRITE=0 to block instead.
 
-# A 1 MB editor log → parsed, deduped, classified (bundled gamedev-log-analyzer):
-▶ /gamedev-log-analyzer:logs
-  41,233 lines · 7 errors · 312 warnings
-  ERROR   [LogStreaming] Failed to load asset <addr>         (×128)   @ AssetManager.cpp:210
-  WARNING [LogPhysics]   Penetration depth <n> exceeds limit (×4,051) @ MyComponent.cpp:88
-  → ~130 tokens   (raw log ≈ 267,000)
+# Editing that symbol? Name it — no Read-the-whole-file, no line counting:
+$ replace_symbol_body symbol="SpawnActor" body="…"           # preview; apply=true writes
+  replace_symbol_body "SpawnActor" — PREVIEW at Source/GameMode.cpp:142-160
 ```
-<sub>Illustrative output with public Unreal Engine symbols.</sub>
+<sub>Illustrative output with public Unreal Engine symbols. `VTS_REWRITE=0` blocks instead of rewriting.</sub>
 
-### Sound familiar?
-- `grep` on a giant Unreal C++ or .NET repo floods the context. Searching clangd/Roslyn's index instead stays token-capped, around 97–99% smaller ([benchmarks](#performance-measured)).
-- A 50 MB editor log is unreadable as-is. Parse it, dedupe it, classify it, and you're down to a few hundred tokens.
-- Claude keeps reaching for `grep` on code. The hook doesn't just block it — it **rewrites the command to the indexed query in place**, so the search still runs and the flow never breaks.
-- You can't tell how much grep is still slipping through. `vts discover` reads your recent sessions and shows exactly which searches bypassed the index and what they cost.
-- Unlike an IDE-proxy approach, the language server runs headlessly. No editor needs to be open.
+## Why
 
-### Contents
-- [Marketplace — two plugins](#marketplace--two-plugins) · [Combined savings](#combined-token-savings-measured) · [Using both together](#using-both-together)
-- [What it does](#what-it-does) · [Performance](#performance-measured) · [Pre-warming & hit-rate](#pre-warming--hit-rate)
-- [Prerequisites](#prerequisites) · [Install](#install) · [Setup](#setup--configuration-command) · [Updating](#updating-to-a-new-version)
-- [Configuration](#configuration-env) · [Troubleshooting](#troubleshooting) · [Status / caveats](#status--caveats) · [Contributing](#contributing) · [Releases](https://github.com/JSungMin/vs-token-safer/releases)
+- `grep` on a giant Unreal C++ / .NET repo floods the context. The clangd/Roslyn index stays token-capped — ~97–99% smaller ([benchmarks](#performance)).
+- Claude keeps reaching for `grep`. The hook doesn't just block it — it **rewrites the command to the indexed query in place**, so the search still runs and the flow never breaks.
+- **Edit by symbol, not by line.** Replace/insert-around/delete a declaration by *naming* it — the index supplies the span, so you skip reading the whole file into context.
+- You can't tell how much grep still slips through. `vts discover` reads your recent sessions and reports exactly which searches bypassed the index and what they cost.
+- The language server runs **headlessly** — no editor open, unlike an IDE-proxy approach.
 
----
+## Quickstart
 
-Symbol search, find-references, go-to-definition, hover, outline, and project-wide rename all route
-through an official language server's index — **clangd** (C/C++), **Roslyn** (C#/.NET), **tsserver**
-(JS/TS), **pyright** (Python) — instead of Bash `grep`, and come back as a compact, capped `file:line`
-list (never source bodies). Built for large Unreal C++ / .NET codebases where `grep` is slow and burns
-context. The IDE-agnostic sibling of
-[rider-mcp-enforcer](https://github.com/JSungMin/rider-mcp-enforcer): same goal, but it spawns the
-language server headlessly — no editor open.
-
-## Marketplace — two plugins
-
-This repo is a Claude Code plugin marketplace. It holds two plugins built around the same goal: reading
-big things without paying for all of it in tokens.
-
-| Plugin | Does | Needs |
-| --- | --- | --- |
-| **vs-token-safer** (this page) | Force code search through clangd/Roslyn/tsserver/pyright's index over Bash grep (hard-block by default, escape hatch opt-out), token-capped to `file:line` | Node + a language server: clangd / Roslyn (you install), JS/TS + Python (auto-installed). No IDE. |
-| **[gamedev-log-analyzer](gamedev-log-analyzer/README.md)** | Parse/dedup/classify huge Unreal/Unity/Godot/MSVC-UBT-MSBuild logs (CLI-first), search + diff + locate + extract scalars | Node only (no IDE) |
-
-One-step install: `vs-token-safer` declares `gamedev-log-analyzer` as a dependency, so installing it
-pulls in both. Each server's `npm install` runs on the first session, so you don't set anything up by
-hand:
 ```bash
+# 1) Install (also auto-installs the gamedev-log-analyzer sibling)
 /plugin marketplace add JSungMin/vs-token-safer
-/plugin install vs-token-safer@vs-token-safer        # also auto-installs gamedev-log-analyzer
-/reload-plugins                                       # first run auto-installs deps for both
+/plugin install vs-token-safer@vs-token-safer
+/reload-plugins        # first run auto-installs the server deps (no manual npm)
+
+# 2) Configure — detects the backend, asks for the project path, writes the config
+/vs-token-safer:setup
 ```
-Want only the log analyzer? Install it alone: `/plugin install gamedev-log-analyzer@vs-token-safer`.
 
-### Combined token savings (measured)
-| Task | Bash / raw | Plugin | Reduction |
-| --- | ---: | ---: | ---: |
-| Symbol search on a real UE5 repo (`FGameplayTag`) | ~282,194 tok | ~2,048 tok | **~99.3% (~138×)** |
-| Raw index response → capped list (eval, 1,000 symbols) | ~57,308 tok | ~1,549 tok | **~97.3%** |
-| Read a ~1 MB editor log (`summary`) | ~267,000 tok | ~130 tok | **~99.95%** |
+Then **restart the Claude Code session** (the `vs-search` MCP server only starts on a fresh session).
+Verify the tools appear and that `grep src/**/*.cpp` is rerouted to the index. Prerequisites: **Node ≥ 18**
+and a language server — clangd (C/C++) / Roslyn (C#) you install; JS/TS + Python auto-install. Details in
+[Prerequisites](#prerequisites-details) below.
 
-### Using both together
-The log analyzer emits `file:line` for each entry; vs-token-safer turns a `file:line` into the actual
-symbol/source. A typical loop:
-1. `/gamedev-log-analyzer:logs` → find the error/warning and its `file:line`.
-2. Hand that location to vs-token-safer's `goto_definition` / `find_references` (or `search_symbol`) to
-   open and understand the code, without ever grepping or dumping the raw log.
+> Want only the log analyzer? `/plugin install gamedev-log-analyzer@vs-token-safer`.
 
-The handoff also runs in reverse: if a code search (a vs-search tool, or a Bash/Grep search) is aimed at a
-log — a `Logs/` dir or a `.log`/`.jsonl` file — vs-token-safer points you back at gamedev-log instead of
-returning an empty result from the code index. The language-server index covers source, not logs.
+## Tools
 
-## What it does
+All search/edit goes through an official language-server index — **clangd** (C/C++), **Roslyn** (C#/.NET),
+**tsserver** (JS/TS), **pyright** (Python) — and comes back as a compact, capped `file:line` list (never
+source bodies). MCP server `vs-search`; same tools as the `vts` CLI.
 
-clangd and Roslyn already do semantic symbol/reference analysis on their own. What this plugin adds on
-top is enforcement, a token cap, and a headless spawn plus warm-up, so Claude actually uses the index
-instead of grep:
+**Search / navigate**
 
-| Layer | File | Effect |
+| Tool | CLI | Does |
 | --- | --- | --- |
-| **Rewrite/enforcement hook** | `hooks/block-code-grep.js` | Covers three surfaces. **Bash** `grep`/`rg`/`ack`/`ag`/`findstr`/`git grep`/`find -name` over source — when it's a single safe segment — is **rewritten to the equivalent `vts` query in place** (an identifier → semantic `search_symbol`, a literal → `search_text`, a `find <dir> -name` → `find_files` rooted at `<dir>`); anything ambiguous (a pipeline, a non-literal pattern, a multi-`-name`/`-o` find that can't be one call) falls back to a block. The built-in **Grep tool**: a clear *symbol hunt* — a bare identifier, a `::`/`(`/`void·class`-style regex, or a CamelCase alternation like `FooBar|BazQux` — is **blocked** with a ready-to-use `search_symbol`/`search_text` call; freeform text and keyword alternations (`TODO|FIXME`) stay a warn. The built-in **Glob tool**: a concrete code-file pattern (`*.cpp`, `Foo.h`, `**/Bar.*`) is **blocked** toward `find_files` (which is walk-bounded, so it won't time out on a giant tree); asset/bare globs (`Foo.png`, `**/*`) are left alone. Messages are agent-directed (they tell the assistant the exact tool to re-run) and i18n'd (EN/KO). Raw-text searches (logs, `.md`/`.json`, config, build dirs) pass through untouched. `VTS_REWRITE=0` → block instead of rewrite; `VTS_GREP_BLOCK=0` → the Grep/Glob escalation reverts to warn-only; `excludeCommands` opts a command out; `VTS_ENFORCE=0` disables all of it. |
-| **Routing skill** | `skills/vs-search/SKILL.md` | Rules that bias Claude toward the indexed tools first: symbol/reference/definition lookups go to `search_symbol` / `find_references` / `goto_definition`, and grep is a last resort. |
-| **Token-capping core** | `server/core.js` | `runTool()` shared by both adapters: turns LSP results into `kind name (in container) @ file:line`, caps at `maxResults`, appends a `… N more` footer. Never ranges, kinds, or source bodies. A refs-heavy result is collapsed further — `find_references` coalesces one row per file (`Foo.cpp:42,88,120`) and factors out a shared directory prefix once, so a deep tree of call sites stays small (every location preserved; `VTS_COMPACT_RESULTS=0` restores one-per-line). A truncated `find_files`/`search_text` writes the full set to a recovery (tee) file so nothing is silently dropped. |
-| **Savings + discover** | `server/core.js` | A local ledger records every search's tokens-saved (with a 30-day graph, daily/history, and an estimated value via `vts savings`). `vts discover` scans your recent Claude sessions for code searches that *bypassed* the index and reports the tokens they cost — so you can see the catch-rate, not just the wins. |
-| **Headless LSP client** | `server/lsp.js` + `server/backends/index.js` | A minimal, fully-owned LSP client (JSON-RPC 2.0, `Content-Length` framing) that spawns the official engine over stdio, plus the spawn configs, `pickBackend(root)` autodetect, and the IDE-style pre-warm (`afterInit`). The project root is resolved **per call** — an explicit `projectPath`, else the enclosing project of the file in the query, else the MCP workspace root — so one globally-installed server answers for **every repo a session touches**, not just one configured pin. Live backends are pooled and bounded (`VTS_MAX_BACKENDS`, plus an idle reaper) so touching several repos can't spawn an unbounded number of language servers. |
-| **VCS output compaction** | `server/compact.js` | The index can't help with `git`/`p4` output, but the raw dump is verbose and repetitive. `vts_git` / `vts_p4` run a **read-only** command and group/dedup/cap the result (status by change-type + dir, log one line per commit, diff as a per-file diffstat, `p4 opened` by action + depot dir), recorded in the same savings ledger. Mutating subcommands are refused; the hook reroutes a plain `git status` / `p4 opened` here automatically. |
+| `search_symbol` | `vts symbol` | Find a symbol declaration by name/substring (semantic, not text). |
+| `find_references` | `vts references` | Every call site of a symbol. Takes the **name directly** (`symbol="FooBar"`) — the one to reach for when you change a function/type and must touch every use. |
+| `goto_definition` | `vts definition` | Definition of the symbol at a position. |
+| `hover` | `vts hover` | Type/signature at a position. |
+| `document_symbols` | `vts symbols` | Outline a file (classes/functions/types as `file:line`). |
+| `find_files` | `vts files` | Find files by name/glob — token-capped stand-in for `find -name`. |
+| `search_text` | `vts text` | Raw text/regex search — capped stand-in for `grep` (`path=`/`glob=`/`docs=true` to target). |
 
-> **Engine = official, glue = ours.** clangd (LLVM) and Roslyn (Microsoft) do the analysis; this repo
-> only writes the LSP↔MCP glue. No third-party MCP server runs over your source.
+**Edit (symbol-level — name it, don't line-count)** — preview by default, `apply=true` writes.
 
-> **It gets better the more you use it.** The pieces compose into a feedback loop: the rewrite sends a
-> bare identifier to the *semantic* `search_symbol` (not just a text grep), `vts discover --learn` feeds
-> the files your past searches actually hit into the warm-up set so the next session pre-loads them, and
-> `discover` reports a catch-rate so you know what's still slipping through. Each session leaves the index
-> warmer and the enforcement tighter.
+| Tool | CLI | Does |
+| --- | --- | --- |
+| `rename` | `vts rename` | Semantic project-wide rename (every reference, not a text sed). |
+| `replace_symbol_body` | `vts replace-symbol` | Replace a whole declaration (signature + body) by name — the index supplies the span. |
+| `insert_after_symbol` | `vts insert-after` | Insert text after a declaration (e.g. add a sibling method). |
+| `insert_before_symbol` | `vts insert-before` | Insert text before a declaration (e.g. an import/attribute). |
+| `safe_delete` | `vts safe-delete` | Delete a declaration — **refuses while it's still referenced** unless `force=true`. |
 
-### Commands & tools
-- `/vs-token-safer:setup` — configure the plugin (see [Setup](#setup--configuration-command)).
-- `/vs-token-safer:savings` — show cumulative token savings.
-- MCP tools (server `vs-search`): `search_symbol`, `find_references`, `goto_definition`, `hover`,
-  `document_symbols`, `rename`, `find_files`, `search_text`, `vts_git`, `vts_p4`, `vts_warmup`, `vts_setup`,
-  `vts_config`, `vts_savings`, `vts_savings_reset`, `vts_discover`. `find_files` and `search_text` are the
-  token-capped stand-ins for `find -name` and `grep` when you genuinely need a filename or raw text rather
-  than a symbol — `search_text` can target one file (`path=`) or a glob (`glob=`, auto-including that
-  extension) or widen to docs (`docs=true`). `vts_git` / `vts_p4` run a **read-only** git/p4 command and
-  return its output compacted (grouped, deduped, capped) — `git status/log/diff`, `p4 opened/status/
-  changes`; mutating subcommands are refused. `rename` is a semantic, project-wide rename: preview by
-  default, `apply=true` to write the edits. `vts_discover` finds code searches that bypassed the index
-  (missed savings; `learn=true` feeds their result files into the warm-up set).
-- **Editing a symbol?** `find_references` takes the symbol NAME directly — `find_references symbol="FooBar"`
-  returns every call site, no line/column needed. It's the one to reach for when you change a function or
-  type and have to touch every use; grepping the name gives you comments and substrings, this gives you the
-  semantic references. (A `path`+`line`+`character` position still works to pin an exact overload.)
-- CLI (`vts`): `symbol`, `references`, `definition`, `hover`, `symbols`, `rename`, `files`, `text`
-  (`--path`/`--glob`/`--docs`), `git`, `p4` (compacted, read-only — e.g. `vts git status`, `vts p4 opened`),
-  `warmup`, `setup`, `config`, `savings` (`--graph`/`--daily`/`--history`), `savings-reset`, `discover`
-  (`--since N`/`--all`/`--learn`).
-- Or hand a whole "where is X / what calls Y / find file W" lookup to the `code-locator` subagent. It
-  does the searching in its own context and gives you back only the `file:line` table.
+**Version control (output compaction, read-only)**
+
+| Tool | CLI | Does |
+| --- | --- | --- |
+| `vts_git` | `vts git` | Run a read-only `git status/log/diff` and group/dedup/cap the output. Mutating subcommands refused. |
+| `vts_p4` | `vts p4` | Same for Perforce `opened/status/changes/reconcile`. |
+
+Plus `vts_warmup`, `vts_setup`, `vts_config`, `vts_savings`, `vts_savings_reset`, `vts_discover`,
+`vts_gen_compile_db`. Or hand a whole "where is X / what calls Y / find file W" lookup to the
+**`code-locator` subagent** — it searches in its own context and returns only the `file:line` table.
 
 ```
 $ vts symbol --q SpawnActor --projectPath ./MyGame
@@ -151,59 +103,78 @@ func SpawnActorFromClass  @ MyGame/Source/SpawnLib.cpp:31
 ✓ Saved ~4,200 tokens here (96.8% / 31× smaller than the raw index response).
 ```
 
-## Performance (measured)
+## How it works
 
-A real A/B on a large Unreal Engine 5 project: finding one public engine symbol (`FGameplayTag`) via
-Bash grep-and-paste vs this plugin. No project source is reproduced, only aggregate counts. See
-[BENCHMARK.md](BENCHMARK.md) for method.
+clangd and Roslyn already do the semantic analysis. What this plugin adds is **enforcement, a token cap,
+and a headless spawn + warm-up**, so Claude actually uses the index instead of grep:
+
+| Layer | Effect |
+| --- | --- |
+| **Rewrite/enforcement hook** | Covers three surfaces. **Bash** grep/rg/`find -name` over source → **rewritten to the equivalent `vts` query in place** (identifier → `search_symbol`, literal → `search_text`, `find <dir> -name` → `find_files` rooted at `<dir>`); ambiguous cases (pipeline, multi-`-name`) block. **Grep tool** symbol hunt (bare identifier, `::`/`(`/`void·class` regex, or a `FooBar\|BazQux` CamelCase alternation) → **blocked** with a ready-to-use call; freeform/keyword alternations stay a warn. **Glob tool** concrete code file (`*.cpp`, `Foo.h`) → **blocked** toward `find_files`. Messages are agent-directed and i18n'd (EN/KO). Logs/`.md`/config pass through. Knobs: `VTS_REWRITE=0`, `VTS_GREP_BLOCK=0`, `VTS_ENFORCE=0`. |
+| **Token-capping core** | Turns LSP results into `kind name @ file:line`, caps, appends `… N more`. A refs-heavy result collapses to one row per file (`Foo.cpp:42,88,120`) with a shared dir prefix factored out once (`VTS_COMPACT_RESULTS=0` restores per-line). A truncated `find_files`/`search_text` tees the full set to a recovery file. |
+| **Symbol-level editing** | `replace_symbol_body`/`insert_*`/`safe_delete` resolve a declaration by name via the outline and splice text at its exact span — preview by default, `apply=true` writes, `safe_delete` refuses while referenced. No whole-file Read into context. |
+| **Headless LSP client** | A fully-owned LSP client spawns the official engine over stdio. The project root is resolved **per call** (explicit `projectPath` → the file's enclosing project → the MCP workspace root), so one global server answers for **every repo a session touches**. Live backends are pooled and bounded (`VTS_MAX_BACKENDS` + idle reaper). |
+| **Savings + discover** | A local ledger records every search's tokens-saved (`vts savings`, with a 30-day graph). `vts discover` scans recent sessions for searches that *bypassed* the index — so you see the catch-rate, not just the wins. |
+
+> **Engine = official, glue = ours.** clangd (LLVM) and Roslyn (Microsoft) do the analysis; this repo
+> only writes the LSP↔MCP glue. No third-party MCP server runs over your source. Local-only, nothing uploaded.
+
+## The two plugins
+
+| Plugin | Does | Needs |
+| --- | --- | --- |
+| **vs-token-safer** (this page) | Force code search/edit through the clangd/Roslyn/tsserver/pyright index over Bash grep, token-capped to `file:line` | Node + a language server (clangd / Roslyn you install; JS/TS + Python auto). No IDE. |
+| **[gamedev-log-analyzer](gamedev-log-analyzer/README.md)** | Parse/dedup/classify huge Unreal/Unity/Godot/MSVC-UBT logs, search + diff + extract scalars | Node only |
+
+`vs-token-safer` declares `gamedev-log-analyzer` as a dependency, so one install pulls in both. **Used
+together:** the log analyzer emits `file:line` per entry → hand it to `goto_definition`/`find_references`
+to open the code, without grepping or dumping the raw log. The handoff runs in reverse too — a code search
+aimed at a log (`Logs/`, `.log`/`.jsonl`) points you back at gamedev-log instead of an empty result.
+
+| Combined savings (measured) | Bash / raw | Plugin | Reduction |
+| --- | ---: | ---: | ---: |
+| Symbol search on a real UE5 repo (`FGameplayTag`) | ~282,194 tok | ~2,048 tok | **~99.3% (~138×)** |
+| Raw index response → capped list (eval, 1,000 symbols) | ~57,308 tok | ~1,549 tok | **~97.3%** |
+| Read a ~1 MB editor log (`summary`) | ~267,000 tok | ~130 tok | **~99.95%** |
+
+## Performance
+
+A real A/B on a large Unreal Engine 5 project: finding one public engine symbol (`FGameplayTag`) via Bash
+grep-and-paste vs this plugin. No project source is reproduced, only aggregate counts; see
+[BENCHMARK.md](BENCHMARK.md).
 
 | | Bash grep-and-paste (whole repo) | **Plugin (clangd index, capped)** |
 | --- | ---: | ---: |
 | What the model receives | 5,654 lines / 1,010 files | 47 semantic decls (`file:line`) |
 | Tokens to the model | ~282,194 | **~2,048** |
 
-- **Tokens: ~99.3% fewer (~138×).** grep returns the full text of every matching line, and it matches by
-  text so it returns more of them (comments, strings, unrelated identifiers). The plugin returns one
-  `file:line` per semantic hit, capped.
-- The mock-LSP eval (`node eval/run.mjs`, no toolchain) gates the response-shaping win on every commit:
-  raw index `~57,308 tok` → capped output `~1,549 tok` = **97.3%** (52/52 checks).
+**~99.3% fewer (~138×).** grep returns the full text of every matching line and matches by text (comments,
+strings, unrelated identifiers); the plugin returns one `file:line` per semantic hit, capped. The mock-LSP
+eval (`node eval/run.mjs`, no toolchain) gates this on every commit: `~57,308 → ~1,549 tok` = **97.3%**
+(53/53 checks).
 
-### Accuracy difference (and why)
-This is a precision/recall trade-off, not a case of one being more correct than the other:
-- **Recall:** the plugin returns the top `N` (cap), not every textual occurrence. The withheld tail is
-  mostly comments, includes, and substring noise. Need an exhaustive list? Raise `maxResults`, or use
-  grep.
-- **Precision:** grep matches every substring (a `Foo` query also hits `FooBar`), so it over-reports
-  heavily. The index returns distinct semantic declarations: `search_symbol` is a symbol-index query,
-  and `find_references`/`goto_definition` resolve the symbol at a position rather than a text match.
+<details>
+<summary><b>Accuracy: precision/recall trade-off</b></summary>
 
-> So for navigation (a definition plus representative usages) the plugin is both more accurate and far
-> cheaper. For an exhaustive occurrence audit, raise the cap or fall back to grep on purpose.
+- **Recall:** the plugin returns the top `N` (cap), not every textual occurrence — the withheld tail is mostly comments/includes/substring noise. Need exhaustive? Raise `maxResults`, or use grep.
+- **Precision:** grep matches every substring (`Foo` also hits `FooBar`); the index returns distinct semantic declarations.
 
-## Pre-warming & hit-rate
+So for navigation (a definition plus representative usages) the plugin is both more accurate and far
+cheaper. For an exhaustive occurrence audit, raise the cap or fall back to grep on purpose.
+</details>
 
-clangd indexes asynchronously, so the *first* search after the server starts pays a one-time warm-up: it
-indexes the engine headers. vs-token-safer handles this like an IDE.
+<details>
+<summary><b>Pre-warming &amp; hit-rate</b></summary>
 
-- **The MCP server pre-warms at boot** (`VTS_PREWARM`, on by default when `projectPath` is set). By the
-  time you run your first search the index is already warming, and the client is cached for the server's
-  lifetime, so you pay the warm-up once per session rather than per query (later searches are
-  sub-second).
-- **`vts warmup`** builds clangd's on-disk index (`.cache/clangd`) up front, for CLI/CI use.
-- **`VTS_CLANGD_REMOTE`** points clangd at a shared/prebuilt clangd-index-server, for near-zero
-  per-developer warm-up (teams/CI query one prebuilt index).
+clangd indexes asynchronously, so the *first* search pays a one-time warm-up. vts handles this like an IDE:
+the MCP server **pre-warms at boot** (`VTS_PREWARM`, on when `projectPath` is set) and keeps the client
+cached for the session, so you pay it once. `vts warmup` builds the on-disk index up front (CLI/CI), and
+`VTS_CLANGD_REMOTE` points clangd at a shared prebuilt index server.
 
-Which files get warmed first matters. clangd boosts the indexing priority of files you open, so vts
-orders the warm-up set likely-query-first: **query history** (files that answered past searches), then
-**what you're editing now** (`git status` modified/untracked + Perforce `p4 opened`), then **git-log
-recency**, then **include centrality** (headers that many candidates `#include`, computed adaptively via
-a persistent include-graph cache that fills a time budget's worth each warm-up, growing coverage over
-runs), then mtime. On a huge tree you can only warm a small slice (hundreds of TUs out of tens of
-thousands in Unreal), so this ordering is what makes the warm window actually contain what you search
-for. Works with both git and Perforce.
-
-Measured lift (`node eval/bench-hitrate.mjs`, the real `orderForWarm()` over a synthetic workload with
-realistic locality, 2,000 files):
+Ordering matters: clangd boosts the priority of files you open, so vts warms **query-history-first**, then
+what you're editing now (`git status` / `p4 opened`), then git-log recency, then include-centrality, then
+mtime. On a huge tree you can only warm a small slice, so this is what makes the warm window contain what
+you search for. Measured lift (`node eval/bench-hitrate.mjs`, 2,000 files):
 
 | warm-up cap | arbitrary order | history-ordered | lift |
 | --- | --- | --- | --- |
@@ -213,324 +184,164 @@ realistic locality, 2,000 files):
 | 20% | 24.8% | **68.5%** | 2.8× |
 | 50% | 46.3% | **80.5%** | 1.7× |
 
-The smaller the slice you can afford to warm, the bigger the win. Arbitrary order hits almost nothing;
-ordering hits the majority.
+The smaller the slice you can afford to warm, the bigger the win.
+</details>
 
-## How much did it save? (token-savings command)
+<details>
+<summary><b>Savings &amp; discover (catch-rate)</b></summary>
 
-For each search, the core records the tokens it saved vs forwarding the language server's raw index
-response. Check the running total any of these ways:
+Each search records the tokens it saved vs forwarding the raw index response. Check it with
+`/vs-token-safer:savings`, `vts savings` (`--graph`/`--daily`/`--history`), or reset via `vts savings-reset`.
 
-- **In Claude Code:** run `/vs-token-safer:savings` (or just ask "how much has the plugin saved?"). It
-  calls the `vts_savings` MCP tool.
-- **From a shell:** `vts savings`
-- **Reset:** call the `vts_savings_reset` tool (or `vts savings-reset`).
-
-Example output:
 ```
 vs-token-safer savings (local, 1 search(es))
   total saved: ~4,200 tokens vs forwarding raw index responses
   raw → output: 4,340 → 140 tok (~31× smaller)
-  biggest single run: 4,340 → 140 tok
-  est. value: ~$0.01 (@ $3/Mtok — rough, set VTS_USD_PER_MTOK)
+  est. value: ~$0.01 (@ $3/Mtok — set VTS_USD_PER_MTOK)
 ```
-`vts savings --graph` adds a 30-day ASCII chart of saved tokens; `--daily` and `--history` break it down
-by day and by recent run. That's the *caught* side. For the *missed* side, `vts discover` scans your
-recent Claude sessions for code searches that went around the index and reports what they cost — together
-they give a catch-rate, not just a feel-good total:
+
+That's the *caught* side. `vts discover` scans recent sessions for searches that went **around** the index:
+
 ```
 $ vts discover --since 1
-vs-token-safer discover — missed token savings (local scan, last 1 day(s), 9 transcript(s))
   86 code search(es) bypassed vts (Grep×48, Glob×18, grep×12, find×8)
-  raw tool output ingested: ~28,692 tok — routed through vts most of this is avoidable
   catch-rate: ~770,333 tok caught (via vts) vs ~28,692 still bypassing → 96.4% routed through vts
 ```
-(Searches the hook itself blocked don't count as bypasses — only the ones that actually slipped through.)
-> "Saved" here is vs the language server's *raw* index response. Savings vs Bash grep are typically far
-> larger; see [BENCHMARK.md](BENCHMARK.md). `discover` is local and read-only — it reads transcript
-> metadata and tool I/O sizes, never ships any of it anywhere.
 
-## Prerequisites
+(Searches the hook *blocked* don't count as bypasses.) `discover` is local and read-only — it reads
+transcript metadata and tool I/O sizes, never ships any of it anywhere. `--learn` feeds the files past
+searches hit into the warm-up set, so each session leaves the index warmer.
+</details>
+
+## Prerequisites (details)
+
+<details>
+<summary><b>Language servers &amp; the compile database</b></summary>
 
 - **Node.js ≥ 18** on PATH.
-- A language server for the language(s) you search:
-  - **C/C++ → clangd ≥ 22** ([clangd releases](https://github.com/clangd/clangd/releases)). The clangd
-    19.1.x bundled with Visual Studio (`…/VC/Tools/Llvm/bin/clangd.exe`) deadlocks indexing real
-    Unreal translation units in server mode, and vts warns if it detects an older one. Needs a
-    `compile_commands.json` compile database.
-  - **C#/.NET → a Roslyn LSP.** Install the VS Code C# extension (`ms-dotnettools.csharp`) and vts
-    auto-detects `Microsoft.CodeAnalysis.LanguageServer` and its private .NET runtime from the bundle.
-    Fallback: `dotnet tool install --global csharp-ls`. Needs a `.sln`/`.csproj`.
-  - **JS/TS → typescript-language-server, Python → pyright.** These ship as plugin dependencies and
-    install automatically on the first session — nothing to set up. vts launches the bundled copy with
-    `node`, so there's no global install or PATH dance. Point `VTS_TS_CMD`/`VTS_PY_CMD` at your own if you
-    prefer. (Heads-up: bundling them adds a one-time ~50 MB to the plugin's first-run `npm install`, and
-    the JS/TS server wants **Node 20+** — on Node 18 it's skipped and the other backends still work.)
-- No IDE has to be running.
+- **C/C++ → clangd ≥ 22** ([releases](https://github.com/clangd/clangd/releases)). The clangd 19.1.x bundled with Visual Studio **deadlocks** indexing real Unreal TUs in server mode; vts warns on an older one. Needs a `compile_commands.json`.
+- **C#/.NET → a Roslyn LSP.** Install the VS Code C# extension (`ms-dotnettools.csharp`) — vts auto-detects `Microsoft.CodeAnalysis.LanguageServer` and its runtime from the bundle. Fallback: `dotnet tool install --global csharp-ls`. Needs a `.sln`/`.csproj`.
+- **JS/TS → typescript-language-server, Python → pyright.** Ship as plugin deps, install automatically on the first session (one-time ~50 MB; JS/TS wants Node 20+, skipped on 18).
 
-clangd needs a compile database (`compile_commands.json`):
-- **Unreal Engine:** generate via UBT, `<UE>/Engine/Build/BatchFiles/RunUBT … -mode=GenerateClangDatabase`.
-  If your targets build with clang-cl, add **`-Compiler=VisualCpp`**, otherwise
-  `GenerateClangDatabase` fails clang-toolchain validation (`Unable to find valid C++ toolchain for
-  Clang x64`). The MSVC-compiler database still resolves the full engine include graph for clangd.
-- **CMake:** configure with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.
+**clangd needs a compile database:**
+- **Unreal:** `<UE>/Engine/Build/BatchFiles/RunUBT … -mode=GenerateClangDatabase`. If targets build with clang-cl, add **`-Compiler=VisualCpp`** or it fails clang-toolchain validation.
+- **CMake:** `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.
 
-### No compile DB yet? Here's exactly what happens
+**No compile DB yet?** You still get answers — `search_symbol` falls back to a bounded literal text
+search, labeled as such, and the first result carries a one-time advisory. The one-command fix:
+`vts_gen_compile_db` (CLI `vts gen-compile-db`) assembles the exact UBT command (finds the `.uproject`,
+derives the `<Name>Editor` target, locates the engine, adds `-Compiler=VisualCpp`). **Dry-run by default**;
+`apply=true` runs UBT and parks the DB **outside the source tree** (`~/.vs-token-safer/db/<project>`, with
+clangd's `.cache/` next to it, so git/`p4 reconcile` never see an artifact). `inTree=true` keeps the
+classic project-root layout, protected by a VCS-ignore guard.
+</details>
 
-A fresh Unreal project usually doesn't have a `compile_commands.json`, and clangd can't build a semantic
-index without one. The plugin doesn't fail silently or leave you at a dead end:
+<details>
+<summary><b>Standalone CLI (no IDE, no Claude Code)</b></summary>
 
-1. **You still get answers.** `search_symbol` falls back to a bounded literal text search, clearly
-   labeled (`Literal text matches … not a semantic decl`) — the name is still locatable, just as text
-   rather than as a resolved symbol.
-2. **You're told why, once.** The first clangd result carries a one-time advisory explaining the index
-   is empty because the compile DB is missing, and `/vs-token-safer:setup` flags it up front when it
-   censuses a C++ project without one.
-3. **The fix is one command, and it's your call.** `vts_gen_compile_db` (CLI: `vts gen-compile-db`)
-   assembles the exact UBT `GenerateClangDatabase` command for your project: it finds the `.uproject`,
-   derives the `<Name>Editor` target, locates the engine (`VTS_UE_ROOT`, an `engineRoot` arg, or a
-   walk-up from the project), and adds `-Compiler=VisualCpp` for clang-cl targets. **Dry-run by
-   default** — it prints the command and runs nothing. Pass `apply=true` and it runs UBT (takes a few
-   minutes), then parks the resulting DB **outside the source tree** at `~/.vs-token-safer/db/<project>`
-   and points clangd there — clangd writes its `.cache/` index next to the DB, so git and `p4 reconcile`
-   never see a single artifact. Want the classic project-root layout instead? Pass `inTree=true`: the DB
-   lands at the project root and a VCS-ignore guard protects it (`.gitignore` append, or the Perforce
-   ignore file found by walking up to the depot root — a versioned read-only file gets the exact
-   `p4 edit` lines instead), with the stray engine-root copy removed either way.
-4. Restart the MCP server (or rerun the query) and `search_symbol` / `find_references` /
-   `goto_definition` answer semantically from the full engine index.
-
-Staying in no-DB text mode is a perfectly reasonable choice for quick lookups. The full DB pays off
-when you need references and definitions resolved across the engine include graph.
-
-## Install
-
-```bash
-# 1) Add the marketplace and install (also auto-installs gamedev-log-analyzer)
-/plugin marketplace add JSungMin/vs-token-safer
-/plugin install vs-token-safer@vs-token-safer
-/reload-plugins        # first run auto-installs the server deps (no manual npm)
-
-# 2) Configure it — from inside Claude Code, just run:
-/vs-token-safer:setup
-#   It detects the backend, asks for the project path, and writes the config.
-```
-
-Verify the `vs-search` MCP server and its tools appear, and that a `grep src/**/*.cpp` is blocked with a
-nudge toward the indexed tools (or runs freely under `VTS_ENFORCE=0`). The MCP server's one dependency
-(`@modelcontextprotocol/sdk`) installs automatically on the first session, into the plugin's data
-directory. **Already had Claude Code open when you installed? Restart the session** — the MCP server only
-starts (and later, only picks up a new version) on a fresh session, not on `/reload-plugins` alone (see
-[Updating](#updating-to-a-new-version)).
-
-### As a standalone CLI (no IDE, no Claude Code)
-
-vs-token-safer isn't published to npm, so install the `vts` CLI from a clone:
+Not published to npm — install `vts` from a clone:
 
 ```bash
 git clone https://github.com/JSungMin/vs-token-safer
 cd vs-token-safer/server && npm install && npm link   # provides `vts`
-# or run directly, no link:
-node /path/to/vs-token-safer/server/cli.js symbol --q SpawnActor --projectPath /path/to/proj
+# or run directly: node /path/to/vs-token-safer/server/cli.js symbol --q SpawnActor --projectPath /path/to/proj
 ```
+</details>
 
-## Setup / configuration command
-
-You don't edit OS environment variables. Settings live in a config file
-(`~/.vs-token-safer/config.json`) the CLI and MCP server read at startup. Configure it any of these ways:
-
-- **In Claude Code (recommended):** `/vs-token-safer:setup` is guided. It shows current settings
-  (`vts_config`), detects the backend, asks for `projectPath`, and applies via the `vts_setup` tool.
-  Then `/reload-plugins`.
-- **Ad-hoc via tools:** ask Claude to call `vts_setup { "projectPath": "…", "backend": "clangd" }`, or
-  `vts_config` to show effective settings.
-- **From a shell:**
-  ```bash
-  vts setup --projectPath <root> --backend clangd
-  vts config
-  ```
-
-Backend auto-detects from the root: `compile_commands.json` (or a `.uproject`) picks **clangd**; a
-`.sln`/`.csproj` picks **roslyn**. Settings are read at startup, so **run `/reload-plugins` after
-changing them**. Precedence: **environment variable (`VTS_*`) > config file > built-in default**, so a
-same-named env var still wins.
-
-## Updating to a new version
-
-Claude Code caches the marketplace repo, so new commits are **not** auto-fetched. To pull a newer
-version of this plugin:
-
-```bash
-# 1) Refresh the cached marketplace catalog
-/plugin marketplace update vs-token-safer
-
-# 2) Update the installed plugin (or uninstall + install to be sure)
-/plugin update vs-token-safer
-#   fallback: /plugin uninstall vs-token-safer  then  /plugin install vs-token-safer@vs-token-safer
-
-# 3) Reload the hooks/commands/skills
-/reload-plugins
-
-# 4) RESTART the Claude Code session — this step is REQUIRED, not optional.
-#    `/reload-plugins` reloads hooks/commands/skills, but the vs-search MCP server is a child process
-#    spawned ONCE at session start. It keeps running the OLD code until you restart, so the new
-#    plugin version's tools (search_symbol, find_references, …) won't actually change until you do.
-```
-
-> ⚠️ **A new plugin version only takes full effect after a session restart.** `/reload-plugins` is not
-> enough on its own — the running `vs-search` MCP server process is not restarted by it, so it serves the
-> previous version's tool code until you quit and reopen Claude Code. Hooks/commands/skills update on
-> reload; the MCP server (and therefore every `search_*` / `find_*` tool) updates only on restart.
-
-Check what's installed with `/plugin` (it lists each plugin's version). If a command like
-`/vs-token-safer:setup` is missing, your installed copy predates it, so update as above.
-
-> Maintainer note: the `version` field in `.claude-plugin/plugin.json` (and the marketplace entry) gates
-> updates, so bump it when you want clients to pick up changes. The headline plugin must bump even when
-> the change lands only in the bundled `gamedev-log-analyzer` (which keeps its own independent semver),
-> otherwise clients see "already at latest". Version history lives in
-> [Releases](https://github.com/JSungMin/vs-token-safer/releases) (auto-generated on each `v*` tag), not
-> in this README.
-
-## Configuration (env)
+## Configuration
 
 <details>
-<summary><b>Show all environment variables</b></summary>
+<summary><b>Setup command &amp; updating</b></summary>
 
-Precedence: **environment variable (`VTS_*`) > `~/.vs-token-safer/config.json` > default.**
+Settings live in `~/.vs-token-safer/config.json` (read at startup — `/reload-plugins` after changes).
+Configure via `/vs-token-safer:setup` (guided), `vts_setup`/`vts_config` tools, or `vts setup
+--projectPath <root> --backend clangd`. Backend auto-detects from the root. Precedence: **env (`VTS_*`) >
+config file > default.**
+
+**Updating:** Claude Code caches the marketplace, so new commits aren't auto-fetched:
+```bash
+/plugin marketplace update vs-token-safer
+/plugin update vs-token-safer
+/reload-plugins
+# then RESTART the session — REQUIRED.
+```
+> ⚠️ A new version only takes full effect after a **session restart**. `/reload-plugins` updates
+> hooks/commands/skills, but the running `vs-search` MCP server serves the old tool code until you quit
+> and reopen. Version history: [Releases](https://github.com/JSungMin/vs-token-safer/releases).
+</details>
+
+<details>
+<summary><b>All environment variables</b></summary>
+
+Precedence: **`VTS_*` env > `~/.vs-token-safer/config.json` > default.**
 
 | Config key | Env var | Default | Meaning |
 | --- | --- | --- | --- |
 | `projectPath` | `VTS_PROJECT_PATH` | cwd | Project root (where the compile DB / `.sln` lives). |
-| `backend` | `VTS_BACKEND` | auto | `clangd` \| `roslyn` (auto-detected from the root). |
+| `backend` | `VTS_BACKEND` | auto | `clangd` \| `roslyn` \| `typescript` \| `pyright`. |
 | `maxResults` | `VTS_MAX_RESULTS` | `60` | Cap on returned `file:line` locations. |
-| — | `VTS_COMPACT_RESULTS` | `1` | `0` restores one-location-per-line output (disables the `find_references` per-file + common-prefix collapse). |
-| — | `VTS_MAX_BACKENDS` | `2` | Max concurrently-live language servers; the least-recently-used idle one is evicted past the cap (memory guard for multi-repo use). |
-| — | `VTS_BACKEND_IDLE_MS` | `300000` | A language server idle this long is shut down by a background reaper (`0` = off). |
+| — | `VTS_COMPACT_RESULTS` | `1` | `0` restores one-location-per-line output. |
+| — | `VTS_MAX_BACKENDS` | `2` | Max concurrently-live language servers (LRU-evict past the cap). |
+| — | `VTS_BACKEND_IDLE_MS` | `300000` | Idle language server shut down after this (`0` = off). |
 | — | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | Override the clangd executable / args. |
 | — | `VTS_ROSLYN_DLL` | auto | Path to a specific `Microsoft.CodeAnalysis.LanguageServer.dll`. |
-| — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto (MS engine) → `csharp-ls` | Override the C# LSP executable / args. |
-| — | `VTS_TS_CMD` / `VTS_TS_ARGS` | bundled `typescript-language-server` | Override the JS/TS LSP executable / args. |
-| — | `VTS_PY_CMD` / `VTS_PY_ARGS` | bundled `pyright-langserver` | Override the Python LSP executable / args. |
-| — | `VTS_TS_OPEN_CAP` / `VTS_PY_OPEN_CAP` | `60` | Max files the JS/TS / Python warm-up opens to prime the server. |
-| — | `VTS_LSP_TIMEOUT_MS` | `30000` | Per-request LSP timeout. Raise for a cold, large (e.g. UE) index. |
-| — | `VTS_LSP_INDEX_WAIT_MS` | `120000` | How long the clangd warm-up waits for background-index completion before the first query. |
-| — | `VTS_CLANGD_OPEN_CAP` | `100` | Max files the warm-up opens to prime clangd's index (cold, no persisted index). |
-| — | `VTS_CLANGD_WARM_CAP_PERSISTED` | `8` | Open cap when a persisted `.cache/clangd` index exists — clangd answers from the index, so few files need re-parsing. |
-| — | `VTS_CLANGD_PERSISTED_WAIT_MS` | `60000` | With a persisted index, the cap on how long a query polls the still-loading index before giving up — it returns the instant the symbol is found (not at a fixed deadline). |
-| — | `VTS_CLANGD_PERSISTED_FLOOR_MS` | `3000` | With a persisted index, the brief floor the warm-up waits before letting the first query start polling. |
-| — | `VTS_CLANGD_INDEX_PRIORITY` | `normal` | clangd background-index thread priority. Default `normal` builds it fast; `background` is idle-CPU-only (slower, but a better citizen on a shared box). |
+| — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto → `csharp-ls` | Override the C# LSP. |
+| — | `VTS_TS_CMD` / `VTS_PY_CMD` (+ `_ARGS`) | bundled | Override the JS/TS / Python LSP. |
+| — | `VTS_TS_OPEN_CAP` / `VTS_PY_OPEN_CAP` | `60` | Files the JS/TS / Python warm-up opens. |
+| — | `VTS_LSP_TIMEOUT_MS` | `30000` | Per-request LSP timeout. Raise for a cold, large index. |
+| — | `VTS_LSP_INDEX_WAIT_MS` | `120000` | How long the clangd warm-up waits for background-index completion. |
+| — | `VTS_CLANGD_OPEN_CAP` | `100` | Files the cold warm-up opens to prime clangd. |
+| — | `VTS_CLANGD_WARM_CAP_PERSISTED` | `8` | Open cap when a persisted `.cache/clangd` index exists. |
+| — | `VTS_CLANGD_PERSISTED_WAIT_MS` | `60000` | Cap on how long a query polls a still-loading persisted index. |
+| — | `VTS_CLANGD_PERSISTED_FLOOR_MS` | `3000` | Brief floor before the first query starts polling. |
+| — | `VTS_CLANGD_INDEX_PRIORITY` | `normal` | clangd background-index priority (`background` = idle-CPU-only). |
 | — | `VTS_CLANGD_JOBS` | `cores-1` | clangd async/index workers (`-j`). |
-| — | `VTS_PREWARM` | on (if `projectPath` set) | MCP server pre-warms the index at boot (IDE-style); set `0` to disable. |
-| — | `VTS_PREWARM_HOOK` | `0` | SessionStart hook also pre-warms via a detached `vts warmup` (opt-in; mainly CLI/non-MCP). |
-| — | `VTS_PREWARM_BACKENDS` | auto | Which backends to pre-warm. `auto` = the single detected/dominant one; `all` = every language present in the repo (each warmed in proportion to its file count); or a comma list like `clangd,typescript`. |
-| — | `VTS_WARM_CAP_RATIO` | `0.1` | Adaptive warm-up: open ~this fraction of a language's files (so a bigger language warms more), clamped to `[per-backend base, VTS_WARM_CAP_MAX]`. An explicit `VTS_*_OPEN_CAP` overrides it. |
-| — | `VTS_WARM_CAP_MAX` | `300` | Upper bound on the adaptive per-backend warm-up open-cap. |
-| — | `VTS_CLANGD_REMOTE` | — | Address of a shared/prebuilt clangd index server (`--remote-index-address`); near-zero per-dev warmup. |
-| — | `VTS_QUERY_HISTORY` | `~/.vs-token-safer/query-history.json` | Where the query-history ledger lives (used to order the warm-up set likely-query-first). |
-| — | `VTS_CENTRALITY_MAX` | `20000` | Upper bound on candidates the centrality scan iterates; `0` disables centrality entirely. |
-| — | `VTS_CENTRALITY_BUDGET_MS` | `400` | Per-warm-up budget for *new* include-prefix reads. Centrality is adaptive: each warm-up scans a budget's worth of new/changed files into a persistent include-graph cache (`VTS_INCLUDE_GRAPH`), so coverage grows across warm-ups (`0` = cache only). |
-| — | `VTS_ENFORCE` | `1` | `0`/`false`/`off` lets Bash code-grep through (escape hatch when the language server is unavailable). |
-| — | `VTS_REWRITE` | `1` | `0` makes the hook block a Bash code-grep instead of rewriting it to a `vts` query. |
-| — | `VTS_GREP_BLOCK` | `1` | `0` reverts the **Grep/Glob tool** symbol-hunt / code-file-glob escalation from block back to warn-only. |
-| — | `VTS_EXCLUDE_COMMANDS` | — | Comma list of executables to exempt from rewrite/block (e.g. `rg,find`). Also `excludeCommands` in config.json. |
-| — | `VTS_COMPACT_VCS` | `1` | `0` stops the hook from rerouting a read-only `git status/log/diff` / `p4 opened/…` to the compacted `vts_git`/`vts_p4` wrapper. |
-| `lang` | `VTS_LANG` | auto | UI language for the hook's block/nudge/log messages: `ko` or `en`. Auto-detects Korean from the OS locale; `VTS_LANG` (or config `lang`) forces it. |
-| — | `VTS_TEE` | `truncate` | `truncate` writes the full result of a capped `find_files`/`search_text` to a recovery file; `off` disables it. Dir: `VTS_TEE_DIR`. |
-| — | `VTS_USD_PER_MTOK` | `3` | $/Mtok rate for the estimated-value line in `vts savings` / `discover`. Informational only. |
-| — | `VTS_CLAUDE_PROJECTS` | `~/.claude/projects` | Where `vts discover` looks for transcripts to scan. |
-| — | `VTS_DB_DIR` | `~/.vs-token-safer/db` | Out-of-tree home for generated compile DBs (one subdir per project; clangd's `.cache/` index lives there too). |
-
-
+| — | `VTS_PREWARM` | on (if `projectPath`) | MCP server pre-warms at boot; `0` disables. |
+| — | `VTS_PREWARM_BACKENDS` | auto | `auto` / `all` / comma list — which backends to pre-warm. |
+| — | `VTS_WARM_CAP_RATIO` / `VTS_WARM_CAP_MAX` | `0.1` / `300` | Adaptive warm-up open-cap (fraction of a language's files, clamped). |
+| — | `VTS_CLANGD_REMOTE` | — | Address of a shared/prebuilt clangd index server. |
+| — | `VTS_QUERY_HISTORY` / `VTS_INCLUDE_GRAPH` | `~/.vs-token-safer/…` | Warm-up ordering caches. |
+| — | `VTS_CENTRALITY_MAX` / `VTS_CENTRALITY_BUDGET_MS` | `20000` / `400` | Include-centrality scan bounds (`0` disables / cache-only). |
+| — | `VTS_ENFORCE` | `1` | `0` lets Bash code-grep through (escape hatch). |
+| — | `VTS_REWRITE` | `1` | `0` makes the hook block a Bash code-grep instead of rewriting it. |
+| — | `VTS_GREP_BLOCK` | `1` | `0` reverts the **Grep/Glob tool** escalation from block to warn-only. |
+| — | `VTS_EXCLUDE_COMMANDS` | — | Comma list of executables to exempt (also `excludeCommands` in config). |
+| — | `VTS_COMPACT_VCS` | `1` | `0` stops rerouting read-only `git`/`p4` to the compacted wrapper. |
+| `lang` | `VTS_LANG` | auto | Hook message language: `ko` / `en` (auto-detects from OS locale). |
+| — | `VTS_TEE` / `VTS_TEE_DIR` | `truncate` | Recovery file for a capped `find_files`/`search_text` result. |
+| — | `VTS_USD_PER_MTOK` | `3` | $/Mtok rate for the estimated-value line (informational). |
+| — | `VTS_CLAUDE_PROJECTS` | `~/.claude/projects` | Where `vts discover` looks for transcripts. |
+| — | `VTS_DB_DIR` | `~/.vs-token-safer/db` | Out-of-tree home for generated compile DBs. |
 </details>
 
-## How enforcement works
-
-- The **hook** runs before every Bash, Grep, and Glob tool call.
-  - A **Bash** code search (grep/rg/ack/ag/findstr/`git grep` or `find <dir> -name`) over a code extension
-    (`*.c/.cc/.cpp/.h/.hpp/.cs/.ts/.tsx/.js/.jsx/.mjs/.cjs/.py`) or `src|source|engine|plugins/`, not aimed
-    at a log/md/json/build path, is **rewritten to the equivalent `vts` query** (semantic `symbol` for an
-    identifier, `text` for a literal, `files` for `find` — rooted at the directory the `find` named). If it
-    can't build a safe, complete rewrite (a pipeline, shell metacharacters, a multi-`-name`/`-o` find), it
-    blocks instead.
-  - The built-in **Grep tool**, when the pattern is a clear symbol hunt (a bare identifier, a code-structural
-    regex, or a CamelCase alternation), is **blocked** toward `search_symbol`/`search_text`; freeform text and
-    ALL-CAPS keyword alternations stay a warn.
-  - The built-in **Glob tool**, when it names a concrete code file (`*.cpp`, `Foo.h`, `**/Bar.*`), is
-    **blocked** toward `find_files` (walk-bounded, so a giant tree can't time it out); asset and bare globs
-    pass.
-  - Knobs: `VTS_REWRITE=0` forces Bash block-only; `VTS_GREP_BLOCK=0` reverts the Grep/Glob escalation to
-    warn-only; `excludeCommands`/`VTS_EXCLUDE_COMMANDS` exempt a Bash command; `VTS_ENFORCE=0` disables it all.
-- The **skill** biases Claude toward the indexed tools proactively.
-- The **core** guarantees the token cap no matter how Claude calls the tool, and tees the full result of a
-  truncated `find_files`/`search_text` so nothing is silently dropped.
-
-## Troubleshooting
-
 <details>
-<summary><b>Show the troubleshooting table</b></summary>
+<summary><b>Troubleshooting</b></summary>
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| `/vs-token-safer:setup` not in autocomplete | Plugin not installed (only marketplace added), or stale | `/plugin install vs-token-safer@vs-token-safer` → `/reload-plugins`. Check version with `/plugin`. |
-| First clangd query is very slow | Per-spawn clangd cost on a UE-scale tree: building the index cold, or (with a persisted index) waiting for clangd to re-validate it | Fixed the worst of it: the index builds at `normal` priority and persists next to the DB; with a persisted index the first query no longer waits for the FULL background re-index (it answers from the loaded shards — measured ~7× faster). The real fix for repeated use is to keep the **MCP server** running so clangd is spawned once and stays warm (the one-shot `vts` CLI re-pays the spawn cost each call). Tune `VTS_CLANGD_PERSISTED_WAIT_MS` / `VTS_LSP_INDEX_WAIT_MS` if the first query returns empty. |
-| clangd query never returns (hangs) on a real UE project | The clangd 19.1.x bundled with Visual Studio **deadlocks** on UE TUs | Install **clangd ≥ 22** and point `VTS_CLANGD_CMD` at it. vts prints a version advisory when it detects an old clangd. |
-| `GenerateClangDatabase` fails: "Unable to find valid C++ toolchain for Clang x64" | Targets build with clang-cl; UBT validates a Clang toolchain | Add **`-Compiler=VisualCpp`** to the UBT command; the MSVC database still resolves the include graph. |
-| clangd resolves only header-free symbols | Compile DB has no include dirs → system/3rd-party headers don't resolve | Use a UBT-generated DB (it includes the paths); a hand-rolled `compile_commands.json` must list the include dirs. |
-| No C# results / "No backend resolved" | Roslyn engine not found | Install the VS Code C# extension (`ms-dotnettools.csharp`), or `dotnet tool install --global csharp-ls`; or set `VTS_ROSLYN_DLL` / `VTS_ROSLYN_CMD`. |
-| No JS/TS or Python results | The bundled LSP didn't install (offline first run, npm failure) | Re-run the session so deps reinstall, or set `VTS_TS_CMD` / `VTS_PY_CMD` at a `typescript-language-server` / `pyright-langserver` on PATH. |
-| Code search blocked when you wanted plain grep | The hook is steering you to the index | Set `VTS_ENFORCE=0` to let grep through (e.g. when the language server is unavailable). |
-| Wrong backend picked | Multiple project files under the root | Pin it: `VTS_BACKEND=clangd` (or `roslyn`), or pass `backend` per call. |
-
-
+| `/vs-token-safer:setup` not in autocomplete | Plugin not installed (only marketplace added), or stale | `/plugin install vs-token-safer@vs-token-safer` → `/reload-plugins`. |
+| First clangd query very slow | Per-spawn clangd cost on a UE-scale tree (cold index, or re-validating a persisted one) | Keep the **MCP server** running so clangd spawns once. Tune `VTS_CLANGD_PERSISTED_WAIT_MS` / `VTS_LSP_INDEX_WAIT_MS`. |
+| clangd query never returns (hangs) on UE | clangd 19.1.x bundled with VS **deadlocks** on UE TUs | Install **clangd ≥ 22**, point `VTS_CLANGD_CMD` at it. |
+| `GenerateClangDatabase` fails: "Unable to find valid C++ toolchain for Clang x64" | Targets build with clang-cl | Add **`-Compiler=VisualCpp`** to the UBT command. |
+| clangd resolves only header-free symbols | Compile DB has no include dirs | Use a UBT-generated DB (it includes the paths). |
+| No C# results / "No backend resolved" | Roslyn engine not found | Install the VS Code C# extension, or `csharp-ls`; or set `VTS_ROSLYN_DLL` / `VTS_ROSLYN_CMD`. |
+| No JS/TS or Python results | Bundled LSP didn't install (offline first run) | Re-run the session, or set `VTS_TS_CMD` / `VTS_PY_CMD`. |
+| Code search blocked when you wanted plain grep | The hook is steering you to the index | `VTS_ENFORCE=0` lets grep through. |
+| Wrong backend picked | Multiple project files under the root | Pin `VTS_BACKEND=clangd` (or pass `backend` per call). |
 </details>
 
-## Status / caveats
+## Status &amp; safety
 
-- **clangd live-verified.** `search_symbol` / `find_references` / `goto_definition` confirmed against
-  real clangd on a `compile_commands.json` project, including a real Unreal 5.x game project
-  end-to-end (it returned the game `UCLASS` plus its `*.generated.h` symbols). Needs a correct compile
-  DB (with include dirs) and **clangd ≥ 22**; older clangd deadlocks on real UE TUs.
-- **Roslyn live-verified.** Confirmed against **Microsoft.CodeAnalysis.LanguageServer** (the actual VS
-  engine) on a real `.csproj`. Auto-detected from the VS Code C# extension bundle, with a `csharp-ls`
-  fallback.
-- Cold UE-scale indexes are slow on the first query, so pre-warm or raise the LSP wait/timeout envs.
-- The savings ledger and benchmark numbers are response-shaping (raw index → capped). Savings vs grep
-  are larger; see [BENCHMARK.md](BENCHMARK.md).
-
-## Permissions & safety
-
-Everything runs locally and nothing is uploaded:
-
-- The **hook** (`PreToolUse` on Bash) only inspects the command string to decide whether to redirect a
-  code-grep to the index. It doesn't read file contents or run anything. It honors `VTS_ENFORCE=0`.
-- The **language server** runs on your machine over stdio. The only outbound network call is the
-  first-run `npm install` of the MCP SDK. No telemetry, no source, and no queries leave your machine; it
-  writes only its config and a local token-savings ledger under `~/.vs-token-safer/`.
-- **gamedev-log-analyzer** reads local log files you point it at and prints summaries.
-
-See [SECURITY.md](SECURITY.md) and [PRIVACY.md](PRIVACY.md).
-
-## Version history
-
-Per-release notes — 🚀 Features / 🐛 Bug Fixes / 📝 Documentation / 🔧 Maintenance — are auto-generated,
-PR-linked, on every `v*` tag. The badge at the top tracks the latest. See the full history on the
-**[Releases](https://github.com/JSungMin/vs-token-safer/releases)** page.
+- **clangd & Roslyn live-verified** — `search_symbol`/`find_references`/`goto_definition` confirmed against real clangd (incl. a real Unreal 5.x game project end-to-end) and **Microsoft.CodeAnalysis.LanguageServer**. Needs clangd ≥ 22 and a correct compile DB.
+- **Local-only, nothing uploaded.** The hook only inspects the command string (honors `VTS_ENFORCE=0`); the language server runs over stdio; the only outbound call is the first-run `npm install` of the MCP SDK. It writes only its config + a local savings ledger under `~/.vs-token-safer/`. See [SECURITY.md](SECURITY.md) and [PRIVACY.md](PRIVACY.md).
+- Savings/benchmark numbers are response-shaping (raw index → capped); savings vs grep are larger ([BENCHMARK.md](BENCHMARK.md)).
 
 ## Contributing
 
-Issues and PRs welcome: bug reports, new backends/engines, additional language mappings, or docs.
-
-This repo is maintained with AI-assisted review, so PRs are judged from the diff, description, and
-evidence. Keep them small, clearly described, backed by evidence, and free of any proprietary data
-(real paths, symbols, or project identifiers). Add an eval guard in `eval/run.mjs` for any new code
-path. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.
-
-If this saved you tokens or debugging time, a star helps others find it. ⭐
-
-## Privacy
-
-These plugins collect no personal data and process everything locally. See [PRIVACY.md](PRIVACY.md).
+Issues and PRs welcome — bug reports, new backends/engines, language mappings, docs. Keep PRs small,
+evidence-backed, and free of proprietary data (real paths/symbols/project IDs); add an `eval/run.mjs` guard
+for any new code path. See [CONTRIBUTING.md](CONTRIBUTING.md). If this saved you tokens, a star helps
+others find it. ⭐
 
 ## License
 

--- a/eval/_mock-lsp.mjs
+++ b/eval/_mock-lsp.mjs
@@ -65,6 +65,11 @@ process.stdin.on("data", (d) => {
           { name: "keepProp", kind: 7, range: rng, selectionRange: sel },
         ] },
       ] });
+    } else if (msg.method === "textDocument/references") {
+      // "Foo"'s name sits at line 4 (its selectionRange) — return one usage there so safe_delete sees a
+      // referrer and refuses; any other position (e.g. the find_references guard at line 41) returns none.
+      const rp = msg.params.position;
+      send({ jsonrpc: "2.0", id: msg.id, result: rp.line === 4 ? [{ uri: "file:///proj/src/User.cpp", range: { start: { line: 7, character: 2 }, end: { line: 7, character: 5 } } }] : [] });
     } else if (msg.method === "textDocument/rename") {
       const uri = msg.params.textDocument.uri, p = msg.params.position;
       if (msg.params.newName === "MULTI") {

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1008,6 +1008,37 @@ const findEdgeOk = hFindMulti.status === 2 &&                                   
 const v22Ok = findDirOk && globBlkOk && hGlobConcrete.status === 2 && hGlobWild.status === 2 &&
   hGlobBare.status === 0 && hGlobAsset.status === 0 && hGlobUasset.status === 0 && findEdgeOk;
 
+// 52) symbolic editing (Serena-style): edit a declaration by NAMING it — the LSP outline (documentSymbol)
+// supplies the body span, so no whole-file Read + line-counting for an exact-match Edit. replace_symbol_body
+// replaces the span; insert_before/after splice at its edges; safe_delete refuses while referenced (the mock
+// returns a referrer at the symbol's name line) unless force=true. Preview by default; apply=true writes.
+const seDir = path.join(os.tmpdir(), `vts-eval-${process.pid}-symedit`);
+fs.mkdirSync(seDir, { recursive: true });
+const seFile = path.join(seDir, "Ed.cpp");
+const SEBODY = "L0\nL1\nL2\nL3\n0123456789 rest\n"; // mock documentSymbol puts "Foo" at line 4, chars 0-10
+const seW = () => fs.writeFileSync(seFile, SEBODY);
+const seR = () => fs.readFileSync(seFile, "utf8");
+seW();
+const sePrev = await runTool("replace_symbol_body", { symbol: "Foo", path: seFile, body: "X", backend: "clangd" });
+const sePrevOk = !sePrev.isError && /PREVIEW/.test(sePrev.text) && /Ed\.cpp:5/.test(sePrev.text) && seR() === SEBODY; // preview → not written
+const seRepl = await runTool("replace_symbol_body", { symbol: "Foo", path: seFile, body: "ZZZ", backend: "clangd", apply: true });
+const seReplOk = !seRepl.isError && /APPLIED/.test(seRepl.text) && seR() === "L0\nL1\nL2\nL3\nZZZ rest\n";
+seW();
+const seBefore = await runTool("insert_before_symbol", { symbol: "Foo", path: seFile, text: "PRE", backend: "clangd", apply: true });
+const seBeforeOk = !seBefore.isError && seR() === "L0\nL1\nL2\nL3\nPRE\n0123456789 rest\n";
+seW();
+const seAfter = await runTool("insert_after_symbol", { symbol: "Foo", path: seFile, text: "POST", backend: "clangd", apply: true });
+const seAfterOk = !seAfter.isError && seR() === "L0\nL1\nL2\nL3\n0123456789\nPOST rest\n";
+seW();
+const seMiss = await runTool("replace_symbol_body", { symbol: "Nope", path: seFile, body: "x", backend: "clangd" });
+const seMissOk = seMiss.isError && /no symbol named "Nope"/.test(seMiss.text);
+const seRefuse = await runTool("safe_delete", { symbol: "Foo", path: seFile, backend: "clangd", apply: true });
+const seRefuseOk = !seRefuse.isError && /REFUSED/.test(seRefuse.text) && /reference/.test(seRefuse.text) && seR() === SEBODY; // referenced → not deleted
+const seForce = await runTool("safe_delete", { symbol: "Foo", path: seFile, force: true, backend: "clangd", apply: true });
+const seForceOk = !seForce.isError && /force/.test(seForce.text) && seR() === "L0\nL1\nL2\nL3\n rest\n";
+try { fs.rmSync(seDir, { recursive: true, force: true }); } catch { /* ignore */ }
+const symEditOk = sePrevOk && seReplOk && seBeforeOk && seAfterOk && seMissOk && seRefuseOk && seForceOk;
+
 await disposeClients();
 // 48) clean teardown (no orphaned child): disposeClients must terminate EVERY spawned language-server
 // child — evicted, swept, mid-warmup, or key-overwritten — via the master registry. A surviving child
@@ -1078,6 +1109,7 @@ const rows = [
   ["Glob-tool nudge → find_files + find_files skips heavy dirs", globAndWalkOk, "true", globAndWalkOk],
   ["enforce v2: symbol-hunt Grep blocks, freeform warns + discover counts Glob", enforceAndDiscoverOk, "true", enforceAndDiscoverOk],
   ["v2.2: find <dir> honored in rewrite + concrete-code Glob blocks → find_files", v22Ok, "true", v22Ok],
+  ["symbolic editing: replace/insert/safe_delete by name (preview+apply+ref-guard)", symEditOk, "true", symEditOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/gamedev-log-analyzer/.claude-plugin/plugin.json
+++ b/gamedev-log-analyzer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gamedev-log-analyzer",
   "description": "Token-efficient game-engine & build log analysis for Claude Code (CLI-first). Parses, deduplicates, and classifies huge Unreal/Unity/Godot/MSVC-UBT-MSBuild logs — search by severity/category, roll up by callsite, diff runs, locate file:line, and extract decisive scalar fields. No IDE required.",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/rider-mcp-enforcer",
   "repository": "https://github.com/JSungMin/rider-mcp-enforcer",

--- a/gamedev-log-analyzer/README.ko.md
+++ b/gamedev-log-analyzer/README.ko.md
@@ -31,7 +31,7 @@
 
 - 각 줄을 `{severity, category, file:line, message}`로 **파싱** — 여러 엔진 지원(아래 지원 매트릭스),
   미인식 줄은 범용 severity-키워드 폴백.
-- **템플릿 dedup:** 숫자/주소/GUID/경로/인스턴스ID 정규화 → 반복 스팸을 `×count` 한 그룹으로.
+- **템플릿 dedup:** 숫자/주소/GUID/경로/인스턴스ID **및 따옴표 리터럴**(`'/Game/Maps/Foo'` 같은 에셋/오브젝트 이름) 정규화 → 반복 스팸을 `×count` 한 그룹으로 (에셋별 스트리밍 실패 스팸이 이름마다 쪼개지지 않고 한 그룹으로 dedup).
 - **검색/필터:** `severityMin`·`category`·`file`·`query`; `groupBy:"callsite"`는 `file:line`별 롤업
   (로그를 뭐가 도배하는지 파악에 최적), `groupBy:"code"`는 진단 코드(`C4996`·`LNK2019`·`CS1002` …)별 롤업
   — warning 수백 개짜리 빌드를 코드당 한 줄(`C4996: … (×37)`)로 접어 grep 대신 즉시 triage.

--- a/gamedev-log-analyzer/README.md
+++ b/gamedev-log-analyzer/README.md
@@ -31,8 +31,10 @@ just the scalar columns that actually decide the answer.
 
 - **Parses** each line into `{severity, category, file:line, message}` across several engines (see the
   support matrix below), with a generic severity-keyword fallback for anything unrecognized.
-- **Template dedup:** numbers/addresses/GUIDs/paths/instance-ids are normalized so repeated spam
-  collapses into one group with a `×count` and representative locations.
+- **Template dedup:** numbers/addresses/GUIDs/paths/instance-ids **and quoted literals** (asset/object
+  names like `'/Game/Maps/Foo'`) are normalized so repeated spam collapses into one group with a `×count`
+  and representative locations — per-asset streaming-failure spam dedups instead of splitting one group
+  per name.
 - **Search/filter:** by `severityMin`, `category`, `file`, `query`; `groupBy: "callsite"` rolls
   everything up by `file:line` (best for "what's flooding my log"), and `groupBy: "code"` rolls up by
   diagnostic code (`C4996`, `LNK2019`, `CS1002` …) — a noisy build with hundreds of warnings collapses

--- a/gamedev-log-analyzer/eval/run.mjs
+++ b/gamedev-log-analyzer/eval/run.mjs
@@ -281,8 +281,18 @@ const hookOptOut = (() => {
 })();
 const rewriteOk = rewritePure && hookRewrites && hookFallsBack && hookOptOut;
 
+// Quoted-literal dedup: per-asset spam (same error, different quoted asset name) must collapse into ONE
+// template group — without the `<str>` normalizer in templateOf these split N ways. Discriminating: the 6
+// distinct asset names must roll up to exactly 1 group with (×6).
+const assetLog = Array.from({ length: 6 }, (_, i) =>
+  `[2026.06.15-00.00.0${i}][${i}]LogStreaming: Warning: Failed to load asset '/Game/Maps/Zone${i}'`
+).join("\n");
+const assetSummary = analyzeLog(assetLog, { severityMin: "Warning", groupBy: "template" });
+const assetDedupOk = bodyGroups(assetSummary) === 1 && /\(×6\)/.test(assetSummary);
+
 const rows = [
   ["parse coverage", (coverage * 100).toFixed(1) + "%", "≥ 95%", coverage >= 0.95],
+  ["quoted-literal dedup (6 names → 1 ×6)", assetDedupOk, "true", assetDedupOk],
   ["token reduction (callsite)", (reduction * 100).toFixed(1) + "%", "≥ 90%", reduction >= 0.9],
   ["callsite groups", groups, "≤ 20", groups <= 20],
   ["log_fields tokens (20 rows)", fieldsTok, "≤ 400", fieldsTok <= 400],

--- a/gamedev-log-analyzer/server/logs.js
+++ b/gamedev-log-analyzer/server/logs.js
@@ -205,6 +205,11 @@ function templateOf(msg) {
   return msg
     .replace(/0x[0-9a-fA-F]+/g, "<addr>")
     .replace(/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/g, "<guid>")
+    // Quoted literals (asset / object / class names: `Failed to load '/Game/Maps/Foo'`) vary per name —
+    // collapse them so per-asset spam dedups into one group instead of splitting N ways. Exact rule (not
+    // fuzzy): only messages identical APART FROM the quoted content merge. Mirrors the learnings-ledger
+    // `"<q>"` normalizer. Runs before <path>/<n> so a quoted path also collapses.
+    .replace(/'[^']*'|"[^"]*"/g, "<str>")
     .replace(/[A-Za-z]:[\\/][^\s'"]+/g, "<path>")
     .replace(/-?\d+(?:\.\d+)?/g, "<n>")
     .trim();

--- a/gamedev-log-analyzer/server/package.json
+++ b/gamedev-log-analyzer/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamedev-log-analyzer",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "type": "module",
   "description": "Token-efficient game-engine & build log analysis (Unreal/Unity/Godot/MSVC-UBT-MSBuild) for the CLI and MCP — parse, dedup, classify by severity/category, diff runs, locate file:line, and extract scalar fields. No IDE required.",
   "keywords": [

--- a/server/cli.js
+++ b/server/cli.js
@@ -28,6 +28,14 @@ Commands:
   symbols        Outline a file (its classes/functions as file:line). [--path <file>]
   rename         Semantic rename across the project. Preview by default; --apply to write.
                  [--path <file> --line N --character N --newName <name> [--apply]]
+  replace-symbol Replace a whole declaration by NAME (outline supplies the span). Preview; --apply to write.
+                 [--symbol <name> --body <text> [--path <file> --line N --apply]]
+  insert-after   Insert text on a new line after a named declaration. Preview; --apply to write.
+                 [--symbol <name> --text <text> [--path <file> --line N --apply]]
+  insert-before  Insert text on a line before a named declaration. Preview; --apply to write.
+                 [--symbol <name> --text <text> [--path <file> --line N --apply]]
+  safe-delete    Delete a named declaration; refuses while referenced unless --force. Preview; --apply.
+                 [--symbol <name> [--path <file> --line N --force --apply]]
   files          Find files by name (substring or glob). [--q <pattern> --projectPath <dir>]
   text           Raw text/regex search (token-capped). [--q <pattern> --projectPath <dir> --path <file> --glob <pat> --docs]
                  --path <file> / --glob <pat> target a file/glob and auto-include its extension (e.g. a .md);
@@ -59,7 +67,7 @@ Backends (auto-detected from the root, or set --backend / VTS_BACKEND):
 Settings precedence: env (VTS_*) > ~/.vs-token-safer/config.json > default.`;
 
 const LIST_FLAGS = new Set([]);
-const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree"]);
+const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force"]);
 
 function parseArgs(argv) {
   const a = {};
@@ -75,7 +83,7 @@ function parseArgs(argv) {
   }
   return a;
 }
-const COMMANDS = { symbol: "search_symbol", references: "find_references", definition: "goto_definition", hover: "hover", symbols: "document_symbols", rename: "rename", files: "find_files", text: "search_text", git: "vts_git", p4: "vts_p4", setup: "vts_setup", config: "vts_config", savings: "vts_savings", "savings-reset": "vts_savings_reset", discover: "vts_discover", warmup: "vts_warmup", "gen-compile-db": "vts_gen_compile_db" };
+const COMMANDS = { symbol: "search_symbol", references: "find_references", definition: "goto_definition", hover: "hover", symbols: "document_symbols", rename: "rename", "replace-symbol": "replace_symbol_body", "insert-after": "insert_after_symbol", "insert-before": "insert_before_symbol", "safe-delete": "safe_delete", files: "find_files", text: "search_text", git: "vts_git", p4: "vts_p4", setup: "vts_setup", config: "vts_config", savings: "vts_savings", "savings-reset": "vts_savings_reset", discover: "vts_discover", warmup: "vts_warmup", "gen-compile-db": "vts_gen_compile_db" };
 
 const [, , rawCmd, ...rest] = process.argv;
 if (!rawCmd || rawCmd === "-h" || rawCmd === "--help" || rawCmd === "help") { console.log(HELP); process.exit(rawCmd ? 0 : 1); }

--- a/server/core.js
+++ b/server/core.js
@@ -937,6 +937,46 @@ function applyEditsToText(text, edits) {
   return out;
 }
 
+// ─── Symbolic editing (Serena-style) ─────────────────────────────────────────
+// Edit a declaration by NAMING it instead of Read-ing the whole file into context + counting lines for an
+// exact-match Edit. The LSP outline (textDocument/documentSymbol) gives `.range` = the WHOLE declaration
+// (signature + body) and `.selectionRange` = just the name; the engine supplies the coordinates, we only
+// splice text. Same model as the rest of vts: official index does the analysis, we glue + token-cap. All
+// callers preview by default (apply=true writes), mirroring rename — the only other mutating tool.
+function flattenDocSyms(syms, out) {
+  out = out || [];
+  for (const s of syms || []) { out.push(s); if (s.children) flattenDocSyms(s.children, out); }
+  return out;
+}
+// Resolve a symbol NAME to the DocumentSymbol whose `.range` bounds its body. `path` (when given) pins the
+// file and goes straight to its outline; otherwise the declaration's file is found via the index (same
+// exact-name ranking as find_references-by-name). An optional 0-based `line` disambiguates same-named
+// symbols. Returns { file, ds, ambiguous } or { error }.
+async function resolveSymbolForEdit(c, root, backendName, a) {
+  const want = String(a.symbol || "");
+  if (!want) return { error: "needs `symbol` (the declaration name to edit)." };
+  let file = a.path ? String(a.path) : null;
+  if (!file) {
+    const persisted = backendName === "clangd" && hasPersistedIndex(root);
+    const syms = await symbolReady(c, want, persisted, envInt("VTS_CLANGD_PERSISTED_WAIT_MS", 60000));
+    const pick = syms.slice().sort((x, y) => (x.name === want ? 0 : 1) - (y.name === want ? 0 : 1))[0];
+    if (!pick) return { error: `no indexed declaration for "${want}" — pass path=<file> (the outline is read per-file), or run search_symbol first.` };
+    file = fromUri(pick.location.uri);
+  }
+  c.didOpen(file, langIdForPath(file, backendName));
+  const flat = flattenDocSyms(await c.documentSymbol(file));
+  let matches = flat.filter((s) => s.name === want);
+  if (matches.length > 1 && a.line != null) {
+    const ln = Number(a.line);
+    const near = matches.filter((s) => ((s.selectionRange || s.range) || {}).start && (s.selectionRange || s.range).start.line === ln);
+    if (near.length) matches = near;
+  }
+  if (!matches.length) return { error: `no symbol named "${want}" in ${file.replace(/\\/g, "/")} — the match is exact-name; check spelling or run document_symbols on the file.` };
+  const ds = matches[0];
+  if (!ds.range) return { error: `backend "${backendName}" returned no body range for "${want}" (flat SymbolInformation, not a hierarchical outline) — can't bound the body to edit safely.` };
+  return { file, ds, ambiguous: matches.length };
+}
+
 // Run an external command (git / p4), capturing stdout even on a non-zero exit (git diff/status return
 // non-zero in some states but still print useful output). Pure best-effort: never throws — a missing
 // binary or a timeout comes back as { out:"", err, code }. The wrapper tools compact `out` before it
@@ -991,6 +1031,17 @@ export async function runTool(name, a = {}) {
     let pre = "";
     if (!_setupNudged && needsSetup()) { _setupNudged = true; pre = SETUP_NUDGE; }
     return out(pre + body + (looksLogTarget(a) ? LOG_STEER : "") + savingsLine(rawTok, outTok));
+  };
+  // Shared preview/apply writer for the symbolic-edit tools. Preview by default (file:line span only —
+  // token-light); apply=true splices the one edit and writes, reusing the rename read-only/Perforce note.
+  const symbolEditResult = (file, edit, apply, headline, rawObj) => {
+    const fp = file.replace(/\\/g, "/");
+    const r = edit.range;
+    const span = r.start.line === r.end.line ? `${fp}:${r.start.line + 1}` : `${fp}:${r.start.line + 1}-${r.end.line + 1}`;
+    if (!apply) return finishOut(rawObj, `${headline} — PREVIEW at ${span}. Pass apply=true to write.`);
+    try { fs.writeFileSync(file, applyEditsToText(fs.readFileSync(file, "utf8"), [edit])); }
+    catch (e) { return finishOut(rawObj, `${headline} — FAILED to write ${span} (${e.code || e.message}). Read-only? Check out of Perforce first.`); }
+    return finishOut(rawObj, `${headline} — APPLIED at ${span}.`);
   };
   try {
     if (name === "vts_setup") {
@@ -1299,6 +1350,37 @@ export async function runTool(name, a = {}) {
       }
       const note = failed.length ? `\n⚠ ${failed.length} file(s) not written (read-only? check out of Perforce first): ${failed.slice(0, 5).join("; ")}` : "";
       return finishOut(we, `rename → "${a.newName}" APPLIED: ${total} edit(s) across ${written}/${m.size} file(s).${note}\n${shown}`);
+    }
+    if (name === "replace_symbol_body" || name === "insert_after_symbol" || name === "insert_before_symbol" || name === "safe_delete") {
+      const c = await getClient(root, backendName);
+      const r = await resolveSymbolForEdit(c, root, backendName, a);
+      if (r.error) return err(`${name}: ${r.error}`);
+      const apply = a.apply === true || a.apply === "true";
+      const rng = r.ds.range;
+      const ambl = r.ambiguous > 1 ? ` (⚠ ${r.ambiguous} symbols named "${a.symbol}"; editing the first — pass line=<0-based> to disambiguate)` : "";
+      if (name === "replace_symbol_body") {
+        if (a.body == null) return err("replace_symbol_body needs `body` (the new full text for the declaration — signature + body).");
+        return symbolEditResult(r.file, { range: rng, newText: String(a.body) }, apply, `replace_symbol_body "${a.symbol}"${ambl}`, r.ds);
+      }
+      if (name === "insert_after_symbol") {
+        if (a.text == null) return err("insert_after_symbol needs `text` (inserted on a new line after the declaration).");
+        return symbolEditResult(r.file, { range: { start: rng.end, end: rng.end }, newText: "\n" + String(a.text) }, apply, `insert_after_symbol "${a.symbol}"${ambl}`, r.ds);
+      }
+      if (name === "insert_before_symbol") {
+        if (a.text == null) return err("insert_before_symbol needs `text` (inserted on a line before the declaration).");
+        return symbolEditResult(r.file, { range: { start: rng.start, end: rng.start }, newText: String(a.text) + "\n" }, apply, `insert_before_symbol "${a.symbol}"${ambl}`, r.ds);
+      }
+      // safe_delete — refuse while the symbol is still referenced (unless force=true), so a delete can't
+      // silently orphan call sites. References resolve at the NAME (selectionRange), not the whole body.
+      const sel = (r.ds.selectionRange || rng).start;
+      const refs = ((await c.references(r.file, sel.line, sel.character, false)) || []).filter(Boolean);
+      const force = a.force === true || a.force === "true";
+      if (refs.length && !force) {
+        const where = refs.slice(0, max).map((l) => locLine(l.uri, l.range)).join("\n");
+        return finishOut(refs, `safe_delete "${a.symbol}" REFUSED — ${refs.length} reference(s) still point here. Remove them first, or pass force=true. References:\n${where}`);
+      }
+      const fl = refs.length ? ` (force: ${refs.length} ref(s) ignored)` : "";
+      return symbolEditResult(r.file, { range: rng, newText: "" }, apply, `safe_delete "${a.symbol}"${fl}${ambl}`, refs);
     }
     return err(`Unknown tool: ${name}`);
   } catch (e) {

--- a/server/index.js
+++ b/server/index.js
@@ -132,6 +132,88 @@ const TOOLS = [
     },
   },
   {
+    name: "replace_symbol_body",
+    description:
+      "Replace a whole declaration (function/method/class body, signature included) by NAMING it — the " +
+      "language-server outline supplies the exact span, so you don't Read the file into context or count " +
+      "lines for an exact-match Edit. Default PREVIEW returns the affected `file:line`; apply=true writes. " +
+      "Token-cheap symbol-level editing instead of read-whole-file-then-Edit.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        symbol: { type: "string", description: "Declaration name to replace (e.g. a function/class name)." },
+        body: { type: "string", description: "New full text for the declaration (signature + body)." },
+        path: { type: "string", description: "File holding the symbol (pins the outline; else resolved via the index)." },
+        line: { type: "number", description: "0-based line to disambiguate same-named symbols (optional)." },
+        apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
+        projectPath: { type: "string" },
+        backend: { type: "string" },
+        maxResults: { type: "number" },
+      },
+      required: ["symbol", "body"],
+    },
+  },
+  {
+    name: "insert_after_symbol",
+    description:
+      "Insert text on a new line AFTER a named declaration (e.g. add a sibling function/method). The outline " +
+      "supplies the insertion point. Default PREVIEW; apply=true writes. No need to Read the file to find the line.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        symbol: { type: "string", description: "Declaration to insert after." },
+        text: { type: "string", description: "Text inserted on a new line after the declaration." },
+        path: { type: "string", description: "File holding the symbol (else resolved via the index)." },
+        line: { type: "number", description: "0-based line to disambiguate same-named symbols (optional)." },
+        apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
+        projectPath: { type: "string" },
+        backend: { type: "string" },
+        maxResults: { type: "number" },
+      },
+      required: ["symbol", "text"],
+    },
+  },
+  {
+    name: "insert_before_symbol",
+    description:
+      "Insert text on a line BEFORE a named declaration (e.g. add an import/attribute/decorator above it). " +
+      "The outline supplies the insertion point. Default PREVIEW; apply=true writes.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        symbol: { type: "string", description: "Declaration to insert before." },
+        text: { type: "string", description: "Text inserted on a line before the declaration." },
+        path: { type: "string", description: "File holding the symbol (else resolved via the index)." },
+        line: { type: "number", description: "0-based line to disambiguate same-named symbols (optional)." },
+        apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
+        projectPath: { type: "string" },
+        backend: { type: "string" },
+        maxResults: { type: "number" },
+      },
+      required: ["symbol", "text"],
+    },
+  },
+  {
+    name: "safe_delete",
+    description:
+      "Delete a named declaration — but REFUSE while it's still referenced (so a delete can't silently orphan " +
+      "call sites). Checks references first; lists them and stops unless force=true. Default PREVIEW; apply=true writes.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        symbol: { type: "string", description: "Declaration to delete." },
+        path: { type: "string", description: "File holding the symbol (else resolved via the index)." },
+        line: { type: "number", description: "0-based line to disambiguate same-named symbols (optional)." },
+        force: { type: "boolean", description: "Delete even if references remain (default false = refuse when referenced)." },
+        apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
+        projectPath: { type: "string" },
+        backend: { type: "string" },
+        maxResults: { type: "number" },
+      },
+      required: ["symbol"],
+    },
+  },
+  {
     name: "find_files",
     description:
       "Find files by name (substring or glob like *Manager.cpp) under the project root — token-capped " +


### PR DESCRIPTION
## Summary
Adds **symbol-level editing** (Serena-inspired) so the model edits a declaration by NAMING it — no whole-file Read + line-counting for an exact-match Edit.

- `replace_symbol_body` / `insert_after_symbol` / `insert_before_symbol` / `safe_delete`
- `resolveSymbolForEdit`: resolves a declaration via the LSP outline (`documentSymbol` `.range` = whole body, `.selectionRange` = name). `path` pins the file else the index resolves it, `line` disambiguates.
- `symbolEditResult`: shared **preview-by-default** / `apply=true` writer (reuses the rename read-only/Perforce note). `safe_delete` refuses while the symbol is still referenced unless `force=true`.
- Wired through core.js dispatch + index.js MCP schemas + cli.js (`replace-symbol`/`insert-after`/`insert-before`/`safe-delete`).

## Docs
Lean README rewrite (EN+KO, **538/517 → 349/347 lines**) benchmarked against Serena's concise structure: Quickstart up top, tools as grouped tables (search / edit / VCS), reference sections in `<details>`, dual-plugin intro kept. CLAUDE.md updated.

## Chore
Sync bundled gamedev-log-analyzer **0.10.5 → 0.10.6**.

## Review points
- Symbol edits are **mutating** — preview by default; `safe_delete` ref-guard.
- Engine supplies coordinates (`documentSymbol`), we only splice text — same "official engine, our glue" model.

## Eval
`node eval/run.mjs` → **53/53** (new guard 52: preview + apply + insert + ref-guard). lint clean. `claude plugin validate . --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)