### PR TITLE
fix: scope copy said C++/C# only — vts also indexes JS/TS + Python

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "vs-token-safer",
       "source": "./",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "category": "development",
       "description": "Force Claude Code to search C++/C# code through clangd/Roslyn's index instead of Bash grep, token-capped to a compact file:line list. No IDE required. Bundles gamedev-log-analyzer."
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vs-token-safer",
   "description": "Force Claude Code to search C++/C# code through an official language server's index (clangd / Roslyn) instead of Bash grep, token-capped to a compact file:line list. No IDE required. Faster and far fewer tokens on large Unreal C++/.NET codebases. Auto-installs gamedev-log-analyzer.",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/vs-token-safer",
   "repository": "https://github.com/JSungMin/vs-token-safer",

--- a/agents/code-locator.md
+++ b/agents/code-locator.md
@@ -1,11 +1,12 @@
 ---
 name: code-locator
 description: >-
-  Delegated, token-isolated code search for C/C++ (clangd) and C#/.NET (Roslyn) projects — no IDE needed.
-  Hand it "where is X defined", "what calls Y", "all usages of Z", "find the file named W", "type info at
-  this position", or "find this string in code" — it uses the official language-server index (clangd /
-  Roslyn), not raw grep, and returns ONLY a compact file:line table; the matched source never enters the
-  caller's context. Use instead of grepping a codebase. Not for logs (use the gamedev-log analyzer).
+  Delegated, token-isolated code search for C/C++ (clangd), C#/.NET (Roslyn), JS/TS (tsserver), and Python
+  (pyright) projects — no IDE needed. Hand it "where is X defined", "what calls Y", "all usages of Z", "find
+  the file named W", "type info at this position", or "find this string in code" — it uses the official
+  language-server index (clangd / Roslyn / tsserver / pyright), not raw grep, and returns ONLY a compact
+  file:line table; the matched source never enters the caller's context. Use instead of grepping a codebase.
+  Not for logs (use the gamedev-log analyzer).
 ---
 
 # code-locator — delegated code search (context-isolated)
@@ -16,9 +17,11 @@ stays small. Same idea as the token-cap, applied at the orchestration layer: a s
 been thousands of grep lines comes back as a few dozen `file:line` rows.
 
 ## Iron rules
-1. **Use the language-server index over Bash grep.** Call the `vs-search` MCP tools — they run clangd
-   (C/C++) or a Roslyn LSP (C#) and are token-capped to `file:line`. The results are *semantic* (accurate
-   refs/defs), not text matches. No IDE has to be open.
+1. **Use the language-server index over Bash grep.** Call the `vs-search` MCP tools — they run the official
+   language server for the project (clangd for C/C++, a Roslyn LSP for C#/.NET, tsserver for JS/TS, pyright
+   for Python) and are token-capped to `file:line`. The results are *semantic* (accurate refs/defs), not
+   text matches. No IDE has to be open. **This applies to ALL four languages — a `.py`/`.ts`/`.js` file is
+   in scope, not just C++/C#.**
 2. **Return `kind name @ file:line` rows, never source bodies.** If the caller needs the body, give the
    `file:line` and let them open a small window.
 3. **Locate; don't review.** Be exhaustive on location, silent on opinion.
@@ -33,8 +36,9 @@ been thousands of grep lines comes back as a few dozen `file:line` rows.
 5. **Outline of a file** → `document_symbols` (`path`).
 
 ## Setup / fallbacks
-- The backend auto-detects from the root (`compile_commands.json` → clangd; `.sln`/`.csproj` → roslyn).
-  Pass `projectPath` if it isn't the cwd. First query pays a one-time warm-up; later queries are fast.
+- The backend auto-detects from the root (`compile_commands.json` → clangd; `.sln`/`.csproj` → roslyn;
+  `tsconfig`/`package.json` → typescript; `pyproject.toml`/`*.py` → pyright). Pass `projectPath` if it
+  isn't the cwd, or `backend=` to force one. First query pays a one-time warm-up; later queries are fast.
 - **clangd ≥ 22** for large Unreal projects — older clangd (the 19.1.x bundled with Visual Studio) can
   deadlock indexing UE translation units. If a query stalls or returns nothing, that's the likely cause.
 - If the language server is genuinely unavailable, do a **bounded** grep (`grep -n … | head`) and label

--- a/server/cli.js
+++ b/server/cli.js
@@ -62,8 +62,10 @@ Commands:
                  [--projectPath --apply --inTree --engineRoot --target ...]
 
 Backends (auto-detected from the root, or set --backend / VTS_BACKEND):
