### PR TITLE
fix: per-file-language backend (.py/.ts in a mixed C++/C# repo)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "vs-token-safer",
       "source": "./",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "category": "development",
       "description": "Force Claude Code to search C++/C# code through clangd/Roslyn's index instead of Bash grep, token-capped to a compact file:line list. No IDE required. Bundles gamedev-log-analyzer."
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vs-token-safer",
   "description": "Force Claude Code to search C++/C# code through an official language server's index (clangd / Roslyn) instead of Bash grep, token-capped to a compact file:line list. No IDE required. Faster and far fewer tokens on large Unreal C++/.NET codebases. Auto-installs gamedev-log-analyzer.",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/vs-token-safer",
   "repository": "https://github.com/JSungMin/vs-token-safer",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,12 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   `$/cancelRequest`; client declares `synchronization` + `workspace.configuration` capabilities.
 - `server/backends/index.js` — clangd/roslyn/typescript/pyright spawn configs + `pickBackend(root)`
   (detect order: compile_commands→clangd > .sln/.csproj→roslyn > tsconfig/package.json→typescript >
-  pyproject/*.py→pyright; strongest build-artifact first). Override via `VTS_CLANGD_CMD/ARGS`,
+  pyproject/*.py→pyright; strongest build-artifact first). MIXED-REPO FIX: a query that TARGETS a file uses
+  `backendForPath(a.path)` (core.js — ext→backend: .py→pyright, .ts/.js→typescript, .cpp/.h→clangd, .cs→
+  roslyn) BEFORE `pickBackend(root)`, so a `.py`/`.ts` file inside a clangd-rooted UE/C++ tree gets pyright/
+  typescript instead of clangd (else the query hits the wrong LSP, finds nothing, model abandons vts).
+  Precedence: explicit `a.backend` > `VTS_BACKEND` > `backendForPath(a.path)` > `pickBackend(root)`. Eval guard 55.
+  Override via `VTS_CLANGD_CMD/ARGS`,
   `VTS_ROSLYN_CMD/ARGS`, `VTS_TS_CMD/ARGS`, `VTS_PY_CMD/ARGS`. `winShell` flag spawns the npm `.cmd`
   shims (ts/pyright) through a shell on Windows. `langIdForPath` (lsp.js) maps file ext → LSP languageId.
   `findProjectRoot(start)` — bounded walk UP from a file to the nearest project marker (compile_commands/

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1099,6 +1099,18 @@ const editEscalateOk =
 try { fs.rmSync(EL, { force: true }); } catch { /* ignore */ }
 const editHookOk = editWarnOk && editEscalateOk;
 
+// 55) per-file-language backend: a query that TARGETS a file gets its OWN language's backend, so a `.py`/
+// `.ts` file in a clangd/roslyn-rooted MIXED repo (e.g. a UE C++ tree with a Python tooling dir) doesn't
+// hit the wrong LSP and find nothing. Pure ext→backend map; wired as a.backend || BACKEND ||
+// backendForPath(a.path) || pickBackend(root) so an explicit backend=/VTS_BACKEND still wins.
+const { backendForPath } = await import("../server/core.js");
+const backendPathOk =
+  backendForPath("Plugins/TSEditorBridge/Python/trace_core.py") === "pyright" &&
+  backendForPath("src/App.tsx") === "typescript" && backendForPath("a/b.mjs") === "typescript" &&
+  backendForPath("Source/Foo.cpp") === "clangd" && backendForPath("Bar.h") === "clangd" &&
+  backendForPath("Svc.cs") === "roslyn" &&
+  backendForPath("README.md") === null && backendForPath("noext") === null && backendForPath(undefined) === null;
+
 await disposeClients();
 // 48) clean teardown (no orphaned child): disposeClients must terminate EVERY spawned language-server
 // child — evicted, swept, mid-warmup, or key-overwritten — via the master registry. A surviving child
@@ -1173,6 +1185,7 @@ const rows = [
   ["symbolic editing: replace/insert/safe_delete by name (preview+apply+ref-guard)", symEditOk, "true", symEditOk],
   ["edit-steer: search EDIT_STEER (toggle) + discover counts whole-decl Edit", editSteerOk, "true", editSteerOk],
   ["edit-steer hook: L1 warn (replace/insert) + L2 safe-insert escalation", editHookOk, "true", editHookOk],
+  ["per-file-language backend (.py→pyright in a clangd-rooted mixed repo)", backendPathOk, "true", backendPathOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/core.js
+++ b/server/core.js
@@ -73,6 +73,21 @@ export function resolveRoot(a = {}) {
 // Root for a CWD-relative external command (git/p4): never the config pin (the user/agent runs these where
 // they ARE), but an MCP workspace root beats the long-lived server's own process.cwd().
 export function resolveCwdRoot(a = {}) { return a.projectPath || MCP_ROOTS[0] || process.cwd(); }
+// File-language backend: when a query TARGETS a specific file, its extension decides the language more
+// reliably than the root's build artifacts. In a MIXED repo — e.g. a UE C++ tree (`.uproject` → clangd)
+// with a Python tooling dir — pickBackend(root) returns clangd for the whole tree, so a `.py`/`.ts` query
+// would hit clangd and find nothing, and the model gives up on vts. Prefer the file's OWN backend over the
+// root heuristic; an explicit `backend=`/`VTS_BACKEND` still wins (this only beats the auto-detect fallback).
+export function backendForPath(p) {
+  const m = p && String(p).toLowerCase().match(/\.[a-z0-9]+$/);
+  if (!m) return null;
+  const e = m[0];
+  if (/^\.(c|cc|cxx|cpp|h|hpp|hh|inl|ipp|tpp)$/.test(e)) return "clangd";
+  if (e === ".cs") return "roslyn";
+  if (/^\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/.test(e)) return "typescript";
+  if (/^\.(py|pyi)$/.test(e)) return "pyright";
+  return null;
+}
 
 const tok = (s) => Math.round(Buffer.byteLength(String(s), "utf8") / 4);
 // The token size of the RAW alternative a tool replaces. A STRING raw (vts_git/vts_p4 stdout) is exactly
@@ -1264,7 +1279,9 @@ export async function runTool(name, a = {}) {
     }
 
     const root = resolveRoot(a);
-    const backendName = a.backend || BACKEND || pickBackend(root);
+    // backendForPath(a.path): a `.py`/`.ts` file in a clangd/roslyn-rooted MIXED repo gets its OWN backend
+    // (pyright/typescript) instead of the root's — else the query hits the wrong LSP and finds nothing.
+    const backendName = a.backend || BACKEND || backendForPath(a.path) || pickBackend(root);
     // search_symbol degrades gracefully when NO backend resolves (text fallback) instead of hard-erroring —
     // so the grep-rewrite hook can always route an identifier to `vts symbol` (semantic when a backend
     // exists, literal text otherwise) without risking a dead-end error.

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vs-token-safer",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "type": "module",
   "description": "Force code search through an official language server's index (clangd for C/C++, Roslyn for C#/.NET, tsserver for JS/TS, pyright for Python) instead of grep, token-capped to a compact file:line list. Local-only. CLI + MCP. No IDE required.",
   "keywords": ["clangd", "roslyn", "tsserver", "pyright", "lsp", "code-search", "cpp", "csharp", "typescript", "javascript", "python", "unreal", "visual-studio", "mcp", "claude", "claude-code", "grep", "token-efficiency"],


### PR DESCRIPTION
## Bug (measured)
A `.py`/`.ts` file nested in a C++/C# project got the **wrong backend**: `pickBackend(root)` chooses by the ROOT's build artifacts, so a `.py` under a UE tree (`.uproject` → clangd) resolved to **clangd**, which can't index Python → the query found nothing → the model abandoned vts and Read/Wrote the file directly.

`vts discover` on that session: **0 grep bypasses / 100% catch-rate** — so the gap wasn't grep, it was the backend.

## Fix
When a query **targets a file**, prefer its own language's backend:
- `backendForPath(a.path)` — ext→backend (`.py`→pyright, `.ts/.js`→typescript, `.cpp/.h`→clangd, `.cs`→roslyn), wired as `a.backend || BACKEND || backendForPath(a.path) || pickBackend(root)` so an explicit `backend=`/`VTS_BACKEND` still wins; only the root-heuristic fallback is overridden.
- Covers the path-based tools (find_references / goto_definition / hover / document_symbols / rename / symbol-edit). search_symbol (bare name) keeps the root default + text fallback.

(Dogfood: the `backendForPath` declaration itself was added with `insert_after_symbol` — the L2 escalation blocked my built-in Edit at streak 8 and the symbol-edit tool wrote it.)

## CI
eval **56/56** (guard 55) + steer 18/18 + skillopt 19/19 + lint + validate. Patch v0.23.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)