### PR TITLE
feat: edit-steer + edit-habit measurement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,14 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   CLI `vts git/p4` are full arg passthrough → run in cwd, no `--projectPath`); `vts_warmup`, `vts_setup`,
   `vts_config`, `vts_savings` (RTK-gain-style: `graph`/`daily`/`history` + est. USD over timestamped day
   buckets), `vts_savings_reset`, `vts_discover` (scans `~/.claude/projects/*.jsonl` for code searches that
-  BYPASSED vts → missed-token report + catch-rate; `learn=true` feeds their result files into the warm-set).
+  BYPASSED vts → missed-token report + catch-rate; `learn=true` feeds their result files into the warm-set;
+  ALSO MEASURES THE EDIT HABIT — `wholeDeclEdit` flags a built-in Edit/MultiEdit whose `old_string` is a
+  whole declaration on a code file (≥`VTS_EDIT_MIN_LINES`+decl cue), and attributes that file's PRIOR Read
+  tokens [`reads`/`readUse` Read↔Edit correlation in `scanBypasses`] = the read a symbol-edit would've
+  skipped → `edit habit:` line). STEER (B, not a rewrite — Edit-rewrite is unsafe [partial≠whole-decl] and
+  too late [read already sunk], so steer EARLIER+SOFTER): `EDIT_STEER` is appended to a FOCUSED
+  `search_symbol` (≤`VTS_EDIT_STEER_MAX` 10) / `goto_definition` result — the moment before the model would
+  Read-the-file-to-Edit — pointing at the symbol-edit tools; `VTS_EDIT_STEER=0` hides it. Eval guard 53.
   `find_files`/`search_text` write a recovery TEE file (`VTS_TEE_DIR`, default on-truncate) when a result is
   capped so the full set is recoverable without re-running; a capped `search_symbol`/`find_references`
   ("… N more") tees too (`teeOverflow` — the rows are already in memory, no re-query). The ledger

--- a/README.ko.md
+++ b/README.ko.md
@@ -304,6 +304,7 @@ cd vs-token-safer/server && npm install && npm link   # `vts` 제공
 | — | `VTS_ENFORCE` | `1` | `0`이면 Bash 코드-grep 통과 (탈출구). |
 | — | `VTS_REWRITE` | `1` | `0`이면 훅이 바꿔치기 대신 Bash 코드-grep을 차단. |
 | — | `VTS_GREP_BLOCK` | `1` | `0`이면 **Grep/Glob 도구** 격상을 차단에서 경고로 되돌림. |
+| — | `VTS_EDIT_STEER` | `1` | `0`이면 포커스된 `search_symbol`/`goto_definition` 결과에 붙는 심볼편집 도구 안내 한 줄을 숨김. `VTS_EDIT_STEER_MAX`(`10`)는 안내가 붙는 결과 크기 상한. |
 | — | `VTS_EXCLUDE_COMMANDS` | — | 면제할 실행 파일 콤마 목록 (설정의 `excludeCommands`도). |
 | — | `VTS_COMPACT_VCS` | `1` | `0`이면 읽기 전용 `git`/`p4`의 압축 래퍼 우회를 멈춤. |
 | `lang` | `VTS_LANG` | auto | 훅 메시지 언어: `ko` / `en` (OS 로케일에서 자동 감지). |

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Precedence: **`VTS_*` env > `~/.vs-token-safer/config.json` > default.**
 | — | `VTS_ENFORCE` | `1` | `0` lets Bash code-grep through (escape hatch). |
 | — | `VTS_REWRITE` | `1` | `0` makes the hook block a Bash code-grep instead of rewriting it. |
 | — | `VTS_GREP_BLOCK` | `1` | `0` reverts the **Grep/Glob tool** escalation from block to warn-only. |
