### PR TITLE
v0.24.1 — fix: L2 edit-block over-eager (default OFF + fire-once)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "vs-token-safer",
       "source": "./",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "category": "development",
       "description": "Force Claude Code to search C++/C# code through clangd/Roslyn's index instead of Bash grep, token-capped to a compact file:line list. No IDE required. Bundles gamedev-log-analyzer."
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vs-token-safer",
   "description": "Force Claude Code to search C++/C# code through an official language server's index (clangd / Roslyn) instead of Bash grep, token-capped to a compact file:line list. No IDE required. Faster and far fewer tokens on large Unreal C++/.NET codebases. Auto-installs gamedev-log-analyzer.",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/vs-token-safer",
   "repository": "https://github.com/JSungMin/vs-token-safer",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,9 +87,11 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   `search_symbol` (≤`VTS_EDIT_STEER_MAX` 10) / `goto_definition` result (`VTS_EDIT_STEER=0` hides); (L1) the
   grep-block hook now also matches `Edit|MultiEdit` — a whole-decl replace/insert gets a MODEL-VISIBLE
   `emitWarn` with a READY symbol-edit call (`replace_symbol_body`/`insert_after_symbol`, `declSymbolName`
-  best-effort names it), `VTS_EDIT_WARN=0` off; (L2) once the adoption ledger's ignore-`streak` hits
-  `VTS_EDIT_BLOCK_AFTER` (5), a SAFE insert (`insertDecl && !replaceDecl` — `insert_after_symbol` can't corrupt)
-  is BLOCKED (exit 2); a replace stays warn. ADOPTION LEDGER (server/edit-ledger.js, `~/.vs-token-safer/
+  best-effort names it), `VTS_EDIT_WARN=0` off; (L2) OPT-IN escalation, `VTS_EDIT_BLOCK_AFTER` DEFAULT 0=OFF — set ≥1 and once the
+  adoption ledger's ignore-`streak` hits it, a SAFE insert (`insertDecl && !replaceDecl` — `insert_after_symbol`
+  can't corrupt) is BLOCKED ONCE (exit 2) then `resetStreak()` (fire-once, NOT a wall — a permanent block
+  TRAPPED the agent: it fought the wall with Edit retries / code contortions instead of switching, and each
+  blocked attempt re-escalated the streak; live-reproduced on US editing edit-ledger.js); a replace stays warn. ADOPTION LEDGER (server/edit-ledger.js, `~/.vs-token-safer/
   edit-adoption.json`, `VTS_EDIT_LEDGER` override): hook records `builtin-warn` (streak++), core.js records
   `symbol-edit` on every symbol-edit dispatch (streak→0); `hooks/edit-report.js` (SessionStart) re-injects the
   adoption % as a goal = the SkillOpt-style measure→re-inject loop (static skill can't self-improve, a

--- a/README.ko.md
+++ b/README.ko.md
@@ -307,7 +307,7 @@ cd vs-token-safer/server && npm install && npm link   # `vts` 제공
 | — | `VTS_GREP_BLOCK` | `1` | `0`이면 **Grep/Glob 도구** 격상을 차단에서 경고로 되돌림. |
 | — | `VTS_EDIT_STEER` | `1` | `0`이면 포커스된 `search_symbol`/`goto_definition` 결과에 붙는 심볼편집 도구 안내 한 줄을 숨김. `VTS_EDIT_STEER_MAX`(`10`)는 안내가 붙는 결과 크기 상한. |
 | — | `VTS_EDIT_WARN` | `1` | `0`이면 built-in Edit/MultiEdit가 **선언 통째**를 교체/추가할 때 뜨는 모델 가시 넛지를 끔(`replace_symbol_body`/`insert_after_symbol` 안내). 선언 일부 수정은 넛지 안 함. |
-| — | `VTS_EDIT_BLOCK_AFTER` | `5` | 넛지를 무시한 선언-통째 편집이 연속 이만큼 쌓이면 **안전한 insert**(새 선언)를 `insert_after_symbol`로 차단; `0`이면 에스컬레이션 끔(`VTS_GREP_BLOCK=0`도 warn으로 묶음). replace는 항상 warn 유지. |
+| — | `VTS_EDIT_BLOCK_AFTER` | `0` (꺼짐) | **옵트인.** ≥1로 두면 넛지를 연속 이만큼 무시했을 때 안전한 insert를 **1회 차단**(그 후 리셋 — 영구 벽 아님). 기본 꺼짐: 영구 차단이 에이전트를 가둠(전환 대신 Edit 재시도로 벽과 싸움). replace는 항상 warn; `VTS_GREP_BLOCK=0`도 warn으로 묶음. |
 | — | `VTS_EXCLUDE_COMMANDS` | — | 면제할 실행 파일 콤마 목록 (설정의 `excludeCommands`도). |
 | — | `VTS_COMPACT_VCS` | `1` | `0`이면 읽기 전용 `git`/`p4`의 압축 래퍼 우회를 멈춤. |
 | `lang` | `VTS_LANG` | auto | 훅 메시지 언어: `ko` / `en` (OS 로케일에서 자동 감지). |

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Precedence: **`VTS_*` env > `~/.vs-token-safer/config.json` > default.**
 | — | `VTS_GREP_BLOCK` | `1` | `0` reverts the **Grep/Glob tool** escalation from block to warn-only. |
 | — | `VTS_EDIT_STEER` | `1` | `0` hides the one-line hint (on a focused `search_symbol`/`goto_definition` result) pointing at the symbol-edit tools. `VTS_EDIT_STEER_MAX` (`10`) caps the result size that gets it. |
 | — | `VTS_EDIT_WARN` | `1` | `0` silences the model-visible nudge when a built-in Edit/MultiEdit replaces or adds a **whole declaration** (it points at `replace_symbol_body` / `insert_after_symbol`). Sub-declaration tweaks are never nudged. |
-| — | `VTS_EDIT_BLOCK_AFTER` | `5` | After this many consecutive whole-declaration edits that ignore the nudge, a **safe insert** (a new declaration) is blocked toward `insert_after_symbol`; `0` disables escalation (also held to warn by `VTS_GREP_BLOCK=0`). A replace always stays a warn. |
+| — | `VTS_EDIT_BLOCK_AFTER` | `0` (off) | **Opt-in.** Set ≥1 to escalate the warn to a one-time **block** on a safe insert after that many consecutive ignored nudges (then it resets — fire-once, not a wall). Default off: a persistent block trapped the agent (it fought the wall with Edit retries instead of switching). A replace always stays a warn; `VTS_GREP_BLOCK=0` also holds it to warn. |
 | — | `VTS_EXCLUDE_COMMANDS` | — | Comma list of executables to exempt (also `excludeCommands` in config). |
 | — | `VTS_COMPACT_VCS` | `1` | `0` stops rerouting read-only `git`/`p4` to the compacted wrapper. |
 | `lang` | `VTS_LANG` | auto | Hook message language: `ko` / `en` (auto-detects from OS locale). |

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1088,14 +1088,16 @@ const editWarnOk =
   hMd.status === 0 && !nudgeCtx(hMd);                                                  // non-code file → silent
 fs.writeFileSync(EL, JSON.stringify({ builtin: 5, symbol: 0, streak: 5 }));            // streak at the threshold
 const hEsc = runHook({ tool_name: "Edit", tool_input: { file_path: "/src/T.cpp", old_string: "  anchor();", new_string: DECLC } }, elEnv({ VTS_EDIT_BLOCK_AFTER: "5" }));
+const escStreakReset = (() => { try { return JSON.parse(fs.readFileSync(EL, "utf8")).streak; } catch { return -1; } })(); // block fires → streak reset (no wall)
 fs.writeFileSync(EL, JSON.stringify({ builtin: 9, symbol: 0, streak: 9 }));
 const hEscRepl = runHook({ tool_name: "Edit", tool_input: { file_path: "/src/T.cpp", old_string: DECLC, new_string: "x" } }, elEnv({ VTS_EDIT_BLOCK_AFTER: "5" }));
 fs.writeFileSync(EL, JSON.stringify({ builtin: 9, symbol: 0, streak: 9 }));
-const hEscOff = runHook({ tool_name: "Edit", tool_input: { file_path: "/src/T.cpp", old_string: "  anchor();", new_string: DECLC } }, elEnv({ VTS_EDIT_BLOCK_AFTER: "0" }));
+const hEscDefault = runHook({ tool_name: "Edit", tool_input: { file_path: "/src/T.cpp", old_string: "  anchor();", new_string: DECLC } }, elEnv()); // NO VTS_EDIT_BLOCK_AFTER → default OFF
 const editEscalateOk =
-  hEsc.status === 2 && /escalated to a block/.test(hEsc.err) &&   // insert past the streak → block
-  hEscRepl.status === 0 &&                                         // replace stays warn even at high streak
-  hEscOff.status === 0;                                            // VTS_EDIT_BLOCK_AFTER=0 → escalation off
+  hEsc.status === 2 && /one-time block/.test(hEsc.err) &&   // opt-in (BLOCK_AFTER=5): insert past the streak → block once
+  escStreakReset === 0 &&                                   // …and it RESETS the streak — fire-once, not a permanent wall
+  hEscRepl.status === 0 &&                                  // replace stays warn even at high streak
+  hEscDefault.status === 0;                                 // DEFAULT (no env) → NOT blocked (escalation off by default)
 try { fs.rmSync(EL, { force: true }); } catch { /* ignore */ }
 const editHookOk = editWarnOk && editEscalateOk;
 

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -35,7 +35,7 @@ import { splitSegments } from "../server/shell-split.js";
 // Whole-declaration edit detector, shared with discover (core.js) so the set we STEER matches the set we
 // MEASURE; the adoption ledger is the live metric the steer is tuned against.
 import { classifyDeclEdit } from "../server/edit-detect.js";
-import { recordEditEvent } from "../server/edit-ledger.js";
+import { recordEditEvent, resetStreak } from "../server/edit-ledger.js";
 
 const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(os.homedir(), ".vs-token-safer", "config.json");
 const readConfig = () => { try { return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8")) || {}; } catch { return {}; } };
@@ -506,14 +506,17 @@ process.stdin.on("end", () => {
       const ce = classifyDeclEdit(toolName, ti, editMinLines());
       if (ce.file && (ce.replaceDecl || ce.insertDecl)) {
         const led = recordEditEvent("builtin-warn");
-        // L2: once whole-decl edits have ignored the nudge enough times in a row, BLOCK the SAFE subset — a
-        // pure insert of a new declaration (insert_after_symbol cleanly adds it without needing the old body,
-        // so the reroute can't corrupt). A replace stays warn-only (riskier to force). VTS_EDIT_BLOCK_AFTER=0
-        // disables escalation; VTS_GREP_BLOCK=0 also holds it to warn (shares the master block switch).
+        // L2: an OPT-IN escalation. After VTS_EDIT_BLOCK_AFTER consecutive ignored nudges, BLOCK once on the
+        // SAFE subset (a pure insert of a new declaration). DEFAULT OFF (0) — a persistent block TRAPPED the
+        // agent: it kept fighting the wall with built-in Edit (re-anchoring, even restructuring code to dodge
+        // the hook) instead of switching, and each blocked attempt re-escalated the streak. When it does fire
+        // (user opted in with VTS_EDIT_BLOCK_AFTER≥1), it RESETS the streak so it's a one-time nudge-with-teeth,
+        // not a wall. VTS_GREP_BLOCK=0 also holds it to warn (shares the master block switch).
         const after = Number(process.env.VTS_EDIT_BLOCK_AFTER);
-        const threshold = Number.isFinite(after) && after >= 0 ? after : 5;
+        const threshold = Number.isFinite(after) && after >= 0 ? after : 0; // OFF by default (block traps the model)
         if (grepBlockOn() && threshold > 0 && led.streak >= threshold && ce.insertDecl && !ce.replaceDecl) {
-          process.stderr.write(editNudgeFor(toolName, ti) + " (escalated to a block: the nudge was ignored " + led.streak + "× — use insert_after_symbol / insert_before_symbol, or VTS_EDIT_BLOCK_AFTER=0 to disable.)" + setup + "\n");
+          resetStreak(); // fire ONCE then back off — no permanent wall
+          process.stderr.write(editNudgeFor(toolName, ti) + " (one-time block: the nudge was ignored " + led.streak + "× — use insert_after_symbol / insert_before_symbol for this insert. Set VTS_EDIT_BLOCK_AFTER=0 to disable entirely.)" + setup + "\n");
           process.exit(2); // block — route the safe insert to a symbol-edit
         }
         emitWarn(editNudgeFor(toolName, ti) + setup);

--- a/server/edit-ledger.js
+++ b/server/edit-ledger.js
@@ -30,3 +30,11 @@ export function adoptionPct(o = readEditLedger()) {
   const total = (o.builtin || 0) + (o.symbol || 0);
   return total ? Math.round((100 * (o.symbol || 0)) / total) : null;
 }
+// Clear the ignore-streak without touching the counts — used after an L2 block FIRES so it backs off
+// (fire-once, not a persistent wall: a permanent block trapped the agent, which fought it with Edit retries
+// and code contortions instead of switching tools).
+export function resetStreak() {
+  const o = readEditLedger();
+  o.streak = 0;
+  write(o);
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vs-token-safer",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "type": "module",
   "description": "Force code search through an official language server's index (clangd for C/C++, Roslyn for C#/.NET, tsserver for JS/TS, pyright for Python) instead of grep, token-capped to a compact file:line list. Local-only. CLI + MCP. No IDE required.",
   "keywords": ["clangd", "roslyn", "tsserver", "pyright", "lsp", "code-search", "cpp", "csharp", "typescript", "javascript", "python", "unreal", "visual-studio", "mcp", "claude", "claude-code", "grep", "token-efficiency"],


### PR DESCRIPTION
Patch — the L2 whole-decl-insert block trapped the agent (it fought the wall with Edit retries instead of switching; live-reproduced on our own edit). VTS_EDIT_BLOCK_AFTER now defaults to 0 (off, opt-in); when it fires it resets the streak (fire-once, no wall). L1 warn unchanged. Closes #81. eval 57/57 + steer 18/18 + skillopt 19/19 + lint + validate. 🤖 Generated with [Claude Code](https://claude.com/claude-code)