### PR TITLE
test: SkillOpt behavioral-eval harness for edit-steer optimization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
         run: node eval/run.mjs
       - name: Edit-steer verification (EDIT_STEER placement + discover edit-habit exactness)
         run: node eval/test-edit-steer.mjs
+      - name: SkillOpt scorer + gate self-test
+        run: node eval/skillopt/selftest.mjs
       - name: Install MCP server deps
         working-directory: server
         run: npm install --no-audit --no-fund

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,9 @@ export default [
   {
     // gamedev-log-analyzer is a VENDORED static mirror of ../rider-mcp-enforcer (synced byte-for-byte by
     // scripts/sync-gamedev.mjs) — lint it in its source repo, not here, or fixes would break the mirror.
-    ignores: ["node_modules", "**/node_modules", "package-lock.json", "**/package-lock.json", "gamedev-log-analyzer/**"],
+    // *.workflow.js run in the Workflow runtime (top-level await/return + injected globals agent/parallel/
+    // phase/log/args), not as plain ESM — eslint can't parse them; they're exercised by running the workflow.
+    ignores: ["node_modules", "**/node_modules", "package-lock.json", "**/package-lock.json", "gamedev-log-analyzer/**", "**/*.workflow.js"],
   },
   {
     ...js.configs.recommended,

--- a/eval/skillopt/README.md
+++ b/eval/skillopt/README.md
@@ -1,0 +1,66 @@
+# SkillOpt behavioral eval (edit-steer optimization)
+
+The lightweight adoption loop (v0.23.0) MEASURES symbol-edit adoption and RE-INJECTS it as a goal, but it
+can't tell you *which wording* of the warn/skill makes an agent actually switch. This harness is the missing
+piece — a [SkillOpt](https://github.com/microsoft/SkillOpt)-style **scored rollout**: run editing scenarios
+under different skill/warn **variants**, see which tool the agent really picks, and **gate** a reword on a
+strict held-out improvement.
+
+## Pieces
+
+| File | Role |
+| --- | --- |
+| `scenarios.mjs` | Synthetic editing situations where a symbol-edit is the right call (insert / replace), split into train + `holdout`. Synthetic names only. |
+| `variants.mjs` | The **trainable artifact** — `baseline` (live behavior) + candidate guidance rewordings. |
+| `score.mjs` | Deterministic scorer + **validation gate** (`classifyRollout` / `variantScore` / `gate`). Unit-tested. |
+| `selftest.mjs` | CI-gated test of the scorer/gate logic (no live agents). `npm run eval:skillopt`. |
+| `rollout.workflow.js` | The live rollout — a Workflow that spawns one sub-agent per scenario×variant, each doing a **real edit** in a sandbox (the hook warn is active) and self-reporting the tools it used. Token-heavy, opt-in. |
+
+## The loop (SkillOpt's rollout → reflection → gate)
+
+1. **Rollout** (opt-in, token-heavy): run `rollout.workflow.js` via the Workflow tool, passing `scenarios`
+   and `variants` as `args`. Each sub-agent sets up a TS sandbox, performs the edit, and reports `toolsUsed`.
+2. **Score**: adoption = symbol-edits / (symbol-edits + built-in-edits) per variant, on the held-out split.
+3. **Gate**: a candidate variant is accepted only if its held-out adoption **strictly beats** the baseline
+   (`minDelta`). The winner's guidance is what should fold into the real warn (`editNudgeFor`) / `SKILL.md`.
+4. **Reflection**: a human (or a reflection sub-agent reading the scored rollouts) proposes the next
+   `variants` entries; repeat.
+
+## Running
+
+Deterministic core (CI):
+```bash
+node eval/skillopt/selftest.mjs      # scorer + gate
+```
+
+Live rollout (opt-in — spawns scenario×variant sub-agents; costs tokens). Build `args` from the fixtures and
+invoke the Workflow tool with `eval/skillopt/rollout.workflow.js`. It returns `{ perVariant, verdicts,
+winner, raw }` — the winner's wording is the candidate to graft into the live warn/skill.
+
+## First live run (2 scenarios × 2 variants, 4 agents)
+
+A smoke run validated the pipeline end-to-end and taught three things:
+
+- **Ceiling effect.** On clean single-declaration toy scenarios, **baseline already scored 100%** symbol-edit
+  adoption — the live plugin (v0.23.0 hook + tools) drives the right choice without extra guidance, so the
+  candidate variant couldn't differentiate (Δ 0pp → gate rejects). To get signal, scenarios must sit in the
+  regime where baseline adoption is *below* 100% — the real-world miss is on **big files / search-less flows**,
+  not toy ones. Widen/harden `scenarios.mjs` before trusting a reword verdict.
+- **Score on `appliedTool`, not `toolsUsed`.** One rollout *tried* a symbol-edit, hit a backend spawn
+  failure, and fell back to the built-in Edit — `toolsUsed` listed both, which inflated it to "symbol". The
+  scorer now classifies on `appliedTool` (the tool that actually made the edit); the smoke surfaced this.
+- **Sandbox path + backend reliability are real noise.** The vs-search MCP server runs on Windows node, so an
+  MSYS `/tmp` sandbox path broke its backend spawn; the prompt now tells the agent to use a Windows-native
+  path. A TS-backend ENOENT in one rollout also forced a fallback. Behavioral eval found live bugs — that's
+  the point — but they add variance to a small-N run.
+
+## Honest caveats
+
+- **Fidelity**: scoring is the agent's *self-report* of tools used after a *real* edit (the hook warn does
+  fire). It's behavior, not a stated preference — but it trusts the agent's report.
+- **Backend dependence**: symbol-edit needs the TS backend to resolve in the sandbox; if it can't, every
+  variant scores low and they don't differentiate. The scenarios use plain single-file TS to minimize this.
+- **Not CI**: the rollout spawns real agents — too token-heavy and non-deterministic for the CI gate. Only
+  the scorer/gate (`selftest.mjs`) runs in CI.
+- **Small N**: a few scenarios give a noisy adoption estimate. Treat a single run as directional; average
+  several, or widen `scenarios.mjs`, before trusting a reword.

--- a/eval/skillopt/rollout.workflow.js
+++ b/eval/skillopt/rollout.workflow.js
@@ -1,0 +1,103 @@
+export const meta = {
+  name: 'skillopt-edit-rollout',
+  description: 'SkillOpt behavioral eval: roll out edit scenarios under skill/warn variants, score tool choice, gate',
+  whenToUse: 'Optimize the symbol-edit steer text — measure which warn/skill wording makes an agent actually pick the symbol-edit tools over the built-in Edit. Token-heavy (one sub-agent per scenario×variant).',
+  phases: [
+    { title: 'Rollout', detail: 'one sub-agent per scenario×variant — real edit in a sandbox, self-report tools' },
+    { title: 'Score', detail: 'adoption per variant + validation gate vs baseline on held-out scenarios' },
+  ],
+};
+
+// Inputs via args (the workflow runtime has no fs/import): { scenarios:[{id,holdout,file,content,task,expect}],
+// variants:[{id,guidance}], minDelta? }. The deterministic scoring mirrors eval/skillopt/score.mjs (which is
+// unit-tested) — kept inline because a workflow script can't import it.
+// args may arrive as an object or as a JSON string depending on how it was passed — accept both.
+const A = typeof args === 'string' ? (() => { try { return JSON.parse(args); } catch { return {}; } })() : (args || {});
+const scenarios = A.scenarios || [];
+const variants = A.variants || [];
+const minDelta = typeof A.minDelta === 'number' ? A.minDelta : 0;
+log(`SkillOpt rollout: ${scenarios.length} scenario(s) × ${variants.length} variant(s) (args type: ${typeof args}).`);
+if (!scenarios.length || !variants.length) { log('No scenarios/variants received — nothing to roll out.'); return { error: 'empty args', argsType: typeof args, perVariant: {}, verdicts: [], winner: null, raw: [] }; }
+
+const RESULT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    toolsUsed: { type: 'array', items: { type: 'string' }, description: 'Every edit/search tool you called (e.g. "Read", "Edit", "replace_symbol_body", "insert_after_symbol").' },
+    appliedTool: { type: 'string', description: 'The SINGLE tool that actually applied the final edit (e.g. "insert_after_symbol" or "Edit"). If you tried one tool, it failed, and you fell back to another, name the one that SUCCEEDED.' },
+    editApplied: { type: 'boolean', description: 'Whether the requested edit was actually made.' },
+    approach: { type: 'string', description: 'One sentence: how you made the edit.' },
+  },
+  required: ['toolsUsed', 'appliedTool', 'editApplied'],
+};
+
+const SYMBOL = new Set(['replace_symbol_body', 'insert_after_symbol', 'insert_before_symbol', 'safe_delete', 'rename']);
+const BUILTIN = new Set(['Edit', 'MultiEdit', 'Write']);
+const bare = (t) => String(t).replace(/^.*__/, '');
+// Score on the tool that APPLIED the edit (honest — a tried-symbol-then-fell-back-to-Edit rollout is builtin);
+// fall back to toolsUsed only if appliedTool is missing. Mirrors eval/skillopt/score.mjs (unit-tested).
+const classify = (r) => {
+  if (r && r.appliedTool) { const t = bare(r.appliedTool); if (SYMBOL.has(t)) return 'symbol'; if (BUILTIN.has(t)) return 'builtin'; }
+  const norm = ((r && r.toolsUsed) || []).map(bare);
+  if (norm.some((t) => SYMBOL.has(t))) return 'symbol';
+  if (norm.some((t) => BUILTIN.has(t))) return 'builtin';
+  return 'other';
+};
+
+function rolloutPrompt(scn, variant) {
+  return [
+    'You are in a tool-choice evaluation. Do the edit task for real, then report the tools you used.',
+    '',
+    'Step 1 — set up an isolated sandbox: create a fresh temp directory, write a minimal `tsconfig.json` ({}) and `package.json` ({}) in it, and write this file:',
+    '',
+    `FILE: ${scn.file}`,
+    '```ts',
+    scn.content,
+    '```',
+    '',
+    `Step 2 — perform this edit on ${scn.file} (pass projectPath=<the sandbox dir> to any vs-search tool so it roots there):`,
+    scn.task,
+    variant.guidance ? `\nGuidance: ${variant.guidance}` : '',
+    '',
+    'Use whatever tools you judge best — the built-in Edit, or the vs-search symbol-edit tools, your call.',
+    'Note: the vs-search MCP server runs on Windows node, so use a Windows-native sandbox path (not an MSYS /tmp path) or its language-server backend can fail to reach the file.',
+    'Then report: every edit/search tool you called (toolsUsed), the SINGLE tool that actually APPLIED the final edit (appliedTool — if you fell back, name the one that succeeded), whether the edit was applied, and a one-sentence approach.',
+  ].join('\n');
+}
+
+phase('Rollout');
+// One rollout per scenario×variant. pipeline keeps each independent (no barrier): score a variant's
+// rollouts as soon as they finish. Stage 1 = the live edit; stage 2 just tags the result with its keys.
+const jobs = [];
+for (const v of variants) for (const scn of scenarios) jobs.push({ v, scn });
+const rolled = await parallel(jobs.map((j) => () =>
+  agent(rolloutPrompt(j.scn, j.v), { label: `roll:${j.v.id}/${j.scn.id}`, phase: 'Rollout', schema: RESULT_SCHEMA })
+    .then((res) => ({ variantId: j.v.id, scenarioId: j.scn.id, holdout: j.scn.holdout === true, result: res, klass: classify(res) }))
+    .catch(() => ({ variantId: j.v.id, scenarioId: j.scn.id, holdout: j.scn.holdout === true, result: null, klass: 'other' }))
+));
+
+phase('Score');
+const scoreOf = (rows) => {
+  let symbol = 0, builtin = 0, other = 0;
+  for (const r of rows) { if (r.klass === 'symbol') symbol++; else if (r.klass === 'builtin') builtin++; else other++; }
+  const total = symbol + builtin;
+  return { symbol, builtin, other, total, adoption: total ? symbol / total : null };
+};
+const ok = rolled.filter(Boolean);
+const perVariant = {};
+for (const v of variants) {
+  const mine = ok.filter((r) => r.variantId === v.id);
+  perVariant[v.id] = { all: scoreOf(mine), holdout: scoreOf(mine.filter((r) => r.holdout)), train: scoreOf(mine.filter((r) => !r.holdout)) };
+}
+const baseline = perVariant['baseline'] ? perVariant['baseline'].holdout : null;
+const verdicts = variants.filter((v) => v.id !== 'baseline').map((v) => {
+  const cand = perVariant[v.id].holdout;
+  let accept = false, reason = 'no baseline';
+  if (cand.adoption == null) { accept = false; reason = 'candidate produced no scorable edits'; }
+  else if (!baseline || baseline.adoption == null) { accept = cand.adoption > 0; reason = 'no baseline — accept any positive signal'; }
+  else { const d = cand.adoption - baseline.adoption; accept = d > minDelta; reason = `holdout adoption ${Math.round((baseline.adoption || 0) * 100)}% → ${Math.round(cand.adoption * 100)}% (Δ ${Math.round(d * 100)}pp, need > ${Math.round(minDelta * 100)}pp)`; }
+  return { variant: v.id, accept, reason, holdout: cand };
+});
+const winner = verdicts.filter((x) => x.accept).sort((a, b) => (b.holdout.adoption || 0) - (a.holdout.adoption || 0))[0];
+log(`SkillOpt rollout done: baseline holdout adoption ${baseline && baseline.adoption != null ? Math.round(baseline.adoption * 100) + '%' : 'n/a'}; ${verdicts.filter((v) => v.accept).length}/${verdicts.length} candidate(s) beat it.`);
+return { perVariant, verdicts, winner: winner ? winner.variant : null, raw: ok };