+| — | `VTS_EDIT_STEER` | `1` | `0` hides the one-line hint (on a focused `search_symbol`/`goto_definition` result) pointing at the symbol-edit tools. `VTS_EDIT_STEER_MAX` (`10`) caps the result size that gets it. |
 | — | `VTS_EXCLUDE_COMMANDS` | — | Comma list of executables to exempt (also `excludeCommands` in config). |
 | — | `VTS_COMPACT_VCS` | `1` | `0` stops rerouting read-only `git`/`p4` to the compacted wrapper. |
 | `lang` | `VTS_LANG` | auto | Hook message language: `ko` / `en` (auto-detects from OS locale). |

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1039,6 +1039,32 @@ const seForceOk = !seForce.isError && /force/.test(seForce.text) && seR() === "L
 try { fs.rmSync(seDir, { recursive: true, force: true }); } catch { /* ignore */ }
 const symEditOk = sePrevOk && seReplOk && seBeforeOk && seAfterOk && seMissOk && seRefuseOk && seForceOk;
 
+// 53) edit-steer (B+A): a FOCUSED search_symbol result appends an EDIT_STEER pointing at the symbol-edit
+// tools (the moment before the model would Read-the-file-to-Edit) — gated to small result sets,
+// VTS_EDIT_STEER=0 hides it. And discover MEASURES the edit habit (A): a whole-declaration Edit on a code
+// file, with the tokens of that file's prior Read attributed (what a symbol-edit would have skipped).
+const ssSteer = await runTool("search_symbol", { q: "Spawn", projectPath: process.cwd(), backend: "clangd" });
+const ssSteerOk = !ssSteer.isError && /replace_symbol_body/.test(ssSteer.text) && /VTS_EDIT_STEER=0/.test(ssSteer.text);
+process.env.VTS_EDIT_STEER = "0";
+const ssOff = await runTool("search_symbol", { q: "Spawn", projectPath: process.cwd(), backend: "clangd" });
+delete process.env.VTS_EDIT_STEER;
+const ssOffOk = !ssOff.isError && !/replace_symbol_body/.test(ssOff.text);
+const eProj = path.join(os.tmpdir(), `vts-eval-${process.pid}-editdisc`);
+fs.mkdirSync(path.join(eProj, "P--proj"), { recursive: true });
+const ENOW = new Date().toISOString();
+const bigRead = "x ".repeat(2000); // a sizable file read → measurable tokens to attribute
+const declOld = "void Foo::Bar()\n{\n  a();\n  b();\n  c();\n  d();\n  e();\n  f();\n  g();\n}"; // 9 newlines + decl cue
+fs.writeFileSync(path.join(eProj, "P--proj", "t.jsonl"),
+  JSON.stringify({ type: "assistant", cwd: eProj, timestamp: ENOW, message: { role: "assistant", content: [{ type: "tool_use", id: "r1", name: "Read", input: { file_path: "/proj/src/Thing.cpp" } }] } }) + "\n" +
+  JSON.stringify({ type: "user", cwd: eProj, timestamp: ENOW, message: { role: "user", content: [{ type: "tool_result", tool_use_id: "r1", content: bigRead }] } }) + "\n" +
+  JSON.stringify({ type: "assistant", cwd: eProj, timestamp: ENOW, message: { role: "assistant", content: [{ type: "tool_use", id: "e1", name: "Edit", input: { file_path: "/proj/src/Thing.cpp", old_string: declOld, new_string: "void Foo::Bar(){}" } }] } }) + "\n");
+process.env.VTS_CLAUDE_PROJECTS = eProj;
+const discEdit = await runTool("vts_discover", { since: 7 });
+delete process.env.VTS_CLAUDE_PROJECTS;
+const editDiscOk = !discEdit.isError && /1 whole-declaration Edit/.test(discEdit.text) && /skip that read/.test(discEdit.text);
+try { fs.rmSync(eProj, { recursive: true, force: true }); } catch { /* ignore */ }
+const editSteerOk = ssSteerOk && ssOffOk && editDiscOk;
+
 await disposeClients();
 // 48) clean teardown (no orphaned child): disposeClients must terminate EVERY spawned language-server
 // child — evicted, swept, mid-warmup, or key-overwritten — via the master registry. A surviving child
