### PR TITLE
feat: vts_setup can generate the C++ compile DB in the same step

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "vs-token-safer",
       "source": "./",
-      "version": "0.23.3",
+      "version": "0.24.0",
       "category": "development",
       "description": "Force Claude Code to search C++/C# code through clangd/Roslyn's index instead of Bash grep, token-capped to a compact file:line list. No IDE required. Bundles gamedev-log-analyzer."
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vs-token-safer",
   "description": "Force Claude Code to search C++/C# code through an official language server's index (clangd / Roslyn) instead of Bash grep, token-capped to a compact file:line list. No IDE required. Faster and far fewer tokens on large Unreal C++/.NET codebases. Auto-installs gamedev-log-analyzer.",
-  "version": "0.23.3",
+  "version": "0.24.0",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/vs-token-safer",
   "repository": "https://github.com/JSungMin/vs-token-safer",

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -31,7 +31,13 @@ Steps:
 4. **Apply:** call `vts_setup` with only the keys to change, e.g.
    `vts_setup { "projectPath": "<root>", "backend": "clangd" }`. `vts_setup` reports the detected language
    mix (e.g. `clangd(820), typescript(40)`) and the `prewarmBackends` it chose.
-5. **Tell the user to run `/reload-plugins`** (or restart) — settings are read at startup.
+5. **C++ with no compile DB?** `vts_setup` warns when a clangd-dominant root has no `compile_commands.json`
+   (clangd can't index semantically without it). Offer to generate it **in the same step** — pass
+   `genCompileDb` to `vts_setup`: `true` = **dry-run** (prints the exact UBT `GenerateClangDatabase` command,
+   runs nothing — show it to the user first), `"apply"` = run UBT now (heavy: indexes engine headers, takes
+   minutes, needs **clangd ≥ 22**). The DB is parked out-of-tree (`~/.vs-token-safer/db/<project>`), so git/p4
+   never see it. Always dry-run first and let the user confirm before `apply`.
+6. **Tell the user to run `/reload-plugins`** (or restart) — settings are read at startup.
 
 Notes:
 - Precedence is **environment variable (`VTS_*`) > config file > default**; a same-named env var wins.

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1111,6 +1111,26 @@ const backendPathOk =
   backendForPath("Svc.cs") === "roslyn" &&
   backendForPath("README.md") === null && backendForPath("noext") === null && backendForPath(undefined) === null;
 
+// 56) vts_setup genCompileDb — setup can kick off the compile-DB generation in the same step (so the user
+// doesn't have to find the separate vts_gen_compile_db tool): `true` = DRY-RUN (prints the UBT command, runs
+// nothing), "apply" = run UBT. Wiring test: the section appears with the GenerateClangDatabase command and
+// UBT was NOT executed (dry).
+const suEng = path.join(os.tmpdir(), `vts-eval-sueng-${process.pid}`);
+fs.mkdirSync(path.join(suEng, "Engine", "Build", "BatchFiles"), { recursive: true });
+fs.writeFileSync(path.join(suEng, "Engine", "Build", "BatchFiles", process.platform === "win32" ? "RunUBT.bat" : "RunUBT.sh"), "");
+const suGame = path.join(os.tmpdir(), `vts-eval-sugame-${process.pid}`);
+fs.mkdirSync(suGame, { recursive: true });
+fs.writeFileSync(path.join(suGame, "MyGame.uproject"), "{}");
+process.env.VTS_UE_ROOT = suEng;
+const suGen = await runTool("vts_setup", { projectPath: suGame, genCompileDb: true });
+delete process.env.VTS_UE_ROOT;
+const setupGenOk =
+  !suGen.isError &&
+  /compile_commands\.json \(dry-run\)/.test(suGen.text) &&   // setup wired the gen step (dry)
+  /GenerateClangDatabase/.test(suGen.text) &&                // the UBT command is shown
+  !/Generated compile_commands/.test(suGen.text);            // …but UBT was NOT actually run
+for (const d of [suEng, suGame]) { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ } }
+
 await disposeClients();
 // 48) clean teardown (no orphaned child): disposeClients must terminate EVERY spawned language-server
 // child — evicted, swept, mid-warmup, or key-overwritten — via the master registry. A surviving child
