### PR TITLE
feat(setup): clickable C++ prereq menu + persist clangd path (clangdCmd)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,12 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
     TU in ~13s and returns symbols.** So it's an upstream clangd 19.x bug, not a vts/glue bug. Fix: use
     clangd ≥ `MIN_CLANGD` (22) — `backends/index.js` probes `clangd --version` and `core.js` prepends a
     one-time advisory if it's older. Isolation proved engine headers (CoreMinimal, GameplayTagContainer)
-    parse fine; only the full game-TU header chain trips 19.x.
+    parse fine; only the full game-TU header chain trips 19.x. The clangd path is a first-class CONFIG key
+    `clangdCmd` (in `CONFIG_KEYS`; `vts_setup`/`vts setup --clangdCmd <path>` persists it, so a setup click
+    survives restart WITHOUT editing the user's OS env) — `backends/index.js` `cfgCmd()` resolves it as
+    `VTS_CLANGD_CMD` env > config `clangdCmd` > `clangd`. Eval guard 57. The `commands/setup.md` flow now
+    presents unmet C++ prereqs (no compile DB / no clangd ≥ 22) as `AskUserQuestion` clickable choices, not a
+    free-text prompt — generate-DB routes to `vts_setup { genCompileDb }`, clangd path to `{ clangdCmd }`.
   - Secondary tuning for cold/large indexes: `VTS_LSP_TIMEOUT_MS` (request timeout), `VTS_LSP_INDEX_WAIT_MS`
     (afterInit waits for `$/progress` index-ready), `VTS_CLANGD_OPEN_CAP` (warm-up open cap).
   - **LATENCY (why it felt slower than a warm IDE like Rider — root-caused on a real 26k-TU UE project, all

--- a/README.ko.md
+++ b/README.ko.md
@@ -283,7 +283,7 @@ cd vs-token-safer/server && npm install && npm link   # `vts` 제공
 | — | `VTS_COMPACT_RESULTS` | `1` | `0`이면 위치당 한 줄 출력으로 복원. |
 | — | `VTS_MAX_BACKENDS` | `2` | 동시에 살아 있는 언어 서버 최대치 (초과분은 LRU 축출). |
 | — | `VTS_BACKEND_IDLE_MS` | `300000` | 이만큼 유휴인 언어 서버는 종료 (`0`이면 끔). |
-| — | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | clangd 실행 파일 / 인자 오버라이드. |
+| `clangdCmd` | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | clangd 실행 파일 (`vts setup --clangdCmd <경로>`로 영속 — VS 번들 19.1.x는 UE에서 교착, ≥ 22 권장) / 인자. |
 | — | `VTS_ROSLYN_DLL` | auto | 특정 `Microsoft.CodeAnalysis.LanguageServer.dll` 경로. |
 | — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto → `csharp-ls` | C# LSP 오버라이드. |
 | — | `VTS_TS_CMD` / `VTS_PY_CMD` (+ `_ARGS`) | 번들 | JS/TS · Python LSP 오버라이드. |

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Precedence: **`VTS_*` env > `~/.vs-token-safer/config.json` > default.**
 | — | `VTS_COMPACT_RESULTS` | `1` | `0` restores one-location-per-line output. |
 | — | `VTS_MAX_BACKENDS` | `2` | Max concurrently-live language servers (LRU-evict past the cap). |
 | — | `VTS_BACKEND_IDLE_MS` | `300000` | Idle language server shut down after this (`0` = off). |
-| — | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | Override the clangd executable / args. |
+| `clangdCmd` | `VTS_CLANGD_CMD` / `VTS_CLANGD_ARGS` | `clangd` | clangd executable (persist via `vts setup --clangdCmd <path>` — VS-bundled 19.1.x deadlocks UE, use ≥ 22) / args. |
 | — | `VTS_ROSLYN_DLL` | auto | Path to a specific `Microsoft.CodeAnalysis.LanguageServer.dll`. |
 | — | `VTS_ROSLYN_CMD` / `VTS_ROSLYN_ARGS` | auto → `csharp-ls` | Override the C# LSP. |
 | — | `VTS_TS_CMD` / `VTS_PY_CMD` (+ `_ARGS`) | bundled | Override the JS/TS / Python LSP. |

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -31,12 +31,22 @@ Steps:
 4. **Apply:** call `vts_setup` with only the keys to change, e.g.
    `vts_setup { "projectPath": "<root>", "backend": "clangd" }`. `vts_setup` reports the detected language
    mix (e.g. `clangd(820), typescript(40)`) and the `prewarmBackends` it chose.
-5. **C++ with no compile DB?** `vts_setup` warns when a clangd-dominant root has no `compile_commands.json`
-   (clangd can't index semantically without it). Offer to generate it **in the same step** — pass
-   `genCompileDb` to `vts_setup`: `true` = **dry-run** (prints the exact UBT `GenerateClangDatabase` command,
-   runs nothing — show it to the user first), `"apply"` = run UBT now (heavy: indexes engine headers, takes
-   minutes, needs **clangd ≥ 22**). The DB is parked out-of-tree (`~/.vs-token-safer/db/<project>`), so git/p4
-   never see it. Always dry-run first and let the user confirm before `apply`.
+5. **Unmet C++ prerequisites → present clickable choices, don't ask in prose.** When the clangd backend
+   is missing `compile_commands.json` and/or a clangd ≥ 22 binary, the user should **click**, not type. Use
+   the **`AskUserQuestion`** tool — one question per missing prerequisite, each with concrete options:
+   - **compile_commands.json missing** → question "Generate the C++ compile database now?" options:
+     - `Dry-run first (Recommended)` → call `vts_setup { genCompileDb: true }` (prints the exact UBT
+       `GenerateClangDatabase` command, runs nothing) — show it, then re-ask to apply.
+     - `Run it now (apply)` → `vts_setup { genCompileDb: "apply" }` (heavy: indexes engine headers, minutes,
+       needs clangd ≥ 22). DB parks out-of-tree (`~/.vs-token-safer/db/<project>`), git/p4 never see it.
+     - `Skip — I'll generate it myself` → leave as-is (text fallback stays active).
+   - **clangd ≥ 22 not on PATH** → question "clangd binary?" options:
+     - `Point vts at an installed clangd` → ask for the path, then `vts_setup { clangdCmd: "<path>" }`
+       (writes `VTS_CLANGD_CMD`).
+     - `I'll install it` → link https://github.com/clangd/clangd/releases (VS-bundled 19.1.x deadlocks on UE).
+     - `Skip for now` → text fallback stays active.
+   Only fall back to a free-text question if `AskUserQuestion` is unavailable. Always dry-run the DB before
+   apply.
 6. **Tell the user to run `/reload-plugins`** (or restart) — settings are read at startup.
 
 Notes:

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1133,6 +1133,18 @@ const setupGenOk =
   !/Generated compile_commands/.test(suGen.text);            // …but UBT was NOT actually run
 for (const d of [suEng, suGame]) { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ } }
 
+// 57) vts_setup clangdCmd — the clangd-binary path is a first-class config key (a `vts setup` click can
+// persist it WITHOUT editing the user's OS env), so backends can prefer a user-supplied clangd ≥ 22 over
+// the deadlock-prone VS-bundled 19.1.x. Assert it lands in the config file and is reported as changed.
+const fakeClangd = process.platform === "win32" ? "C:/tools/clangd/bin/clangd.exe" : "/opt/clangd/bin/clangd";
+const suClangd = await runTool("vts_setup", { clangdCmd: fakeClangd });
+let cfPersisted = {};
+try { cfPersisted = JSON.parse(fs.readFileSync(CF, "utf8")) || {}; } catch { /* none */ }
+const setupClangdOk =
+  !suClangd.isError &&
+  /clangdCmd/.test(suClangd.text) &&          // reported as a changed key
+  cfPersisted.clangdCmd === fakeClangd;        // …and actually written to the config file
+
 await disposeClients();
 // 48) clean teardown (no orphaned child): disposeClients must terminate EVERY spawned language-server
 // child — evicted, swept, mid-warmup, or key-overwritten — via the master registry. A surviving child
@@ -1209,6 +1221,7 @@ const rows = [
   ["edit-steer hook: L1 warn (replace/insert) + L2 safe-insert escalation", editHookOk, "true", editHookOk],
   ["per-file-language backend (.py→pyright in a clangd-rooted mixed repo)", backendPathOk, "true", backendPathOk],
   ["vts_setup genCompileDb: generates the compile DB in the setup step (dry)", setupGenOk, "true", setupGenOk],
+  ["vts_setup clangdCmd: persists the clangd-binary path to config", setupClangdOk, "true", setupClangdOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -15,6 +15,12 @@ import { resolveBinJs } from "../resolve-bin.js";
 
 const env = (name, def) => { const v = process.env[name]; return v && v !== "" ? v : def; };
 const splitArgs = (s) => (s ? s.split(/\s+/).filter(Boolean) : null);
+// config-file fallback for an engine-cmd override: env (VTS_*_CMD) wins, then the config key a `vts setup`
+// click persists (e.g. clangdCmd — so "point vts at an installed clangd" survives restart without editing
+// the user's OS env), then the default binary name. Read once at module load (settings apply at startup).
+let _fileCfg = {};
+try { _fileCfg = JSON.parse(fs.readFileSync(process.env.VTS_CONFIG_FILE || path.join(os.homedir(), ".vs-token-safer", "config.json"), "utf8")) || {}; } catch { /* none */ }
+const cfgCmd = (envName, key, def) => env(envName) || (_fileCfg[key] ? String(_fileCfg[key]) : "") || def;
 
 // clangd ≥ this is recommended for large Unreal projects. Older clangd (notably the 19.1.x bundled with
 // Visual Studio) can DEADLOCK indexing real UE translation units in LSP-server mode — clangd --check
@@ -169,7 +175,7 @@ export const BACKENDS = {
   // C/C++ via clangd (LLVM). Needs compile_commands.json (Unreal: generate via UBT
   // `-mode=GenerateClangDatabase`, or CMake `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`). LIVE-TARGET.
   clangd: {
-    cmd: env("VTS_CLANGD_CMD", "clangd"),
+    cmd: cfgCmd("VTS_CLANGD_CMD", "clangdCmd", "clangd"),
     args: (root) => {
       const ov = splitArgs(env("VTS_CLANGD_ARGS"));
       if (ov) return ov;

--- a/server/cli.js
+++ b/server/cli.js
@@ -49,6 +49,7 @@ Commands:
   setup          Persist config. [--projectPath --backend --maxResults]
                  [--genCompileDb dry|apply] — also generate the C++ compile DB in this step (dry-run prints
                  the UBT command; apply runs it, needs clangd ≥ 22). Parks it out-of-tree.
+                 [--clangdCmd <path>] — persist the clangd ≥ 22 binary path (VS-bundled 19.1.x deadlocks UE).
   config         Show effective settings.
   savings        How many tokens you've saved vs forwarding raw index responses.
                  [--graph (30-day ASCII) --daily --history]

--- a/server/core.js
+++ b/server/core.js
@@ -33,7 +33,7 @@ export const PROJECT_PATH = cfg("VTS_PROJECT_PATH", "projectPath", "");
 export const BACKEND = cfg("VTS_BACKEND", "backend", ""); // "clangd" | "roslyn" | "" (auto)
 export const MAX_RESULTS = parseInt(cfg("VTS_MAX_RESULTS", "maxResults", "60"), 10) || 60;
 export const PREWARM_BACKENDS = cfg("VTS_PREWARM_BACKENDS", "prewarmBackends", ""); // "" | auto | all | comma-list
-const CONFIG_KEYS = ["projectPath", "backend", "maxResults", "prewarmBackends", "tee", "excludeCommands", "usdPerMtok"];
+const CONFIG_KEYS = ["projectPath", "backend", "maxResults", "prewarmBackends", "tee", "excludeCommands", "usdPerMtok", "clangdCmd"];
 
 // ---- per-call project root resolution ----
 // The MCP server is ONE long-lived process serving every repo a session touches, so a single configured

--- a/server/index.js
+++ b/server/index.js
@@ -296,6 +296,7 @@ const TOOLS = [
         backend: { type: "string", description: "clangd | roslyn | typescript | pyright (default: auto)." },
         maxResults: { type: "number", description: "Default cap on returned locations." },
         genCompileDb: { description: "Generate the C++ compile_commands.json (for clangd semantic search) in this step: `true` = DRY-RUN (prints the exact UBT command, runs nothing); \"apply\" = run UBT now (heavy — indexes engine headers, needs clangd ≥ 22). The DB is parked out-of-tree (~/.vs-token-safer/db/<project>).", "type": ["boolean", "string"] },
+        clangdCmd: { type: "string", description: "Path to the clangd ≥ 22 binary to use (persists to config, no OS-env edit). The VS-bundled clangd 19.1.x deadlocks on Unreal TUs — point this at a current clangd from https://github.com/clangd/clangd/releases. Env VTS_CLANGD_CMD overrides it." },
       },
     },
   },


### PR DESCRIPTION
## What
Setup yielded a free-text question for missing C++ prerequisites instead of clickable choices.

- `commands/setup.md` now drives **AskUserQuestion** for unmet prereqs: no compile DB → `vts_setup{genCompileDb}`, no clangd ≥22 → `vts_setup{clangdCmd}`.
- New first-class config key **`clangdCmd`** so "point vts at an installed clangd" persists WITHOUT editing the user OS env:
  - `core.js` `CONFIG_KEYS` += `clangdCmd`
  - `backends/index.js` `cfgCmd()`: `VTS_CLANGD_CMD` env > config `clangdCmd` > `clangd`
  - `index.js` schema + `cli.js` `--clangdCmd` + README EN/KO + CLAUDE.md

## Review points
- Backend reads config at module load → takes effect on restart (settings-at-startup, documented).
- `clangdCmd` is config-file only; `VTS_CLANGD_CMD` env still wins.

## Verify
- eval **58/58** (new guard 57: clangdCmd persists to config), `npx eslint .` clean, `claude plugin validate . --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