@@ -1110,6 +1136,7 @@ const rows = [
   ["enforce v2: symbol-hunt Grep blocks, freeform warns + discover counts Glob", enforceAndDiscoverOk, "true", enforceAndDiscoverOk],
   ["v2.2: find <dir> honored in rewrite + concrete-code Glob blocks → find_files", v22Ok, "true", v22Ok],
   ["symbolic editing: replace/insert/safe_delete by name (preview+apply+ref-guard)", symEditOk, "true", symEditOk],
+  ["edit-steer: search EDIT_STEER (toggle) + discover counts whole-decl Edit", editSteerOk, "true", editSteerOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/core.js
+++ b/server/core.js
@@ -107,6 +107,15 @@ const EMPTY_HINT =
   "match. search_symbol matches DEFINITIONS, not every reference. Looking for something in a LOG? Logs " +
   "aren't indexed — use gamedev-log.";
 const LOG_EMPTY_HINT = " Looking for something in a LOG? Logs aren't indexed for code search — use gamedev-log for log content.";
+// Appended to a FOCUSED symbol/definition result: the model just located a declaration, the moment right
+// BEFORE it would Read the whole file to Edit it. Point it at the symbol-edit tools, which edit by NAME and
+// skip that read — the token win lives here (upstream of Edit), not at the Edit call. Additive, one line,
+// only on small result sets (a 60-hit search isn't an edit precursor). `VTS_EDIT_STEER=0` hides it.
+const EDIT_STEER =
+  "\n↪ Going to CHANGE one of these? Edit by NAME — replace_symbol_body (whole body) / insert_after_symbol / " +
+  "insert_before_symbol / safe_delete (preview by default, apply=true writes). It skips reading the file into " +
+  "context. (VTS_EDIT_STEER=0 to hide.)";
+const editSteerOn = () => process.env.VTS_EDIT_STEER !== "0" && process.env.VTS_EDIT_STEER !== "false";
 
 // First-use setup nudge: if the plugin has never been configured (no config file), prepend a one-time
 // pointer to setup the FIRST time a search/nav tool runs in a process. Once per process (not per call) so
@@ -305,6 +314,24 @@ function matchBypass(name, input) {
   }
   return null;
 }
+// A built-in Edit/MultiEdit whose replaced text is a WHOLE declaration on a code file — the case the
+// symbol-edit tools (replace_symbol_body / insert_* / safe_delete) address. Heuristic, for MEASUREMENT only
+// (discover): a multi-line old_string (≥ VTS_EDIT_MIN_LINES) that carries a declaration cue. Write is a new
+// file (not a symbol replace) and a tiny tweak isn't worth a symbol-edit, so both are skipped. Returns
+// { file } so the scan can attribute the file's prior Read (the token the symbol-edit would have skipped).
+const DECL_HINT = /\b(class|struct|enum|interface|namespace|template|def|function|func|fn|public|private|protected|static|void|virtual|override|async)\b|\)\s*(const)?\s*\{?\s*$/m;
+function wholeDeclEdit(name, input) {
+  if (!input) return null;
+  const file = String(input.file_path || "").replace(/\\/g, "/");
+  if (!DISCOVER_CODE_EXT.test(file)) return null;
+  const minLines = envInt("VTS_EDIT_MIN_LINES", 8);
+  const chunks = [];
+  if (name === "Edit") chunks.push(String(input.old_string || ""));
+  else if (name === "MultiEdit" && Array.isArray(input.edits)) for (const e of input.edits) chunks.push(String(e.old_string || ""));
+  else return null;
+  for (const c of chunks) if ((c.match(/\n/g) || []).length >= minLines && DECL_HINT.test(c)) return { file: file.toLowerCase() };
+  return null;
+}
 // Shared transcript scan: find bypassed code searches and (always, cheaply) harvest the source-file
 // paths their results contained. discoverReport formats this; autoLearn feeds the harvest straight into
 // the warm-set so the loop closes without a human in it.
@@ -343,8 +370,13 @@ function scanBypasses(a = {}) {
   const PATH_RE = /([A-Za-z]:)?[\w./\\-]+\.(?:c|cc|cxx|cpp|h|hpp|hh|inl|ipp|tpp|cs|ts|tsx|mts|cts|js|jsx|mjs|cjs|py|pyi)\b/g;
   const cand = new Map(); // tool_use_id → {tool,q}
   const missed = []; let rawTokTotal = 0; let lines = 0; const MAX_LINES = 300000;
+  // Edit-habit measurement (A): count whole-declaration Edits on code files, and attribute the tokens of a
+  // PRIOR Read of that same file — that read is what a symbol-edit (edit-by-name) would have skipped.
+  let editCount = 0, editReadTok = 0;
+  const reads = new Map();   // normalized file → tokens of its most recent Read result (per transcript)
+  const readUse = new Map(); // Read tool_use_id → normalized file (its result carries the size)
   outer: for (const { p } of files) {
-    cand.clear(); // a tool_use and its result always share one transcript → bound the map per file
+    cand.clear(); reads.clear(); readUse.clear(); // a tool_use and its result always share one transcript → bound per file
     let txt; try { txt = fs.readFileSync(p, "utf8"); } catch { continue; }
     for (const line of txt.split(/\r?\n/)) {
       if (!line.trim()) continue;
@@ -358,7 +390,16 @@ function scanBypasses(a = {}) {
       const content = e && e.message && e.message.content;
       if (!Array.isArray(content)) continue;
       for (const b of content) {
-        if (b && b.type === "tool_use") { const m = matchBypass(b.name, b.input); if (m) cand.set(b.id, m); }
+        if (b && b.type === "tool_use") {
+          const m = matchBypass(b.name, b.input); if (m) cand.set(b.id, m);
+          if (b.name === "Read" && b.input && b.input.file_path) readUse.set(b.id, String(b.input.file_path).replace(/\\/g, "/").toLowerCase());
+          else { const we = wholeDeclEdit(b.name, b.input); if (we) { editCount++; if (reads.has(we.file)) { editReadTok += reads.get(we.file); reads.delete(we.file); } } } // attribute a read ONCE (a re-Read re-adds it) — no double-count when several edits follow one read
+        }
+        else if (b && b.type === "tool_result" && readUse.has(b.tool_use_id)) {
+          const f = readUse.get(b.tool_use_id); readUse.delete(b.tool_use_id);
+          const o = typeof b.content === "string" ? b.content : JSON.stringify(b.content || "");
+          reads.set(f, tok(o)); // most recent Read of this file → the token a later symbol-edit would skip
+        }
         else if (b && b.type === "tool_result" && cand.has(b.tool_use_id)) {
           const meta = cand.get(b.tool_use_id); cand.delete(b.tool_use_id);
           const o = typeof b.content === "string" ? b.content : JSON.stringify(b.content || "");
@@ -381,7 +422,7 @@ function scanBypasses(a = {}) {
       }
     }
   }
-  return { missed, rawTokTotal, learned, filesCount: files.length, all, since };
+  return { missed, rawTokTotal, learned, filesCount: files.length, all, since, editCount, editReadTok };
 }
 // Boot-time self-improvement: harvest the last `since` days of bypassed searches and record their result
 // files into the warm-set query-history — the same write `vts discover --learn` does, but automatic.
@@ -398,7 +439,9 @@ export function autoLearn(root, since = 7) {
 function discoverReport(a = {}) {
   const r = scanBypasses(a);
   if (r.error) return r.error;
-  const { missed, rawTokTotal, learned, filesCount: fc, all, since } = r;
+  const { missed, rawTokTotal, learned, filesCount: fc, all, since, editCount, editReadTok } = r;
+  // A: surface the edit habit alongside the search bypasses — whole-declaration Edits that could edit by name.
+  const editLine = editCount ? `\n  edit habit: ${editCount} whole-declaration Edit(s) on code; ~${editReadTok.toLocaleString()} tok went to reading those files first — replace_symbol_body / insert_after_symbol / insert_before_symbol / safe_delete edit by NAME and skip that read.` : "";
   const files = { length: fc };
   const learn = a.learn === true || a.learn === "true";
   const learnRoot = resolveRoot(a);
@@ -417,7 +460,7 @@ function discoverReport(a = {}) {
   const caught = (() => { const s = readSavings(); return Math.max(0, (s.rawTok || 0) - (s.outTok || 0)); })();
   const rate = caught + rawTokTotal > 0 ? (100 * caught / (caught + rawTokTotal)).toFixed(1) : "—";
   const catchLine = `\n  catch-rate: ~${caught.toLocaleString()} tok caught (via vts) vs ~${rawTokTotal.toLocaleString()} still bypassing → ${rate}% of search tokens routed through vts`;
-  if (!missed.length) return `vs-token-safer discover (${scope}, ${files.length} transcript(s)): no code searches bypassed vts. It's catching them. ✓` + catchLine + learnLine;
+  if (!missed.length) return `vs-token-safer discover (${scope}, ${files.length} transcript(s)): no code searches bypassed vts. It's catching them. ✓` + catchLine + editLine + learnLine;
   const byTool = {};
   for (const m of missed) byTool[m.tool] = (byTool[m.tool] || 0) + 1;
   const toolLine = Object.entries(byTool).sort((x, y) => y[1] - x[1]).map(([t, n]) => `${t}×${n}`).join(", ");
@@ -427,7 +470,7 @@ function discoverReport(a = {}) {
     `  ${missed.length} code search(es) bypassed vts (${toolLine})\n` +
     `  raw tool output ingested: ~${rawTokTotal.toLocaleString()} tok (~$${usd(rawTokTotal).toFixed(2)}) — routed through vts (file:line, capped) most of this is avoidable (typically 70–90% less)${catchLine}\n` +
     `  biggest:\n${top}\n` +
-    `  Fix: rewrite is on by default (Bash grep auto-reroutes to vts); for the Grep tool, prefer the vs-search MCP tools (search_symbol / search_text / find_files).${learnLine}`;
+    `  Fix: rewrite is on by default (Bash grep auto-reroutes to vts); for the Grep tool, prefer the vs-search MCP tools (search_symbol / search_text / find_files).${editLine}${learnLine}`;
 }
 
 // ---- LSP client pool (one per root+backend; reused across calls in a process) ----
@@ -1263,7 +1306,8 @@ export async function runTool(name, a = {}) {
         return finishOut([], adv + `No symbols matching "${a.q}" (backend: ${backendName}).` + EMPTY_HINT);
       }
       const symTee = teeOverflow("search_symbol", a.q, syms.map((s) => `${s.name} @ ${locLine(s.location.uri, s.location.range)}`), max);
-      return finishOut(syms, adv + `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root})${symTee}:\n` + fmtSymbols(syms, max));
+      const symEdit = editSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10) ? EDIT_STEER : ""; // focused lookup → likely an edit precursor
+      return finishOut(syms, adv + `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root})${symTee}:\n` + fmtSymbols(syms, max) + symEdit);
     }
     if (name === "find_references") {
       const c = await getClient(root, backendName);
@@ -1313,7 +1357,8 @@ export async function runTool(name, a = {}) {
       const c = await getClient(root, backendName);
       const locs = (await c.definition(a.path, Number(a.line), Number(a.character))) || [];
       try { recordQueryResults(root, (Array.isArray(locs) ? locs : [locs]).filter(Boolean).map((l) => fromUri(l.uri))); } catch { /* best-effort */ }
-      return finishOut(locs, backendAdvisory(backendName, root) + `definition of ${a.path}:${Number(a.line) + 1} (backend: ${backendName}):\n` + fmtLocations(locs, max, "definition(s)"));
+      const defEdit = editSteerOn() && (Array.isArray(locs) ? locs.length : !!locs) ? EDIT_STEER : ""; // landed on a decl → edit precursor
+      return finishOut(locs, backendAdvisory(backendName, root) + `definition of ${a.path}:${Number(a.line) + 1} (backend: ${backendName}):\n` + fmtLocations(locs, max, "definition(s)") + defEdit);
     }
     if (name === "hover") {
       if (!a.path || a.line == null || a.character == null) return err("hover needs path, line, character (0-based position).");

--- a/skills/vs-search/SKILL.md
+++ b/skills/vs-search/SKILL.md
@@ -15,6 +15,11 @@ be open; the engine is spawned headlessly. Karpathy-style rules: do the listed t
 - Type / signature at a position → `hover`  (args: `path`, `line`, `character`).
 - Outline a file (its classes/functions) → `document_symbols`  (args: `path`).
 - Rename a symbol project-wide → `rename`  (args: `path`, `line`, `character`, `newName`, `apply`). Semantic (every reference), not a `sed`. Preview by default; `apply=true` writes the edits.
+- **Add / replace / delete a WHOLE declaration → edit it by NAME**, don't Read-the-file-then-Edit:
+  - Replace a function/method/class body (signature included) → `replace_symbol_body`  (args: `symbol`, `body`, optional `path`/`line`, `apply`).
+  - Add a sibling declaration after/before one → `insert_after_symbol` / `insert_before_symbol`  (args: `symbol`, `text`, `apply`).
+  - Remove a declaration → `safe_delete`  (args: `symbol`, `force`, `apply`). Refuses while it's still referenced unless `force=true`.
+  - The outline supplies the exact span, so you skip reading the whole file into context. Preview by default; `apply=true` writes. Use the built-in Edit for a sub-declaration tweak (a few lines inside a body); use these when the unit is the whole declaration.
 - Raw text / string / comment / config key (the symbol index can't answer) → `search_text`  (args: `q`, `projectPath`). Token-capped; the sanctioned grep replacement.
 - File by name (substring or glob) → `find_files`  (args: `q`, `projectPath`). Replaces `find -name`.
 - Show/adjust config → `vts_config` / `vts_setup`. Token savings → `vts_savings`. Pre-warm → `vts_warmup`.


### PR DESCRIPTION
## Summary
The symbol-edit tools (v0.21.0) were under-used in practice. A grep-style rewrite/block **can't** transfer to editing — Edit→symbol-edit is a cross-tool switch (`updatedInput` can't change the tool), and the token win (skipping the file Read) is already sunk by the time Edit fires. So steer **earlier** (before the read) and **softer**, and **measure** whether it lands.

## B — steer at the search/nav result
`EDIT_STEER` appended to a FOCUSED `search_symbol` (≤ `VTS_EDIT_STEER_MAX` 10) / `goto_definition` result, pointing at `replace_symbol_body` / `insert_*` / `safe_delete`. `VTS_EDIT_STEER=0` hides it.

## A — measure the edit habit (`vts discover`)
`wholeDeclEdit` flags a built-in Edit/MultiEdit whose `old_string` is a whole declaration (≥ `VTS_EDIT_MIN_LINES` + decl cue) on a code file, and attributes that file's **prior Read** tokens (the read a symbol-edit would skip) via a Read↔Edit correlation. A read is counted **once** (no double-count when several edits follow one read). Surfaced as an `edit habit:` line.

**Measured (30d real transcripts):** 616 whole-declaration edits, **~287k tok** spent reading those files first — comparable to the 372k search bypass. The edit habit is a real token sink.

## C — SKILL routing line
Add/replace/delete a whole declaration → edit by NAME; built-in Edit for sub-declaration tweaks.

## Why not a hard Edit hook
Blocking Edit recovers nothing (read already sunk) and can't rewrite cross-tool — pure friction. The only capturable point is *before* the read, i.e. the search result (B). B/C are nudges; A measures whether they actually dent the 287k habit, to decide if more is warranted.

## CI
eval **54/54** (guard 53: steer toggle + discover edit count). lint clean. README EN+KO `VTS_EDIT_STEER` row + CLAUDE.md note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)