### PR TITLE
chore(release): gamedev-log-analyzer 0.10.7 + vs-token-safer 0.21.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,14 +10,14 @@
     {
       "name": "vs-token-safer",
       "source": "./",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "category": "development",
       "description": "Force Claude Code to search C++/C# code through clangd/Roslyn's index instead of Bash grep, token-capped to a compact file:line list. No IDE required. Bundles gamedev-log-analyzer."
     },
     {
       "name": "gamedev-log-analyzer",
       "source": "./gamedev-log-analyzer",
-      "version": "0.10.6",
+      "version": "0.10.7",
       "category": "development",
       "description": "Token-efficient game-engine & build log analysis (Unreal/Unity/Godot/MSVC-UBT-MSBuild + JSONL traces), CLI-first: parse, dedup, classify, diff runs, locate file:line, and extract decisive scalar fields over a time window. Also on npm. No IDE required."
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vs-token-safer",
   "description": "Force Claude Code to search C++/C# code through an official language server's index (clangd / Roslyn) instead of Bash grep, token-capped to a compact file:line list. No IDE required. Faster and far fewer tokens on large Unreal C++/.NET codebases. Auto-installs gamedev-log-analyzer.",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/vs-token-safer",
   "repository": "https://github.com/JSungMin/vs-token-safer",

--- a/gamedev-log-analyzer/.claude-plugin/plugin.json
+++ b/gamedev-log-analyzer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gamedev-log-analyzer",
   "description": "Token-efficient game-engine & build log analysis for Claude Code (CLI-first). Parses, deduplicates, and classifies huge Unreal/Unity/Godot/MSVC-UBT-MSBuild logs — search by severity/category, roll up by callsite, diff runs, locate file:line, and extract decisive scalar fields. No IDE required.",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/rider-mcp-enforcer",
   "repository": "https://github.com/JSungMin/rider-mcp-enforcer",

--- a/gamedev-log-analyzer/README.ko.md
+++ b/gamedev-log-analyzer/README.ko.md
@@ -31,7 +31,7 @@
 
 - 각 줄을 `{severity, category, file:line, message}`로 **파싱** — 여러 엔진 지원(아래 지원 매트릭스),
   미인식 줄은 범용 severity-키워드 폴백.
-- **템플릿 dedup:** 숫자/주소/GUID/경로/인스턴스ID **및 따옴표 리터럴**(`'/Game/Maps/Foo'` 같은 에셋/오브젝트 이름) 정규화 → 반복 스팸을 `×count` 한 그룹으로 (에셋별 스트리밍 실패 스팸이 이름마다 쪼개지지 않고 한 그룹으로 dedup).
+- **템플릿 dedup:** 숫자/주소/GUID/경로/인스턴스ID **및 따옴표 리터럴**(`'/Game/Maps/Foo'` 같은 에셋/오브젝트 이름) 정규화 → 반복 스팸을 `×count` 한 그룹으로 (에셋별 스트리밍 실패 스팸이 이름마다 쪼개지지 않고 한 그룹으로 dedup). **실제 이름이 필요하면?** `search --members N`(또는 `members` 인자)이 그 그룹이 접은 **distinct** 메시지를 최대 N개까지 나열 — 토큰 상한 드릴다운이라, 기본은 개요 / 필요할 때만 세부를 raw 덤프 없이 본다.
 - **검색/필터:** `severityMin`·`category`·`file`·`query`; `groupBy:"callsite"`는 `file:line`별 롤업
   (로그를 뭐가 도배하는지 파악에 최적), `groupBy:"code"`는 진단 코드(`C4996`·`LNK2019`·`CS1002` …)별 롤업
   — warning 수백 개짜리 빌드를 코드당 한 줄(`C4996: … (×37)`)로 접어 grep 대신 즉시 triage.

--- a/gamedev-log-analyzer/README.md
+++ b/gamedev-log-analyzer/README.md
@@ -34,7 +34,9 @@ just the scalar columns that actually decide the answer.
 - **Template dedup:** numbers/addresses/GUIDs/paths/instance-ids **and quoted literals** (asset/object
   names like `'/Game/Maps/Foo'`) are normalized so repeated spam collapses into one group with a `×count`
   and representative locations — per-asset streaming-failure spam dedups instead of splitting one group
-  per name.
+  per name. **Need the actual names back?** `search --members N` (or the `members` arg) lists up to N of the
+  **distinct** messages a group collapsed — token-bounded drill-down, so you get the overview by default and
+  the specifics on demand without dumping the raw log.
 - **Search/filter:** by `severityMin`, `category`, `file`, `query`; `groupBy: "callsite"` rolls
   everything up by `file:line` (best for "what's flooding my log"), and `groupBy: "code"` rolls up by
   diagnostic code (`C4996`, `LNK2019`, `CS1002` …) — a noisy build with hundreds of warnings collapses

--- a/gamedev-log-analyzer/eval/run.mjs
+++ b/gamedev-log-analyzer/eval/run.mjs
@@ -290,9 +290,21 @@ const assetLog = Array.from({ length: 6 }, (_, i) =>
 const assetSummary = analyzeLog(assetLog, { severityMin: "Warning", groupBy: "template" });
 const assetDedupOk = bodyGroups(assetSummary) === 1 && /\(×6\)/.test(assetSummary);
 
+// --members drill-down: with members>0 the DISTINCT collapsed messages are listed; off (default) only the
+// representative shows. Discriminating: Item_D is collapsed (absent) by default, present + 4 bullets with --members.
+const memLog = Array.from({ length: 4 }, (_, i) =>
+  `[2026.06.15-09.00.0${i}][${i}]LogStreaming: Warning: Failed to load asset '/Game/A/Item_${String.fromCharCode(65 + i)}'`
+).join("\n");
+const memOff = analyzeLog(memLog, { severityMin: "Warning", groupBy: "template" });
+const memOn = analyzeLog(memLog, { severityMin: "Warning", groupBy: "template", members: 10 });
+const membersOk =
+  /Item_A/.test(memOff) && !/Item_D/.test(memOff) &&
+  /Item_A/.test(memOn) && /Item_D/.test(memOn) && (memOn.match(/^ {4}• /gm) || []).length === 4;
+
 const rows = [
   ["parse coverage", (coverage * 100).toFixed(1) + "%", "≥ 95%", coverage >= 0.95],
   ["quoted-literal dedup (6 names → 1 ×6)", assetDedupOk, "true", assetDedupOk],
+  ["--members drill-down (distinct list)", membersOk, "true", membersOk],
   ["token reduction (callsite)", (reduction * 100).toFixed(1) + "%", "≥ 90%", reduction >= 0.9],
   ["callsite groups", groups, "≤ 20", groups <= 20],
   ["log_fields tokens (20 rows)", fieldsTok, "≤ 400", fieldsTok <= 400],

--- a/gamedev-log-analyzer/server/cli.js
+++ b/gamedev-log-analyzer/server/cli.js
@@ -23,7 +23,8 @@ Commands:
   detect            Find editor logs (newest first).               [--projectPath]
   summary           Severity counts + top categories (no bodies).  [--path|--projectPath]
   search            Parse + dedup into templated groups w/ counts.
-                    [--path --query --severityMin --category --file --groupBy --maxGroups]
+                    [--path --query --severityMin --category --file --groupBy --maxGroups --members N]
+                    --members N: drill down — list up to N DISTINCT collapsed messages (the actual names)
   fields            Columnar scalar extraction from trace logs. Add --stats for per-column
                     min/max/avg/Δ (one line/col) instead of rows — even fewer tokens.
                     [--path --fields a,b,c --query --severityMin --window t0,t1 --max --stats]

--- a/gamedev-log-analyzer/server/core.js
+++ b/gamedev-log-analyzer/server/core.js
@@ -299,6 +299,7 @@ export function runTool(name, a = {}) {
             maxGroups: Number(a.maxGroups) || MAX_GROUPS,
             maxLineChars: MAX_LINE_CHARS,
             summaryOnly: name === "log_summary",
+            members: Number(a.members) > 0 ? Number(a.members) : 0,
             groupBy: ["callsite", "code"].includes(a.groupBy) ? a.groupBy : "template",
           }) + covHint
       );

--- a/gamedev-log-analyzer/server/index.js
+++ b/gamedev-log-analyzer/server/index.js
@@ -56,6 +56,7 @@ const TOOLS = [
         file: { type: "string" },
         maxGroups: { type: "number" },
         groupBy: { type: "string", description: "'template', 'callsite', or 'code' (roll up by diagnostic code)" },
+        members: { type: "number", description: "drill-down: list up to N DISTINCT collapsed full messages (e.g. the actual asset names) under each group; 0 = off (default)" },
       },
     },
   },