--- a/eval/skillopt/scenarios.mjs
+++ b/eval/skillopt/scenarios.mjs
@@ -1,0 +1,42 @@
+// SkillOpt scenarios — synthetic editing situations where a SYMBOL-EDIT tool is the right choice (a whole
+// declaration is added or replaced). The rollout writes these files into a temp sandbox, hands the agent the
+// task, and scores which edit tool it reached for. `holdout: true` marks the validation set the gate scores
+// on (so a variant can't be tuned to the same scenarios it's accepted on). Synthetic names only — no
+// proprietary symbols ever enter the repo. TypeScript so the live backend (tsserver) resolves symbol edits.
+export const SCENARIOS = [
+  {
+    id: "add-method",
+    holdout: false,
+    file: "widget.ts",
+    content: "export class Widget {\n  width = 0;\n  area(): number {\n    return this.width * this.width;\n  }\n}\n",
+    task: "Add a new method `perimeter(): number` to the Widget class that returns this.width * 4.",
+    expect: "insert",
+  },
+  {
+    id: "replace-fn",
+    holdout: false,
+    file: "calc.ts",
+    content: "export function compute(a: number, b: number): number {\n  // old implementation\n  return a + b;\n}\n",
+    task: "Replace the body of `compute` so it returns a * b instead of a + b.",
+    expect: "replace",
+  },
+  {
+    id: "add-class",
+    holdout: true,
+    file: "shapes.ts",
+    content: "export class Circle {\n  radius = 1;\n  area(): number {\n    return 3.14 * this.radius * this.radius;\n  }\n}\n",
+    task: "Add a new class `Square` (with a field `side = 1` and an `area()` method) after the Circle class.",
+    expect: "insert",
+  },
+  {
+    id: "replace-method",
+    holdout: true,
+    file: "service.ts",
+    content: "export class Service {\n  run(): string {\n    return \"old\";\n  }\n}\n",
+    task: "Replace the body of the `run` method so it returns \"new\".",
+    expect: "replace",
+  },
+];
+
+export const heldout = (s) => s.holdout === true;
+export const train = (s) => s.holdout !== true;

