### PR TITLE
feat: edit-warn L1+L2 + symbol-edit adoption loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,13 +70,25 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   `vts_config`, `vts_savings` (RTK-gain-style: `graph`/`daily`/`history` + est. USD over timestamped day
   buckets), `vts_savings_reset`, `vts_discover` (scans `~/.claude/projects/*.jsonl` for code searches that
   BYPASSED vts → missed-token report + catch-rate; `learn=true` feeds their result files into the warm-set;
-  ALSO MEASURES THE EDIT HABIT — `wholeDeclEdit` flags a built-in Edit/MultiEdit whose `old_string` is a
-  whole declaration on a code file (≥`VTS_EDIT_MIN_LINES`+decl cue), and attributes that file's PRIOR Read
-  tokens [`reads`/`readUse` Read↔Edit correlation in `scanBypasses`] = the read a symbol-edit would've
-  skipped → `edit habit:` line). STEER (B, not a rewrite — Edit-rewrite is unsafe [partial≠whole-decl] and
-  too late [read already sunk], so steer EARLIER+SOFTER): `EDIT_STEER` is appended to a FOCUSED
-  `search_symbol` (≤`VTS_EDIT_STEER_MAX` 10) / `goto_definition` result — the moment before the model would
-  Read-the-file-to-Edit — pointing at the symbol-edit tools; `VTS_EDIT_STEER=0` hides it. Eval guard 53.
+  ALSO MEASURES THE EDIT HABIT — `classifyDeclEdit` (server/edit-detect.js, SHARED with the enforcement hook)
+  flags a built-in Edit/MultiEdit whose `old_string` is a whole declaration (replace → `replaceDecl`) OR whose
+  `new_string` is (add → `insertDecl`) on a code file (≥`VTS_EDIT_MIN_LINES`+decl cue), and attributes that
+  file's PRIOR Read tokens [`reads`/`readUse` Read↔Edit correlation in `scanBypasses`, read counted ONCE] = the
+  read a symbol-edit would've skipped → `edit habit:` line; ALSO `editUnreached` = how many had NO prior vts
+  search on that file [`searchUse`/`searchedBn` basename match] = the fraction the search-result steer CAN'T
+  reach. Measured 30d: 1284 whole-decl edits, ~468k tok read-first, 1194/1284 (93%) search-unreachable). STEER
+  is THREE layers, soft→hard (Edit-rewrite impossible: cross-tool `updatedInput` can't switch Edit→MCP, and the
+  read is sunk by Edit time so a block recovers nothing — only a LEARNING signal): (B) `EDIT_STEER` on a FOCUSED
+  `search_symbol` (≤`VTS_EDIT_STEER_MAX` 10) / `goto_definition` result (`VTS_EDIT_STEER=0` hides); (L1) the
+  grep-block hook now also matches `Edit|MultiEdit` — a whole-decl replace/insert gets a MODEL-VISIBLE
+  `emitWarn` with a READY symbol-edit call (`replace_symbol_body`/`insert_after_symbol`, `declSymbolName`
+  best-effort names it), `VTS_EDIT_WARN=0` off; (L2) once the adoption ledger's ignore-`streak` hits
+  `VTS_EDIT_BLOCK_AFTER` (5), a SAFE insert (`insertDecl && !replaceDecl` — `insert_after_symbol` can't corrupt)
+  is BLOCKED (exit 2); a replace stays warn. ADOPTION LEDGER (server/edit-ledger.js, `~/.vs-token-safer/
+  edit-adoption.json`, `VTS_EDIT_LEDGER` override): hook records `builtin-warn` (streak++), core.js records
+  `symbol-edit` on every symbol-edit dispatch (streak→0); `hooks/edit-report.js` (SessionStart) re-injects the
+  adoption % as a goal = the SkillOpt-style measure→re-inject loop (static skill can't self-improve, a
+  re-injected live metric can). Eval guards 53 (steer+discover) + 54 (L1/L2 hook); `eval/test-edit-steer.mjs`.
   `find_files`/`search_text` write a recovery TEE file (`VTS_TEE_DIR`, default on-truncate) when a result is
   capped so the full set is recoverable without re-running; a capped `search_symbol`/`find_references`
   ("… N more") tees too (`teeOverflow` — the rows are already in memory, no re-query). The ledger

--- a/README.ko.md
+++ b/README.ko.md
@@ -305,6 +305,8 @@ cd vs-token-safer/server && npm install && npm link   # `vts` 제공
 | — | `VTS_REWRITE` | `1` | `0`이면 훅이 바꿔치기 대신 Bash 코드-grep을 차단. |
 | — | `VTS_GREP_BLOCK` | `1` | `0`이면 **Grep/Glob 도구** 격상을 차단에서 경고로 되돌림. |
 | — | `VTS_EDIT_STEER` | `1` | `0`이면 포커스된 `search_symbol`/`goto_definition` 결과에 붙는 심볼편집 도구 안내 한 줄을 숨김. `VTS_EDIT_STEER_MAX`(`10`)는 안내가 붙는 결과 크기 상한. |
+| — | `VTS_EDIT_WARN` | `1` | `0`이면 built-in Edit/MultiEdit가 **선언 통째**를 교체/추가할 때 뜨는 모델 가시 넛지를 끔(`replace_symbol_body`/`insert_after_symbol` 안내). 선언 일부 수정은 넛지 안 함. |
+| — | `VTS_EDIT_BLOCK_AFTER` | `5` | 넛지를 무시한 선언-통째 편집이 연속 이만큼 쌓이면 **안전한 insert**(새 선언)를 `insert_after_symbol`로 차단; `0`이면 에스컬레이션 끔(`VTS_GREP_BLOCK=0`도 warn으로 묶음). replace는 항상 warn 유지. |
 | — | `VTS_EXCLUDE_COMMANDS` | — | 면제할 실행 파일 콤마 목록 (설정의 `excludeCommands`도). |
 | — | `VTS_COMPACT_VCS` | `1` | `0`이면 읽기 전용 `git`/`p4`의 압축 래퍼 우회를 멈춤. |
 | `lang` | `VTS_LANG` | auto | 훅 메시지 언어: `ko` / `en` (OS 로케일에서 자동 감지). |

--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ Precedence: **`VTS_*` env > `~/.vs-token-safer/config.json` > default.**
 | — | `VTS_REWRITE` | `1` | `0` makes the hook block a Bash code-grep instead of rewriting it. |
 | — | `VTS_GREP_BLOCK` | `1` | `0` reverts the **Grep/Glob tool** escalation from block to warn-only. |
 | — | `VTS_EDIT_STEER` | `1` | `0` hides the one-line hint (on a focused `search_symbol`/`goto_definition` result) pointing at the symbol-edit tools. `VTS_EDIT_STEER_MAX` (`10`) caps the result size that gets it. |
+| — | `VTS_EDIT_WARN` | `1` | `0` silences the model-visible nudge when a built-in Edit/MultiEdit replaces or adds a **whole declaration** (it points at `replace_symbol_body` / `insert_after_symbol`). Sub-declaration tweaks are never nudged. |
+| — | `VTS_EDIT_BLOCK_AFTER` | `5` | After this many consecutive whole-declaration edits that ignore the nudge, a **safe insert** (a new declaration) is blocked toward `insert_after_symbol`; `0` disables escalation (also held to warn by `VTS_GREP_BLOCK=0`). A replace always stays a warn. |
 | — | `VTS_EXCLUDE_COMMANDS` | — | Comma list of executables to exempt (also `excludeCommands` in config). |
 | — | `VTS_COMPACT_VCS` | `1` | `0` stops rerouting read-only `git`/`p4` to the compacted wrapper. |
 | `lang` | `VTS_LANG` | auto | Hook message language: `ko` / `en` (auto-detects from OS locale). |

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -22,6 +22,8 @@ const SV = path.join(os.tmpdir(), `vts-eval-sv-${process.pid}.json`); // isolate
 process.env.VTS_SAVINGS_FILE = SV;
 const TEE = path.join(os.tmpdir(), `vts-eval-tee-${process.pid}`); // isolate the tee dir
 process.env.VTS_TEE_DIR = TEE;
+const EDL = path.join(os.tmpdir(), `vts-eval-edl-${process.pid}.json`); // isolate the edit-adoption ledger
+process.env.VTS_EDIT_LEDGER = EDL; // so the symbolic-edit guards don't write the user's real adoption ledger
 process.env.VTS_LANG = "en"; // force English UI so message-marker assertions are deterministic regardless of OS locale
 const { runTool, disposeClients, prewarm } = await import("../server/core.js");
 
@@ -1065,6 +1067,38 @@ const editDiscOk = !discEdit.isError && /1 whole-declaration Edit/.test(discEdit
 try { fs.rmSync(eProj, { recursive: true, force: true }); } catch { /* ignore */ }
 const editSteerOk = ssSteerOk && ssOffOk && editDiscOk;
 
+// 54) edit-steer HOOK (L1 warn + L2 escalation): a whole-decl REPLACE/INSERT Edit gets a model-visible
+// nudge with a ready symbol-edit call; a sub-decl tweak / non-code file / VTS_EDIT_WARN=0 stays silent. L2:
+// once the adoption ledger's ignore-streak hits VTS_EDIT_BLOCK_AFTER, a SAFE insert is BLOCKED (a replace
+// stays warn — riskier to force). The ledger is isolated to a temp file so the eval never touches the real one.
+const EL = path.join(os.tmpdir(), `vts-eval-el-${process.pid}.json`);
+const elEnv = (extra) => ({ VTS_EDIT_LEDGER: EL, VTS_LANG: "en", ...(extra || {}) });
+const DECLC = "void Foo::Bar()\n{\n  a();\n  b();\n  c();\n  d();\n  e();\n  f();\n  g();\n}"; // 9 newlines + decl cue
+try { fs.rmSync(EL, { force: true }); } catch { /* ignore */ }
+const hRepl = runHook({ tool_name: "Edit", tool_input: { file_path: "/src/T.cpp", old_string: DECLC, new_string: "x" } }, elEnv());
+const hIns = runHook({ tool_name: "Edit", tool_input: { file_path: "/src/T.cpp", old_string: "  anchor();", new_string: DECLC } }, elEnv());
+const hSub = runHook({ tool_name: "Edit", tool_input: { file_path: "/src/T.cpp", old_string: "a,\nb,", new_string: "a,\nb,\nc," } }, elEnv());
+const hOff = runHook({ tool_name: "Edit", tool_input: { file_path: "/src/T.cpp", old_string: DECLC, new_string: "x" } }, elEnv({ VTS_EDIT_WARN: "0" }));
+const hMd = runHook({ tool_name: "Edit", tool_input: { file_path: "/notes/T.md", old_string: DECLC, new_string: "x" } }, elEnv());
+const editWarnOk =
+  hRepl.status === 0 && /replace_symbol_body symbol="Bar"/.test(nudgeCtx(hRepl)) &&   // whole-decl replace → ready replace call
+  hIns.status === 0 && /insert_after_symbol symbol="Bar"/.test(nudgeCtx(hIns)) &&     // new-decl insert → ready insert call
+  hSub.status === 0 && !nudgeCtx(hSub) &&                                              // sub-decl tweak → silent
+  hOff.status === 0 && !nudgeCtx(hOff) &&                                              // VTS_EDIT_WARN=0 → silent
+  hMd.status === 0 && !nudgeCtx(hMd);                                                  // non-code file → silent
+fs.writeFileSync(EL, JSON.stringify({ builtin: 5, symbol: 0, streak: 5 }));            // streak at the threshold
+const hEsc = runHook({ tool_name: "Edit", tool_input: { file_path: "/src/T.cpp", old_string: "  anchor();", new_string: DECLC } }, elEnv({ VTS_EDIT_BLOCK_AFTER: "5" }));
+fs.writeFileSync(EL, JSON.stringify({ builtin: 9, symbol: 0, streak: 9 }));
+const hEscRepl = runHook({ tool_name: "Edit", tool_input: { file_path: "/src/T.cpp", old_string: DECLC, new_string: "x" } }, elEnv({ VTS_EDIT_BLOCK_AFTER: "5" }));
+fs.writeFileSync(EL, JSON.stringify({ builtin: 9, symbol: 0, streak: 9 }));
+const hEscOff = runHook({ tool_name: "Edit", tool_input: { file_path: "/src/T.cpp", old_string: "  anchor();", new_string: DECLC } }, elEnv({ VTS_EDIT_BLOCK_AFTER: "0" }));
+const editEscalateOk =
+  hEsc.status === 2 && /escalated to a block/.test(hEsc.err) &&   // insert past the streak → block
+  hEscRepl.status === 0 &&                                         // replace stays warn even at high streak
+  hEscOff.status === 0;                                            // VTS_EDIT_BLOCK_AFTER=0 → escalation off
+try { fs.rmSync(EL, { force: true }); } catch { /* ignore */ }
+const editHookOk = editWarnOk && editEscalateOk;
+
 await disposeClients();
 // 48) clean teardown (no orphaned child): disposeClients must terminate EVERY spawned language-server
 // child — evicted, swept, mid-warmup, or key-overwritten — via the master registry. A surviving child
@@ -1081,6 +1115,7 @@ try { fs.rmSync(IG, { force: true }); } catch { /* ignore */ }
 try { fs.rmSync(CF, { force: true }); } catch { /* ignore */ }
 try { fs.rmSync(SV, { force: true }); } catch { /* ignore */ }
 try { fs.rmSync(TEE, { recursive: true, force: true }); } catch { /* ignore */ }
+try { fs.rmSync(EDL, { force: true }); } catch { /* ignore */ }
 
 const rows = [
   ["LSP client handshake + symbol", lspOk, "true", lspOk],
@@ -1137,6 +1172,7 @@ const rows = [
   ["v2.2: find <dir> honored in rewrite + concrete-code Glob blocks → find_files", v22Ok, "true", v22Ok],
   ["symbolic editing: replace/insert/safe_delete by name (preview+apply+ref-guard)", symEditOk, "true", symEditOk],
   ["edit-steer: search EDIT_STEER (toggle) + discover counts whole-decl Edit", editSteerOk, "true", editSteerOk],
+  ["edit-steer hook: L1 warn (replace/insert) + L2 safe-insert escalation", editHookOk, "true", editHookOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/eval/test-edit-steer.mjs
+++ b/eval/test-edit-steer.mjs
@@ -20,6 +20,7 @@ process.env.VTS_INCLUDE_GRAPH = tmp("ig.json");
 process.env.VTS_CONFIG_FILE = tmp("cfg.json"); fs.writeFileSync(process.env.VTS_CONFIG_FILE, "{}");
 process.env.VTS_SAVINGS_FILE = tmp("sv.json");
 process.env.VTS_TEE_DIR = tmp("tee");
+process.env.VTS_EDIT_LEDGER = tmp("edl.json"); // isolate the adoption ledger from the user's real one
 process.env.VTS_LANG = "en";
 const { runTool, disposeClients } = await import("../server/core.js");
 
@@ -70,6 +71,8 @@ const useRead = (id, file) => ({ type: "tool_use", id, name: "Read", input: { fi
 const resRead = (id, body) => ({ type: "tool_result", tool_use_id: id, content: body });
 const useEdit = (file, oldStr, name = "Edit") => ({ type: "tool_use", id: u(), name, input: name === "MultiEdit" ? { file_path: file, edits: [{ old_string: oldStr, new_string: "x" }] } : { file_path: file, old_string: oldStr, new_string: "x" } });
 const useWrite = (file, body) => ({ type: "tool_use", id: u(), name: "Write", input: { file_path: file, content: body } });
+const useSearch = (id) => ({ type: "tool_use", id, name: "mcp__plugin_vs-token-safer_vs-search__search_symbol", input: { q: "X" } });
+const resSearch = (id, body) => ({ type: "tool_result", tool_use_id: id, content: body });
 // Build an isolated transcript dir, run discover scoped to it, parse the edit-habit line.
 let dirN = 0;
 async function editHabit(lines) {
@@ -81,7 +84,8 @@ async function editHabit(lines) {
   delete process.env.VTS_CLAUDE_PROJECTS;
   fs.rmSync(base, { recursive: true, force: true });
   const m = r.text.match(/edit habit: (\d+) whole-declaration Edit\(s\) on code; ~([\d,]+) tok/);
-  return m ? { count: Number(m[1]), readTok: Number(m[2].replace(/,/g, "")) } : { count: 0, readTok: 0 };
+  const mu = r.text.match(/of those, (\d+)\/\d+ had NO prior vts search/);
+  return m ? { count: Number(m[1]), readTok: Number(m[2].replace(/,/g, "")), unreached: mu ? Number(mu[1]) : 0 } : { count: 0, readTok: 0, unreached: 0 };
 }
 const RT = tok(BIG); // expected tokens for one BIG read
 // 1 read + 1 whole-decl edit on the same file → count 1, read attributed once.
@@ -111,6 +115,12 @@ check("A: MultiEdit whole-decl → counted", a8.count === 1);
 // Write (a new file, not a symbol replace) → not counted.
 const a9 = await editHabit([ev("assistant", [useWrite("/src/New.cpp", DECL)])]);
 check("A: Write → not counted", a9.count === 0);
+// reachability: edit with NO prior vts search on the file → steer-unreachable (the user's search-less flow).
+const a10 = await editHabit([ev("assistant", [useEdit("/src/Thing.cpp", DECL)])]);
+check("A: edit, no prior search → unreached 1/1", a10.count === 1 && a10.unreached === 1);
+// a prior vts search whose RESULT named the file → steer-reachable → NOT counted as unreached.
+const a11 = await editHabit([ev("assistant", [useSearch("s1")]), ev("user", [resSearch("s1", "FooThing @ /proj/src/Thing.cpp:10")]), ev("assistant", [useEdit("/src/Thing.cpp", DECL)])]);
+check("A: search result named the file → reachable → unreached 0", a11.count === 1 && a11.unreached === 0);
 
 await disposeClients();
 console.log("vs-token-safer — edit-steer + edit-habit verification\n");

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -32,6 +32,10 @@ import { fileURLToPath } from "node:url";
 // inside quotes is part of a grep pattern — `grep "FooA|FooB" src/x.cpp` used to split into two
 // non-matching segments and sail through the hook entirely (the top bypass `vts discover` surfaced).
 import { splitSegments } from "../server/shell-split.js";
+// Whole-declaration edit detector, shared with discover (core.js) so the set we STEER matches the set we
+// MEASURE; the adoption ledger is the live metric the steer is tuned against.
+import { classifyDeclEdit } from "../server/edit-detect.js";
+import { recordEditEvent, readEditLedger } from "../server/edit-ledger.js";
 
 const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(os.homedir(), ".vs-token-safer", "config.json");
 const readConfig = () => { try { return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8")) || {}; } catch { return {}; } };
@@ -300,6 +304,38 @@ function grepNudgeFor(ti) {
       "code-locator subagent." + concrete + " For a JUST-edited / unindexed file or a quick literal peek, " +
       "Grep is fine — carry on. Disable: VTS_ENFORCE=0.";
 }
+
+// ── Edit steering (L1 warn): a whole-DECLARATION edit via the built-in Edit gets a model-visible nudge with
+// a ready symbol-edit call. The token win (skipping the file Read) is already sunk by Edit time, so this
+// can't recover the CURRENT edit — it's a learning signal for the NEXT one, and the adoption ledger measures
+// whether it lands (escalating to a block only if it doesn't; see L2). A sub-declaration tweak isn't flagged.
+function editWarnOn() { const v = String(process.env.VTS_EDIT_WARN ?? "1").toLowerCase(); return !(v === "0" || v === "false" || v === "off"); }
+function editMinLines() { const n = Number(process.env.VTS_EDIT_MIN_LINES); return Number.isFinite(n) && n > 0 ? n : 8; }
+// Best-effort declaration name from a code chunk, so the nudge can name the symbol (a ready call beats a
+// vague hint — the SkillOpt "actionable artifact" principle). null when no name is confidently found.
+function declSymbolName(chunk) {
+  const c = String(chunk || "");
+  let m;
+  if ((m = c.match(/\b(?:class|struct|enum|interface|namespace)\s+([A-Za-z_]\w*)/))) return m[1];
+  if ((m = c.match(/\b(?:def|function|func|fn)\s+([A-Za-z_]\w*)/))) return m[1];
+  if ((m = c.match(/^[^\n=;]*?\b([A-Za-z_]\w*)\s*\([^;{)]*\)\s*(?:const)?\s*\{?\s*$/m))) return m[1]; // a signature line
+  return null;
+}
+function editNudgeFor(toolName, ti) {
+  const ce = classifyDeclEdit(toolName, ti, editMinLines());
+  const pairs = toolName === "MultiEdit" && Array.isArray(ti.edits) ? ti.edits : [ti];
+  let name = null;
+  for (const e of pairs) { name = declSymbolName(ce.replaceDecl ? e.old_string : e.new_string); if (name) break; }
+  const sym = name ? `symbol="${name}"` : "symbol=<name>";
+  if (ce.replaceDecl) {
+    return KO
+      ? `[vs-token-safer] 선언을 *통째* 교체하네요. 파일을 통째로 Read해서 Edit하는 대신 이름으로 편집하세요 — replace_symbol_body ${sym} body=<새 선언 전체> (preview 기본, apply=true 기록; 파일 Read 생략·토큰 절약). 선언 일부만 고치는 거면 Edit 그대로 OK. 끄기: VTS_EDIT_WARN=0.`
+      : `[vs-token-safer] This replaces a WHOLE declaration. Instead of Read-the-file-then-Edit, edit by name — replace_symbol_body ${sym} body=<the full new declaration> (preview by default, apply=true writes; skips the file Read, saves tokens). A sub-declaration tweak? Built-in Edit is fine. Disable: VTS_EDIT_WARN=0.`;
+  }
+  return KO
+    ? `[vs-token-safer] 새 선언을 *추가*하네요. 앵커를 Read할 필요 없이 이름 옆에 삽입하세요 — insert_after_symbol ${sym} text=<추가할 선언> (또는 insert_before_symbol; preview 기본, apply=true 기록). 끄기: VTS_EDIT_WARN=0.`
+    : `[vs-token-safer] This ADDS a new declaration. Insert it next to an anchor by name (no Read needed for the anchor) — insert_after_symbol ${sym} text=<the new declaration> (or insert_before_symbol; preview by default, apply=true writes). Disable: VTS_EDIT_WARN=0.`;
+}
 // enforcement v2 (A+) + v2.1: a Grep-TOOL pattern HUNTING A NAMED SYMBOL is escalated from warn to BLOCK —
 // a semantic tool is strictly better (smaller, exact, no regex false positives — `void.*Foo\(` also matches
 // `SetActiveFoo`), and the reroute is search_text/search_symbol (same regex, token-capped → no wrong/missing
@@ -460,6 +496,31 @@ process.stdin.on("end", () => {
   // First-use setup nudge: if the plugin was never configured, append a pointer to setup on whatever
   // message we emit (the user is already mid-grep, exactly when configuring helps).
   const setup = notSetUp() ? SETUP_LINE : "";
+
+  // Edit / MultiEdit — L1 steer: a whole-DECLARATION edit (replace or add) gets a model-visible nudge with a
+  // ready symbol-edit call, and is recorded in the adoption ledger. Non-blocking (the read is already sunk;
+  // forcing a redo here recovers nothing — see the asymmetry note). L2 escalates to a block on the safe
+  // insert subset once the streak shows the nudge is being ignored.
+  if (toolName === "Edit" || toolName === "MultiEdit") {
+    if (editWarnOn()) {
+      const ce = classifyDeclEdit(toolName, ti, editMinLines());
+      if (ce.file && (ce.replaceDecl || ce.insertDecl)) {
+        const led = recordEditEvent("builtin-warn");
+        // L2: once whole-decl edits have ignored the nudge enough times in a row, BLOCK the SAFE subset — a
+        // pure insert of a new declaration (insert_after_symbol cleanly adds it without needing the old body,
+        // so the reroute can't corrupt). A replace stays warn-only (riskier to force). VTS_EDIT_BLOCK_AFTER=0
+        // disables escalation; VTS_GREP_BLOCK=0 also holds it to warn (shares the master block switch).
+        const after = Number(process.env.VTS_EDIT_BLOCK_AFTER);
+        const threshold = Number.isFinite(after) && after >= 0 ? after : 5;
+        if (grepBlockOn() && threshold > 0 && led.streak >= threshold && ce.insertDecl && !ce.replaceDecl) {
+          process.stderr.write(editNudgeFor(toolName, ti) + " (escalated to a block: the nudge was ignored " + led.streak + "× — use insert_after_symbol / insert_before_symbol, or VTS_EDIT_BLOCK_AFTER=0 to disable.)" + setup + "\n");
+          process.exit(2); // block — route the safe insert to a symbol-edit
+        }
+        emitWarn(editNudgeFor(toolName, ti) + setup);
+      }
+    }
+    process.exit(0);
+  }
 
   // Grep TOOL — enforcement v2 (A+): a clear SYMBOL HUNT is BLOCKED (semantic tool is strictly better);
   // everything else stays warn-only (Grep is the sanctioned fallback for freeform text / just-edited files).

--- a/hooks/edit-report.js
+++ b/hooks/edit-report.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+// SessionStart self-report — read the edit-adoption ledger and re-inject the symbol-edit adoption ratio as
+// a goal the model sees at the top of the session. This is the "learning" half of the steer loop: the hook
+// + discover MEASURE, this RE-INJECTS the gap as a concrete goal, behavior shifts, and the next session
+// measures again (the SkillOpt textual-gradient cadence — a static skill rule can't self-improve, but a
+// re-injected live metric can). Stays quiet until there's enough data to be worth a line of context.
+import { readEditLedger, adoptionPct } from "../server/edit-ledger.js";
+
+try {
+  const o = readEditLedger();
+  const pct = adoptionPct(o);
+  const total = (o.builtin || 0) + (o.symbol || 0);
+  if (pct === null || total < 5) process.exit(0); // too little data — don't nag
+  const msg =
+    `[vs-token-safer] Symbol-edit adoption: ${pct}% (${o.symbol || 0} symbol-edit vs ${o.builtin || 0} built-in Edit on whole declarations). ` +
+    `When you ADD or REPLACE a whole declaration this session, prefer replace_symbol_body / insert_after_symbol / insert_before_symbol — ` +
+    `they edit by NAME and skip reading the file into context. Aim to raise the ratio. (Built-in Edit stays right for sub-declaration tweaks.)`;
+  process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: msg } }) + "\n");
+} catch { /* best-effort — never break session start */ }
+process.exit(0);

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -10,13 +10,17 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/prewarm.js\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/edit-report.js\""
           }
         ]
       }
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash|Grep|Glob",
+        "matcher": "Bash|Grep|Glob|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/server/core.js
+++ b/server/core.js
@@ -14,6 +14,8 @@ import { LspClient, fromUri, langIdForPath, envInt } from "./lsp.js";
 import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot } from "./backends/index.js";
 import { recordQueryResults, languageCensus } from "./warmset.js";
 import { splitSegments } from "./shell-split.js";
+import { classifyDeclEdit } from "./edit-detect.js";
+import { recordEditEvent } from "./edit-ledger.js";
 import { compactGit, compactP4 } from "./compact.js";
 
 const CONFIG_DIR = path.join(os.homedir(), ".vs-token-safer");
@@ -314,24 +316,9 @@ function matchBypass(name, input) {
   }
   return null;
 }
-// A built-in Edit/MultiEdit whose replaced text is a WHOLE declaration on a code file — the case the
-// symbol-edit tools (replace_symbol_body / insert_* / safe_delete) address. Heuristic, for MEASUREMENT only
-// (discover): a multi-line old_string (≥ VTS_EDIT_MIN_LINES) that carries a declaration cue. Write is a new
-// file (not a symbol replace) and a tiny tweak isn't worth a symbol-edit, so both are skipped. Returns
-// { file } so the scan can attribute the file's prior Read (the token the symbol-edit would have skipped).
-const DECL_HINT = /\b(class|struct|enum|interface|namespace|template|def|function|func|fn|public|private|protected|static|void|virtual|override|async)\b|\)\s*(const)?\s*\{?\s*$/m;
-function wholeDeclEdit(name, input) {
-  if (!input) return null;
-  const file = String(input.file_path || "").replace(/\\/g, "/");
-  if (!DISCOVER_CODE_EXT.test(file)) return null;
-  const minLines = envInt("VTS_EDIT_MIN_LINES", 8);
-  const chunks = [];
-  if (name === "Edit") chunks.push(String(input.old_string || ""));
-  else if (name === "MultiEdit" && Array.isArray(input.edits)) for (const e of input.edits) chunks.push(String(e.old_string || ""));
-  else return null;
-  for (const c of chunks) if ((c.match(/\n/g) || []).length >= minLines && DECL_HINT.test(c)) return { file: file.toLowerCase() };
-  return null;
-}
+// Whole-declaration edit detection (replace + insert) lives in edit-detect.js, SHARED with the enforcement
+// hook so the set we MEASURE here matches the set the hook STEERS. Discover counts an edit when its replaced
+// text is a whole declaration (replace_symbol_body territory) OR its added text is (insert_after/before).
 // Shared transcript scan: find bypassed code searches and (always, cheaply) harvest the source-file
 // paths their results contained. discoverReport formats this; autoLearn feeds the harvest straight into
 // the warm-set so the loop closes without a human in it.
@@ -372,11 +359,15 @@ function scanBypasses(a = {}) {
   const missed = []; let rawTokTotal = 0; let lines = 0; const MAX_LINES = 300000;
   // Edit-habit measurement (A): count whole-declaration Edits on code files, and attribute the tokens of a
   // PRIOR Read of that same file — that read is what a symbol-edit (edit-by-name) would have skipped.
-  let editCount = 0, editReadTok = 0;
-  const reads = new Map();   // normalized file → tokens of its most recent Read result (per transcript)
-  const readUse = new Map(); // Read tool_use_id → normalized file (its result carries the size)
+  let editCount = 0, editReadTok = 0, editUnreached = 0; // editUnreached: whole-decl edits with NO prior vts
+  // search on that file → the EDIT_STEER (which only rides a search_symbol/goto result) could never have
+  // reached them. A high fraction is the case for a harder lever (a warn on the Edit itself).
+  const reads = new Map();      // normalized file → tokens of its most recent Read result (per transcript)
+  const readUse = new Map();    // Read tool_use_id → normalized file (its result carries the size)
+  const searchUse = new Map();  // vts search/goto/refs tool_use id → true (its result carries the file:line)
+  const searchedBn = new Set(); // basenames seen in a prior vts search/goto/refs RESULT → steer-reachable
   outer: for (const { p } of files) {
-    cand.clear(); reads.clear(); readUse.clear(); // a tool_use and its result always share one transcript → bound per file
+    cand.clear(); reads.clear(); readUse.clear(); searchUse.clear(); searchedBn.clear(); // tool_use+result share one transcript → bound per file
     let txt; try { txt = fs.readFileSync(p, "utf8"); } catch { continue; }
     for (const line of txt.split(/\r?\n/)) {
       if (!line.trim()) continue;
@@ -393,12 +384,18 @@ function scanBypasses(a = {}) {
         if (b && b.type === "tool_use") {
           const m = matchBypass(b.name, b.input); if (m) cand.set(b.id, m);
           if (b.name === "Read" && b.input && b.input.file_path) readUse.set(b.id, String(b.input.file_path).replace(/\\/g, "/").toLowerCase());
-          else { const we = wholeDeclEdit(b.name, b.input); if (we) { editCount++; if (reads.has(we.file)) { editReadTok += reads.get(we.file); reads.delete(we.file); } } } // attribute a read ONCE (a re-Read re-adds it) — no double-count when several edits follow one read
+          else if (/(?:search_symbol|goto_definition|find_references)$/.test(String(b.name || ""))) searchUse.set(b.id, true);
+          else { const ce = classifyDeclEdit(b.name, b.input, envInt("VTS_EDIT_MIN_LINES", 8)); if (ce.file && (ce.replaceDecl || ce.insertDecl)) { editCount++; if (reads.has(ce.file)) { editReadTok += reads.get(ce.file); reads.delete(ce.file); } if (!searchedBn.has(path.basename(ce.file))) editUnreached++; } } // attribute a read ONCE (a re-Read re-adds it); unreached = no prior vts search landed on this file
         }
         else if (b && b.type === "tool_result" && readUse.has(b.tool_use_id)) {
           const f = readUse.get(b.tool_use_id); readUse.delete(b.tool_use_id);
           const o = typeof b.content === "string" ? b.content : JSON.stringify(b.content || "");
           reads.set(f, tok(o)); // most recent Read of this file → the token a later symbol-edit would skip
+        }
+        else if (b && b.type === "tool_result" && searchUse.has(b.tool_use_id)) {
+          searchUse.delete(b.tool_use_id);
+          const o = typeof b.content === "string" ? b.content : JSON.stringify(b.content || "");
+          let pm; PATH_RE.lastIndex = 0; while ((pm = PATH_RE.exec(o))) searchedBn.add(path.basename(pm[0]).toLowerCase()); // files a prior steer-carrying search surfaced
         }
         else if (b && b.type === "tool_result" && cand.has(b.tool_use_id)) {
           const meta = cand.get(b.tool_use_id); cand.delete(b.tool_use_id);
@@ -422,7 +419,7 @@ function scanBypasses(a = {}) {
       }
     }
   }
-  return { missed, rawTokTotal, learned, filesCount: files.length, all, since, editCount, editReadTok };
+  return { missed, rawTokTotal, learned, filesCount: files.length, all, since, editCount, editReadTok, editUnreached };
 }
 // Boot-time self-improvement: harvest the last `since` days of bypassed searches and record their result
 // files into the warm-set query-history — the same write `vts discover --learn` does, but automatic.
@@ -439,9 +436,12 @@ export function autoLearn(root, since = 7) {
 function discoverReport(a = {}) {
   const r = scanBypasses(a);
   if (r.error) return r.error;
-  const { missed, rawTokTotal, learned, filesCount: fc, all, since, editCount, editReadTok } = r;
+  const { missed, rawTokTotal, learned, filesCount: fc, all, since, editCount, editReadTok, editUnreached } = r;
   // A: surface the edit habit alongside the search bypasses — whole-declaration Edits that could edit by name.
-  const editLine = editCount ? `\n  edit habit: ${editCount} whole-declaration Edit(s) on code; ~${editReadTok.toLocaleString()} tok went to reading those files first — replace_symbol_body / insert_after_symbol / insert_before_symbol / safe_delete edit by NAME and skip that read.` : "";
+  // editUnreached = those with no prior vts search on the file → the EDIT_STEER (search-result-only) can't
+  // reach them; a high fraction is the evidence for a harder lever (a warn on the Edit itself).
+  const editLine = editCount ? `\n  edit habit: ${editCount} whole-declaration Edit(s) on code; ~${editReadTok.toLocaleString()} tok went to reading those files first — replace_symbol_body / insert_after_symbol / insert_before_symbol / safe_delete edit by NAME and skip that read.` +
+    `\n    of those, ${editUnreached}/${editCount} had NO prior vts search on that file → the search-result steer can't reach them (the case for a warn-on-Edit if this fraction stays high).` : "";
   const files = { length: fc };
   const learn = a.learn === true || a.learn === "true";
   const learnRoot = resolveRoot(a);
@@ -1400,6 +1400,7 @@ export async function runTool(name, a = {}) {
       const c = await getClient(root, backendName);
       const r = await resolveSymbolForEdit(c, root, backendName, a);
       if (r.error) return err(`${name}: ${r.error}`);
+      try { recordEditEvent("symbol-edit"); } catch { /* best-effort: adoption ledger feeds the edit-steer loop */ }
       const apply = a.apply === true || a.apply === "true";
       const rng = r.ds.range;
       const ambl = r.ambiguous > 1 ? ` (⚠ ${r.ambiguous} symbols named "${a.symbol}"; editing the first — pass line=<0-based> to disambiguate)` : "";

--- a/server/edit-detect.js
+++ b/server/edit-detect.js
@@ -1,0 +1,34 @@
+// Shared whole-declaration edit detector — used by BOTH the discover measurement (core.js) and the
+// edit-enforcement hook (hooks/block-code-grep.js), so the set we MEASURE and the set we STEER are the
+// same (mirrors splitSegments, shared between the grep hook and discover). The token win of the symbol-
+// edit tools lives in whole-DECLARATION operations: replacing a function/class body, or adding a new one.
+// A sub-declaration tweak (a few lines inside a body — e.g. one more item in an array) is NOT a fit and is
+// deliberately ignored; built-in Edit stays correct there.
+const CODE_EXT = /\.(c|cc|cxx|cpp|h|hpp|hh|inl|ipp|tpp|cs|ts|tsx|mts|cts|js|jsx|mjs|cjs|py|pyi)\b/;
+// A declaration cue: a structural keyword, or a line that ends in `)` / `) {` (a signature/body opener).
+const DECL_HINT = /\b(class|struct|enum|interface|namespace|template|def|function|func|fn|public|private|protected|static|void|virtual|override|async|UFUNCTION|UCLASS|USTRUCT)\b|\)\s*(const)?\s*\{?\s*$/m;
+const isWholeDecl = (s, minLines) => (String(s).match(/\n/g) || []).length >= minLines && DECL_HINT.test(String(s));
+
+// Classify a built-in edit tool call against the whole-declaration heuristic.
+//   replaceDecl — the text being REPLACED (old_string) is a whole declaration → replace_symbol_body fits.
+//   insertDecl  — the text being ADDED (new_string) is a whole declaration while what it replaces is NOT
+//                 → an addition; insert_after_symbol / insert_before_symbol fit.
+// `file` is the normalized lowercase path, or null when the target isn't a code file (callers early-out).
+// Write (a whole new file) and non-edit tools return all-false: not a symbol-level replace/insert.
+export function classifyDeclEdit(name, input, minLines = 8) {
+  const none = { file: null, replaceDecl: false, insertDecl: false };
+  if (!input) return none;
+  const fileRaw = String(input.file_path || "").replace(/\\/g, "/");
+  if (!CODE_EXT.test(fileRaw)) return none;
+  const file = fileRaw.toLowerCase();
+  const pairs = [];
+  if (name === "Edit") pairs.push([input.old_string, input.new_string]);
+  else if (name === "MultiEdit" && Array.isArray(input.edits)) for (const e of input.edits) pairs.push([e.old_string, e.new_string]);
+  else return { file, replaceDecl: false, insertDecl: false };
+  let replaceDecl = false, insertDecl = false;
+  for (const [oldS, newS] of pairs) {
+    if (isWholeDecl(oldS || "", minLines)) replaceDecl = true;       // replacing a whole declaration
+    else if (isWholeDecl(newS || "", minLines)) insertDecl = true;   // adding a whole declaration (old isn't one)
+  }
+  return { file, replaceDecl, insertDecl };
+}

--- a/server/edit-ledger.js
+++ b/server/edit-ledger.js
@@ -1,0 +1,32 @@
+// Edit-adoption ledger — the live metric for the symbol-edit steering loop (the SkillOpt-style "score"):
+// how often a whole-declaration edit went through a vts symbol-edit tool (the behavior we want) vs the
+// built-in Edit (which we warned on). The hook records a builtin-warn; core.js records a symbol-edit. The
+// `streak` (consecutive builtin-warns since the last symbol-edit) drives the L2 auto-escalation, and the
+// SessionStart self-report reads the ratio back to the model as a goal. Local JSON, best-effort, never throws.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const LEDGER = () => process.env.VTS_EDIT_LEDGER || path.join(os.homedir(), ".vs-token-safer", "edit-adoption.json");
+
+export function readEditLedger() {
+  try { return JSON.parse(fs.readFileSync(LEDGER(), "utf8")); } catch { return { builtin: 0, symbol: 0, streak: 0 }; }
+}
+function write(o) {
+  try { const p = LEDGER(); fs.mkdirSync(path.dirname(p), { recursive: true }); fs.writeFileSync(p, JSON.stringify(o)); } catch { /* best-effort */ }
+}
+// kind: "symbol-edit" (a vts symbol-edit tool was used → adoption up, ignore-streak reset) or anything else
+// (a whole-decl edit went through the built-in Edit and we warned → builtin up, streak up). Returns the
+// updated ledger so the caller (the hook) can read the fresh streak for an escalation decision.
+export function recordEditEvent(kind) {
+  const o = readEditLedger();
+  if (kind === "symbol-edit") { o.symbol = (o.symbol || 0) + 1; o.streak = 0; }
+  else { o.builtin = (o.builtin || 0) + 1; o.streak = (o.streak || 0) + 1; }
+  write(o);
+  return o;
+}
+// Adoption % = symbol-edits / all whole-decl edits. null when there's no data yet.
+export function adoptionPct(o = readEditLedger()) {
+  const total = (o.builtin || 0) + (o.symbol || 0);
+  return total ? Math.round((100 * (o.symbol || 0)) / total) : null;
+}


### PR DESCRIPTION
## Summary
The v0.22.0 search-result `EDIT_STEER` can't reach a **search-less edit flow** — measured **93%** (1194/1284) of whole-declaration edits had no prior vts search on the file. So reach the Edit itself, soft→hard, and close a measure/re-inject learning loop.

## Measurement (insert now counted)
`edit-detect.js` `classifyDeclEdit` — shared whole-decl detector for **both** discover (measure) and the hook (steer): **replace** (old_string is a whole decl) + **insert** (new_string is). discover now counts inserts → **626→1284 edits, ~290k→~468k tok / 30d**, and reports `editUnreached`.

## L1 — warn (model-visible)
Hook matches `Edit|MultiEdit`. Whole-decl replace/insert → `emitWarn` with a **ready** symbol-edit call (`replace_symbol_body symbol="X"` / `insert_after_symbol`, `declSymbolName` names it). Sub-declaration tweaks stay silent. `VTS_EDIT_WARN=0`. Non-blocking (read already sunk → learning signal, not token recovery).

## L2 — auto-escalation
Adoption ledger ignore-streak ≥ `VTS_EDIT_BLOCK_AFTER` (5) → a **safe insert** is blocked (`insert_after_symbol` can't corrupt); a replace stays warn.

## Adoption loop (lightweight SkillOpt)
`edit-ledger.js`: hook records `builtin-warn`, core.js records `symbol-edit`. `edit-report.js` (SessionStart) re-injects the adoption % as a goal — measure→re-inject, the cadence a static skill can't do. Full-automation (behavioral A/B eval) is the planned follow-up patch.

## CI
eval **55/55** (guard 54), `eval/test-edit-steer.mjs` 18/18, lint + validate green. `VTS_EDIT_LEDGER` isolated in the evals. README EN+KO + CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)