--- a/gamedev-log-analyzer/server/logs.js
+++ b/gamedev-log-analyzer/server/logs.js
@@ -378,9 +378,11 @@ export function analyzeLog(text, opts = {}) {
     maxLocs = 5,
     maxLineChars = 200,
     summaryOnly = false,
+    members = 0, // drill-down: list up to N DISTINCT collapsed full messages under each group (0 = off)
     groupBy = "template", // "template" (per distinct message) | "callsite" (per file:line) | "code" (per diagnostic code)
   } = opts;
   const minRank = rank(severityMin);
+  const memberCap = members > 0 ? Math.min(members, 100) : 0; // opt-in + hard ceiling so it can't re-flood
   const q = String(query).toLowerCase();
   const catLc = String(category).toLowerCase();
   const fileLc = String(file).toLowerCase();
@@ -411,11 +413,12 @@ export function analyzeLog(text, opts = {}) {
         : `${e.severity}|${e.category}|${templateOf(e.message)}`;
     let g = groups.get(key);
     if (!g) {
-      g = { severity: e.severity, category: e.category, code: e.code || "", message: e.message, count: 0, locs: new Set() };
+      g = { severity: e.severity, category: e.category, code: e.code || "", message: e.message, count: 0, locs: new Set(), members: memberCap ? new Set() : null };
       groups.set(key, g);
     }
     g.count++;
     if (e.location && g.locs.size < maxLocs) g.locs.add(e.location);
+    if (g.members && g.members.size < memberCap) g.members.add(e.message); // Set dedups → DISTINCT values
   }
 
   const header =
