### PR TITLE
test(skillopt): hard scenarios + conclusive no-headroom finding

### DIFF
--- a/eval/skillopt/README.md
+++ b/eval/skillopt/README.md
@@ -54,6 +54,25 @@ A smoke run validated the pipeline end-to-end and taught three things:
   path. A TS-backend ENOENT in one rollout also forced a fallback. Behavioral eval found live bugs — that's
   the point — but they add variance to a small-N run.
 
+## Result: no headroom for warn-wording optimization
+
+Two live runs (4 toy-scenario agents + 12 harder-scenario agents = **16 rollouts**, ~810k tokens) gave a
+clear, negative answer: **`baseline` already hit 100% symbol-edit adoption on every scenario — toy and
+hard.** The candidate variants (`explicit-ready-call`, `cost-framed`) couldn't differentiate (Δ 0pp → gate
+rejects all). A focused rollout agent, once the symbol-edit tools exist and the file is in view, reaches for
+them unprompted; the warn *wording* is not the bottleneck.
+
+So the real-world gap (discover: ~93% of whole-decl edits are search-unreachable, near-zero historical
+adoption) is **not a persuasion problem** the harness can optimize — it's (a) historical data from before
+the tools/steer existed, and (b) attention/context in long real sessions, which a clean single-task rollout
+structurally can't reproduce (the rollout always favors symbol-edit). **Don't spend tokens optimizing the
+warn text** — there's no measurable headroom. The lever is the already-shipped v0.23.0 machinery (live hook
+warn at edit time + L2 block + SessionStart re-injection); let it run and re-measure real-session adoption
+via `vts discover` over time. Revisit only if real adoption stays low — and then the intervention is about
+*attention*, not wording.
+
+The harness did its job: it conclusively ruled out a direction before we sank tokens into it.
+
 ## Honest caveats
 
 - **Fidelity**: scoring is the agent's *self-report* of tools used after a *real* edit (the hook warn does

--- a/eval/skillopt/scenarios.mjs
+++ b/eval/skillopt/scenarios.mjs
@@ -38,5 +38,33 @@ export const SCENARIOS = [
   },
 ];
 
+// Harder scenarios — bigger, multi-declaration files so Read is non-trivial and a hurried agent might
+// default to Read+Edit. Used to probe whether warn WORDING moves adoption when the choice is less obvious.
+// FINDING (16 rollouts: this set + the toy set, baseline + 2 variants): adoption stayed 100% on baseline
+// too — a focused rollout agent always reaches for symbol-edit once the tools exist, regardless of wording.
+// So wording optimization has NO headroom in the clean-rollout regime; see README "No headroom" note.
+export const HARD = [
+  {
+    id: "add-method-big", holdout: false, file: "store.ts",
+    content: "export interface Item { id: number; name: string; }\n\nexport class Store {\n  private items: Item[] = [];\n  add(it: Item): void { this.items.push(it); }\n  remove(id: number): void { this.items = this.items.filter(x => x.id !== id); }\n  find(id: number): Item | undefined { return this.items.find(x => x.id === id); }\n  count(): number { return this.items.length; }\n}\n\nexport class Logger {\n  private lines: string[] = [];\n  log(s: string): void { this.lines.push(s); }\n  dump(): string { return this.lines.join(\"\\n\"); }\n}\n",
+    task: "Add a new method `clear(): void` to the Store class that empties its items array.", expect: "insert",
+  },
+  {
+    id: "replace-body-big", holdout: false, file: "util.ts",
+    content: "export function slugify(s: string): string {\n  return s.toLowerCase().replace(/\\s+/g, \"-\");\n}\n\nexport function truncate(s: string, n: number): string {\n  if (s.length <= n) return s;\n  return s.slice(0, n) + \"...\";\n}\n\nexport function parseRange(s: string): [number, number] {\n  const parts = s.split(\"-\");\n  return [Number(parts[0]), Number(parts[1])];\n}\n",
+    task: "Replace the body of `parseRange` so it trims whitespace from each part before converting to a number.", expect: "replace",
+  },
+  {
+    id: "add-fn-after", holdout: true, file: "math.ts",
+    content: "export function lerp(a: number, b: number, t: number): number {\n  return a + (b - a) * t;\n}\n\nexport function sign(n: number): number {\n  return n < 0 ? -1 : n > 0 ? 1 : 0;\n}\n\nexport function avg(xs: number[]): number {\n  return xs.reduce((s, x) => s + x, 0) / xs.length;\n}\n",
+    task: "Add a new exported function `clamp(n: number, min: number, max: number): number` after the `lerp` function.", expect: "insert",
+  },
+  {
+    id: "replace-method-class", holdout: true, file: "cache.ts",
+    content: "export class Cache<V> {\n  private map = new Map<string, V>();\n  set(k: string, v: V): void { this.map.set(k, v); }\n  get(k: string): V | undefined { return this.map.get(k); }\n  has(k: string): boolean { return this.map.has(k); }\n  clear(): void { this.map.clear(); }\n}\n",
+    task: "Replace the body of the `get` method in the Cache class so it returns undefined and logs a miss via console.warn when the key is absent.", expect: "replace",
+  },
+];
+
 export const heldout = (s) => s.holdout === true;
 export const train = (s) => s.holdout !== true;


### PR DESCRIPTION
## Result of running the harness (16 rollouts, ~810k tokens)
**Negative, and useful:** warn WORDING is not the lever. `baseline` (no guidance) hit **100% symbol-edit adoption on every scenario** — toy AND a harder big-file / multi-declaration set — so the candidate variants couldn't differentiate (Δ 0pp → gate rejects all). A focused rollout agent reaches for the symbol-edit tools unprompted once they exist.

So the real-world ~93%-unreached / near-zero historical adoption is **not a persuasion problem** the harness can optimize — it's pre-tool/pre-steer historical data + attention in long real sessions (a clean single-task rollout can't reproduce that). **Don't optimize the warn text** — no headroom; rely on the shipped v0.23.0 levers and re-measure adoption via `vts discover` over real sessions.

## Changes
- `scenarios.mjs`: add the `HARD` set (the big-file scenarios the run used) for reproducibility.
- `README.md`: record the no-headroom result.

No runtime change → no version bump. selftest 19/19, lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)