-  clangd  — C/C++ (needs compile_commands.json; Unreal: UBT -mode=GenerateClangDatabase)
-  roslyn  — C#/.NET (.sln/.csproj; default engine csharp-ls, override via VTS_ROSLYN_CMD)
+  clangd      — C/C++ (needs compile_commands.json; Unreal: UBT -mode=GenerateClangDatabase)
+  roslyn      — C#/.NET (.sln/.csproj; default engine csharp-ls, override via VTS_ROSLYN_CMD)
+  typescript  — JS/TS (tsconfig/jsconfig/package.json; bundled typescript-language-server)
+  pyright     — Python (pyproject/setup.py/requirements or *.py; bundled pyright-langserver)
 Settings precedence: env (VTS_*) > ~/.vs-token-safer/config.json > default.`;
 
 const LIST_FLAGS = new Set([]);

--- a/server/index.js
+++ b/server/index.js
@@ -23,8 +23,9 @@ const TOOLS = [
     name: "search_symbol",
     description:
       "Search symbol DECLARATIONS by name/substring across the project via the language server's index " +
-      "(clangd for C++, Roslyn for C#) — NOT grep. Returns a token-capped `kind name @ file:line` list, " +
-      "no source bodies. Use this instead of Bash grep/rg for finding a class/function/type/variable.",
+      "(clangd C/C++, Roslyn C#/.NET, tsserver JS/TS, pyright Python — auto-detected) — NOT grep. Returns a " +
+      "token-capped `kind name @ file:line` list, no source bodies. Use this instead of Bash grep/rg for " +
+      "finding a class/function/type/variable in any of those languages.",
     inputSchema: {
       type: "object",
       properties: {

--- a/server/package.json
+++ b/server/package.json
@@ -1,9 +1,9 @@
 {
   "name": "vs-token-safer",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "type": "module",
-  "description": "Force code search through an official language server's index (clangd for C++, Roslyn for C#) instead of grep, token-capped to a compact file:line list. Local-only. CLI + MCP. No IDE required.",
-  "keywords": ["clangd", "roslyn", "lsp", "code-search", "cpp", "csharp", "unreal", "visual-studio", "mcp", "claude", "claude-code", "grep", "token-efficiency"],
+  "description": "Force code search through an official language server's index (clangd for C/C++, Roslyn for C#/.NET, tsserver for JS/TS, pyright for Python) instead of grep, token-capped to a compact file:line list. Local-only. CLI + MCP. No IDE required.",
+  "keywords": ["clangd", "roslyn", "tsserver", "pyright", "lsp", "code-search", "cpp", "csharp", "typescript", "javascript", "python", "unreal", "visual-studio", "mcp", "claude", "claude-code", "grep", "token-efficiency"],
   "homepage": "https://github.com/JSungMin/vs-token-safer",
   "repository": { "type": "git", "url": "git+https://github.com/JSungMin/vs-token-safer.git", "directory": "server" },
   "bugs": { "url": "https://github.com/JSungMin/vs-token-safer/issues" },

--- a/skills/vs-search/SKILL.md
+++ b/skills/vs-search/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Routing rules for code search in C++/C# projects via vs-token-safer — use the vs-search MCP tools (clangd/Roslyn language-server index) or the `vts` CLI instead of Bash grep. Use whenever searching for a symbol, definition, function, variable, type, or finding references/usages in a C/C++ or C#/.NET (incl. Unreal, Visual Studio) codebase.
+description: Routing rules for code search in C/C++, C#/.NET, JS/TS, and Python projects via vs-token-safer — use the vs-search MCP tools (clangd/Roslyn/tsserver/pyright language-server index) or the `vts` CLI instead of Bash grep. Use whenever searching for a symbol, definition, function, variable, type, or finding references/usages in a C/C++, C#/.NET (incl. Unreal, Visual Studio), JavaScript/TypeScript, or Python codebase.
 ---
 
 # vs-token-safer search routing


### PR DESCRIPTION
## Bug
The backends have covered **JS/TS (tsserver)** and **Python (pyright)** since v0.18, but several **model-facing descriptions** still scoped vts to "C/C++ and C#/.NET". So a sub-agent (e.g. `code-locator`) reading its own description concluded a `.py`/`.ts` file was out of scope and read it directly instead of using the index. Reported live: *"Python file — vs-search is C++/C# only, doesn't apply. Reading trace_mcp.py directly."*

Not a code limitation — stale copy.

## Fix (the text the model actually reads)
- `agents/code-locator.md` — description + the "use the index" iron rule (now: applies to ALL four languages; a `.py`/`.ts`/`.js` file is in scope) + backend-autodetect note.
- `skills/vs-search/SKILL.md` — routing description.
- `server/index.js` — `search_symbol` tool description (all four backends).
- `server/package.json` — npm description + keywords.
- `server/cli.js` — `--help` Backends list (+ typescript, pyright).

No logic change — `pickBackend` and the backends already supported all four; this only corrects the copy that suppressed JS/TS/Python usage. Patch (v0.23.1). eval 55/55, lint + validate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)