@@ -445,7 +448,14 @@ export function analyzeLog(text, opts = {}) {
       const loc = g.locs.size ? "  @ " + [...g.locs].join(", ") : "";
       const mult = g.count > 1 ? `  (×${g.count})` : "";
       const codeTag = groupBy === "code" && g.code && !g.message.startsWith(g.code) ? `${g.code}: ` : "";
-      return `${g.severity.toUpperCase()} [${g.category}] ${codeTag}${msg}${mult}${loc}`;
+      // --members drill-down: list the DISTINCT collapsed full messages under the group (capped).
+      let memberLines = "";
+      if (g.members && g.members.size) {
+        const items = [...g.members].map((m) => `    • ${m.length > maxLineChars ? m.slice(0, maxLineChars) + " …" : m}`);
+        memberLines = "\n" + items.join("\n");
+        if (g.members.size >= memberCap) memberLines += `\n    … +more distinct (×${g.count} total; raise --members)`;
+      }
+      return `${g.severity.toUpperCase()} [${g.category}] ${codeTag}${msg}${mult}${loc}${memberLines}`;
     })
     .join("\n");
   const more = sorted.length - shown.length;

--- a/gamedev-log-analyzer/server/package.json
+++ b/gamedev-log-analyzer/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamedev-log-analyzer",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "type": "module",
   "description": "Token-efficient game-engine & build log analysis (Unreal/Unity/Godot/MSVC-UBT-MSBuild) for the CLI and MCP — parse, dedup, classify by severity/category, diff runs, locate file:line, and extract scalar fields. No IDE required.",
   "keywords": [

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vs-token-safer",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "type": "module",
   "description": "Force code search through an official language server's index (clangd for C++, Roslyn for C#) instead of grep, token-capped to a compact file:line list. Local-only. CLI + MCP. No IDE required.",
   "keywords": ["clangd", "roslyn", "lsp", "code-search", "cpp", "csharp", "unreal", "visual-studio", "mcp", "claude", "claude-code", "grep", "token-efficiency"],


### PR DESCRIPTION
## What
Bundled **gamedev-log-analyzer 0.10.6 → 0.10.7** (mirrored from the maintained source via `scripts/sync-gamedev.mjs`), headline plugin bumped **0.21.0 → 0.21.1** so clients pick up the new bundle.

Standalone patch (off `main`) — keeps the symbol-editing minor clean.

## CI
`node eval/run.mjs` → 53/53 (marketplace↔plugin.json parity guard included). `claude plugin validate . --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)