--- a/eval/skillopt/score.mjs
+++ b/eval/skillopt/score.mjs
@@ -1,0 +1,49 @@
+// SkillOpt scorer — the deterministic, testable core of the behavioral-eval harness. A "rollout" is one
+// sub-agent run on one editing scenario under one skill/warn VARIANT; the agent self-reports the edit tools
+// it used. This module classifies that report and aggregates an ADOPTION score per variant, then a
+// validation GATE decides whether a candidate variant beats the baseline. The live rollouts (spawning the
+// agents) live in rollout.workflow.js — they're token-heavy and opt-in; the SCORING is kept here so the
+// gate logic itself is deterministic and CI-testable (a gate you can't trust isn't a gate).
+const SYMBOL_EDIT_TOOLS = new Set(["replace_symbol_body", "insert_after_symbol", "insert_before_symbol", "safe_delete", "rename"]);
+const BUILTIN_EDIT_TOOLS = new Set(["Edit", "MultiEdit", "Write"]);
+
+// Classify one rollout by the edit tool that ACTUALLY APPLIED the change. `appliedTool` (the single tool
+// that made the final edit) is the honest signal — a smoke run showed an agent that TRIED a symbol-edit,
+// hit a backend failure, and fell back to the built-in Edit; counting it as "symbol" off `toolsUsed` (which
+// listed both) inflated adoption. Prefer appliedTool; fall back to toolsUsed only when it's absent. MCP
+// names (mcp__…__replace_symbol_body) are normalized to the bare tool. "other" = no edit (not scorable).
+const bare = (t) => String(t).replace(/^.*__/, "");
+export function classifyRollout(r) {
+  if (r && r.appliedTool) {
+    const t = bare(r.appliedTool);
+    if (SYMBOL_EDIT_TOOLS.has(t)) return "symbol";
+    if (BUILTIN_EDIT_TOOLS.has(t)) return "builtin";
+  }
+  const norm = ((r && r.toolsUsed) || []).map(bare);
+  if (norm.some((t) => SYMBOL_EDIT_TOOLS.has(t))) return "symbol";
+  if (norm.some((t) => BUILTIN_EDIT_TOOLS.has(t))) return "builtin";
+  return "other";
+}
+
+// Aggregate a variant's rollouts into an adoption rate = symbol-edits / (symbol-edits + builtin-edits).
+// "other" rollouts (no edit) are excluded from the denominator — they carry no tool-choice signal.
+export function variantScore(rollouts) {
+  let symbol = 0, builtin = 0, other = 0;
+  for (const r of rollouts) {
+    const c = classifyRollout(r);
+    if (c === "symbol") symbol++; else if (c === "builtin") builtin++; else other++;
+  }
+  const total = symbol + builtin;
+  return { symbol, builtin, other, total, adoption: total ? symbol / total : null };
+}
+
+// Validation gate (SkillOpt's "accept only on strict held-out improvement"). Accept the candidate iff its
+// held-out adoption beats the baseline by more than minDelta. A candidate that produced no scorable edits
+// is rejected (no signal); with no baseline, any positive signal is accepted as the new floor.
+export function gate(baseline, candidate, minDelta = 0) {
+  if (!candidate || candidate.adoption == null) return { accept: false, delta: null, reason: "candidate produced no scorable edits" };
+  if (!baseline || baseline.adoption == null) return { accept: candidate.adoption > 0, delta: null, reason: "no baseline — accept any positive signal" };
+  const delta = candidate.adoption - baseline.adoption;
+  const pp = (x) => `${Math.round(x * 100)}%`;
+  return { accept: delta > minDelta, delta, reason: `adoption ${pp(baseline.adoption)} → ${pp(candidate.adoption)} (Δ ${Math.round(delta * 100)}pp, need > ${Math.round(minDelta * 100)}pp)` };
+}