@@ -1186,6 +1206,7 @@ const rows = [
   ["edit-steer: search EDIT_STEER (toggle) + discover counts whole-decl Edit", editSteerOk, "true", editSteerOk],
   ["edit-steer hook: L1 warn (replace/insert) + L2 safe-insert escalation", editHookOk, "true", editHookOk],
   ["per-file-language backend (.py→pyright in a clangd-rooted mixed repo)", backendPathOk, "true", backendPathOk],
+  ["vts_setup genCompileDb: generates the compile DB in the setup step (dry)", setupGenOk, "true", setupGenOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/cli.js
+++ b/server/cli.js
@@ -47,6 +47,8 @@ Commands:
                  Pass-through: 'vts p4 opened', 'vts p4 changes -m 50'. reconcile is forced to preview (-n).
   warmup         Pre-build the index (IDE-style) so later searches are fast. [--projectPath --backend]
   setup          Persist config. [--projectPath --backend --maxResults]
+                 [--genCompileDb dry|apply] — also generate the C++ compile DB in this step (dry-run prints
+                 the UBT command; apply runs it, needs clangd ≥ 22). Parks it out-of-tree.
   config         Show effective settings.
   savings        How many tokens you've saved vs forwarding raw index responses.
                  [--graph (30-day ASCII) --daily --history]

--- a/server/core.js
+++ b/server/core.js
@@ -1124,7 +1124,20 @@ export async function runTool(name, a = {}) {
         // (at setup) rather than letting the user discover empty search_symbol results later.
         if (census.clangd > 0 && !hasCompileDb(root)) langLine += `\n${compileDbAdvisory(root)}`;
       } catch { /* census is best-effort */ }
-      return out((changed.length ? `Updated ${changed.join(", ")}.` : "No recognized keys.") + langLine + `\nConfig: ${CONFIG_FILE}\n${JSON.stringify(current, null, 2)}`);
+      // genCompileDb — one-stop: kick off the compile-DB generation right from setup so the user doesn't have
+      // to find the separate vts_gen_compile_db tool. `true` = DRY-RUN (prints the UBT command, runs nothing);
+      // "apply" = run UBT now (heavy — indexes engine headers, needs clangd ≥ 22). Reuses the gen-compile-db
+      // logic verbatim (plan, out-of-tree DB, VCS guard) by dispatching to it.
+      let genLine = "";
+      if (a.genCompileDb) {
+        try {
+          const root = a.projectPath || current.projectPath || PROJECT_PATH || process.cwd();
+          const apply = a.genCompileDb === "apply" || a.genCompileDb === true && (a.apply === true || a.apply === "true");
+          const g = await runTool("vts_gen_compile_db", { projectPath: root, apply });
+          genLine = `\n\n── compile_commands.json (${apply ? "apply" : "dry-run"}) ──\n${g.text}`;
+        } catch (e) { genLine = `\n\n(compile-DB step failed: ${e.message} — run vts_gen_compile_db directly)`; }
+      }
+      return out((changed.length ? `Updated ${changed.join(", ")}.` : "No recognized keys.") + langLine + `\nConfig: ${CONFIG_FILE}\n${JSON.stringify(current, null, 2)}` + genLine);
     }
     if (name === "vts_config") {
       return out(`Effective settings (env > config > default):\n` + JSON.stringify({ projectPath: PROJECT_PATH || "(unset)", backend: BACKEND || "(auto)", maxResults: MAX_RESULTS, prewarmBackends: PREWARM_BACKENDS || "(auto)" }, null, 2) + `\n\nConfig file: ${CONFIG_FILE}`);

--- a/server/index.js
+++ b/server/index.js
@@ -287,13 +287,15 @@ const TOOLS = [
     name: "vts_setup",
     description:
       "Configure vs-token-safer (projectPath, backend, maxResults). Writes ~/.vs-token-safer/config.json; " +
-      "run /reload-plugins after. Precedence: env (VTS_*) > config file > default.",
+      "run /reload-plugins after. Precedence: env (VTS_*) > config file > default. Can also generate the " +
+      "C++ compile DB in the same step (genCompileDb).",
     inputSchema: {
       type: "object",
       properties: {
         projectPath: { type: "string", description: "Default project root." },
         backend: { type: "string", description: "clangd | roslyn | typescript | pyright (default: auto)." },
         maxResults: { type: "number", description: "Default cap on returned locations." },
+        genCompileDb: { description: "Generate the C++ compile_commands.json (for clangd semantic search) in this step: `true` = DRY-RUN (prints the exact UBT command, runs nothing); \"apply\" = run UBT now (heavy — indexes engine headers, needs clangd ≥ 22). The DB is parked out-of-tree (~/.vs-token-safer/db/<project>).", "type": ["boolean", "string"] },
       },
     },
   },

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vs-token-safer",
-  "version": "0.23.3",
+  "version": "0.24.0",
   "type": "module",
   "description": "Force code search through an official language server's index (clangd for C/C++, Roslyn for C#/.NET, tsserver for JS/TS, pyright for Python) instead of grep, token-capped to a compact file:line list. Local-only. CLI + MCP. No IDE required.",
   "keywords": ["clangd", "roslyn", "tsserver", "pyright", "lsp", "code-search", "cpp", "csharp", "typescript", "javascript", "python", "unreal", "visual-studio", "mcp", "claude", "claude-code", "grep", "token-efficiency"],


### PR DESCRIPTION
## Why
`vts_setup` already warns when a clangd-dominant root has no `compile_commands.json` — but the fix lived in a separate tool (`vts_gen_compile_db`) the user had to go find. Expose it from setup so it's one stop. (Came from a real setup run that warned "no compile_commands.json → C++ semantic limited" and pointed at the other tool.)

## What
- `vts_setup` gains **`genCompileDb`**: `true` = **dry-run** (prints the exact UBT `GenerateClangDatabase` command, runs nothing), `"apply"` = run UBT (heavy; needs clangd ≥ 22). Dispatches to the existing `vts_gen_compile_db` logic verbatim (plan, out-of-tree DB park, VCS guard) and appends the result.
- MCP schema + CLI (`vts setup --genCompileDb dry|apply`) + `/vs-token-safer:setup` skill (always dry-run first, confirm before apply).

## CI
eval **57/57** (guard 56) + steer 18/18 + skillopt 19/19 + lint + validate. Minor v0.24.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)