--- a/eval/skillopt/selftest.mjs
+++ b/eval/skillopt/selftest.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Deterministic self-test for the SkillOpt scorer + gate (no live agents — that's rollout.workflow.js). The
+// gate decides whether a reworded skill/warn is accepted, so its logic has to be trustworthy on its own.
+// Run: `node eval/skillopt/selftest.mjs`.
+import { classifyRollout, variantScore, gate } from "./score.mjs";
+import { SCENARIOS, train, heldout } from "./scenarios.mjs";
+import { VARIANTS, byId } from "./variants.mjs";
+
+const checks = [];
+const check = (name, pass) => checks.push([name, pass]);
+
+// classifyRollout: symbol-edit tools (incl. MCP-prefixed) → "symbol"; built-in → "builtin"; nothing → "other".
+check("classify: symbol-edit tool → symbol", classifyRollout({ toolsUsed: ["insert_after_symbol"] }) === "symbol");
+check("classify: MCP-prefixed symbol-edit → symbol", classifyRollout({ toolsUsed: ["mcp__plugin_vs-token-safer_vs-search__replace_symbol_body"] }) === "symbol");
+check("classify: built-in Edit → builtin", classifyRollout({ toolsUsed: ["Read", "Edit"] }) === "builtin");
+check("classify: symbol wins when both present (no appliedTool)", classifyRollout({ toolsUsed: ["Edit", "replace_symbol_body"] }) === "symbol");
+check("classify: no edit → other", classifyRollout({ toolsUsed: ["Read", "search_symbol"] }) === "other");
+// appliedTool is the honest signal: a tried-symbol-but-fell-back-to-Edit rollout is "builtin", not "symbol".
+check("classify: appliedTool=Edit overrides symbol in toolsUsed", classifyRollout({ toolsUsed: ["insert_after_symbol", "Edit"], appliedTool: "Edit" }) === "builtin");
+check("classify: appliedTool=symbol-edit → symbol", classifyRollout({ toolsUsed: ["Read", "Edit", "replace_symbol_body"], appliedTool: "mcp__x__replace_symbol_body" }) === "symbol");
+
+// variantScore: adoption = symbol / (symbol + builtin); "other" excluded from the denominator.
+const vs = variantScore([
+  { toolsUsed: ["replace_symbol_body"] },
+  { toolsUsed: ["insert_after_symbol"] },
+  { toolsUsed: ["Edit"] },
+  { toolsUsed: ["search_symbol"] }, // other → excluded
+]);
+check("variantScore: 2 symbol / 1 builtin → adoption 2/3", vs.symbol === 2 && vs.builtin === 1 && vs.other === 1 && Math.abs(vs.adoption - 2 / 3) < 1e-9);
+check("variantScore: no edits → adoption null", variantScore([{ toolsUsed: ["Read"] }]).adoption === null);
+
+// gate: accept only a STRICT held-out improvement; reject a no-signal candidate; floor with no baseline.
+const base = { adoption: 0.2 };
+check("gate: candidate beats baseline → accept", gate(base, { adoption: 0.6 }).accept === true);
+check("gate: candidate equals baseline → reject", gate(base, { adoption: 0.2 }).accept === false);
+check("gate: candidate worse → reject", gate(base, { adoption: 0.1 }).accept === false);
+check("gate: minDelta margin enforced", gate(base, { adoption: 0.25 }, 0.1).accept === false && gate(base, { adoption: 0.35 }, 0.1).accept === true);
+check("gate: candidate with no edits → reject", gate(base, { adoption: null }).accept === false);
+check("gate: no baseline + positive signal → accept", gate({ adoption: null }, { adoption: 0.5 }).accept === true);
+
+// fixtures sanity: scenarios cover both insert + replace, have a train/holdout split, and use synthetic names.
+const expects = new Set(SCENARIOS.map((s) => s.expect));
+check("scenarios: cover insert + replace", expects.has("insert") && expects.has("replace"));
+check("scenarios: have a train/holdout split", SCENARIOS.some(train) && SCENARIOS.some(heldout));
+check("scenarios: no obvious proprietary names", !SCENARIOS.some((s) => /mutable|cheat|smilegate|TSGame|SGE/i.test(s.content + s.task)));
+check("variants: baseline present + ≥2 candidates", byId("baseline") && VARIANTS.length >= 3);
+
+console.log("vs-token-safer — SkillOpt scorer + gate self-test\n");
+let ok = true;
+for (const [name, pass] of checks) { console.log(`${pass ? "✓" : "✗"} ${name}`); if (!pass) ok = false; }
+if (!ok) { console.error("\nSKILLOPT SELFTEST FAILED."); process.exit(1); }
+console.log(`\n${checks.length}/${checks.length} checks. SKILLOPT SELFTEST PASSED.`);

--- a/eval/skillopt/variants.mjs
+++ b/eval/skillopt/variants.mjs
@@ -1,0 +1,28 @@
+// SkillOpt variants — the TRAINABLE ARTIFACT. Each variant is a piece of guidance prepended to the rollout
+// agent's task, standing in for what the skill/warn text would tell it. `baseline` is the live behavior
+// (no extra guidance — only whatever the installed hook/skill already injects); the rest are candidate
+// rewordings the gate scores against the baseline. The optimizer (a human, or a reflection sub-agent reading
+// the scored rollouts) proposes new entries here; the harness measures whether they raise adoption.
+export const VARIANTS = [
+  {
+    id: "baseline",
+    guidance: "",
+  },
+  {
+    id: "explicit-ready-call",
+    guidance:
+      "Tooling note: when you ADD or REPLACE a whole declaration (a function, method, or class), use the " +
+      "vs-search symbol-edit tools — insert_after_symbol / insert_before_symbol / replace_symbol_body with " +
+      "symbol=<name> — instead of reading the file and using the built-in Edit. They edit by name and skip " +
+      "reading the file into context.",
+  },
+  {
+    id: "cost-framed",
+    guidance:
+      "Tooling note: reading a whole file just to edit one declaration wastes tokens. For a whole-declaration " +
+      "add or replace, call insert_after_symbol or replace_symbol_body (symbol=<name>, apply=true) — no file " +
+      "read needed; the language-server outline supplies the span.",
+  },
+];
+
+export const byId = (id) => VARIANTS.find((v) => v.id === id);

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -35,7 +35,7 @@ import { splitSegments } from "../server/shell-split.js";
 // Whole-declaration edit detector, shared with discover (core.js) so the set we STEER matches the set we
 // MEASURE; the adoption ledger is the live metric the steer is tuned against.
 import { classifyDeclEdit } from "../server/edit-detect.js";
-import { recordEditEvent, readEditLedger } from "../server/edit-ledger.js";
+import { recordEditEvent } from "../server/edit-ledger.js";
 
 const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(os.homedir(), ".vs-token-safer", "config.json");
 const readConfig = () => { try { return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8")) || {}; } catch { return {}; } };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format:check": "prettier --check .",
     "eval": "node eval/run.mjs",
     "eval:steer": "node eval/test-edit-steer.mjs",
-    "test": "npm run eval && npm run eval:steer",
+    "eval:skillopt": "node eval/skillopt/selftest.mjs",
+    "test": "npm run eval && npm run eval:steer && npm run eval:skillopt",
     "bump": "node scripts/bump.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
The v0.23.0 adoption loop measures + re-injects, but can't tell which warn/skill **wording** makes an agent switch. This adds the missing **scored rollout** — a [SkillOpt](https://github.com/microsoft/SkillOpt)-style harness. **No runtime change → no version bump.**

## Pieces
- `eval/skillopt/{scenarios,variants,score}.mjs` — synthetic TS edit fixtures (train/holdout), the trainable variant texts, deterministic scorer + validation gate.
- `selftest.mjs` — CI-gated test of the scorer/gate (19 checks); wired into `npm test` + CI.
- `rollout.workflow.js` — the live rollout (Workflow): one sub-agent per scenario×variant does a **real edit** in a sandbox (the hook warn is live) and self-reports the tool that **applied** the edit. eslint-ignored (Workflow-runtime globals).

## First live smoke (4 agents) — validated + taught
1. **Ceiling effect**: toy scenarios hit 100% baseline adoption → need harder ones to differentiate variants.
2. **Score on `appliedTool`, not `toolsUsed`**: an agent that tried a symbol-edit, hit a backend failure, and fell back to Edit was inflating adoption — the scorer now classifies on the tool that actually applied the edit.
3. **Sandbox path**: the MCP server is Windows-node, so an MSYS `/tmp` path breaks the backend spawn (prompt now says use a native path). Behavioral eval found live bugs — the point.

## CI
`eval/run.mjs` 55/55 + `test-edit-steer` 18/18 + `skillopt/selftest` 19/19 + lint + validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)