### PR TITLE
fix(edit-warn): exclude control-flow blocks from whole-declaration detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,12 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   BYPASSED vts → missed-token report + catch-rate; `learn=true` feeds their result files into the warm-set;
   ALSO MEASURES THE EDIT HABIT — `classifyDeclEdit` (server/edit-detect.js, SHARED with the enforcement hook)
   flags a built-in Edit/MultiEdit whose `old_string` is a whole declaration (replace → `replaceDecl`) OR whose
-  `new_string` is (add → `insertDecl`) on a code file (≥`VTS_EDIT_MIN_LINES`+decl cue), and attributes that
+  `new_string` is (add → `insertDecl`) on a code file (≥`VTS_EDIT_MIN_LINES`+decl cue). CONTROL-FLOW EXCLUSION
+  (dogfood-found FP): a `) {` opener also matches `if/for/while/switch/catch (…) {`, so `isWholeDecl` now only
+  counts the opener when the callee identifier is NOT a reserved control-flow keyword (else a multi-line
+  `if(…){…}` block edited inside a body was flagged a whole decl → suggested `replace_symbol_body symbol="if"`,
+  not a named symbol); the hook's `declSymbolName` likewise refuses a reserved keyword as the symbol name. Eval
+  guard 59. It attributes that
   file's PRIOR Read tokens [`reads`/`readUse` Read↔Edit correlation in `scanBypasses`, read counted ONCE] = the
   read a symbol-edit would've skipped → `edit habit:` line; ALSO `editUnreached` = how many had NO prior vts
   search on that file [`searchUse`/`searchedBn` basename match] = the fraction the search-result steer CAN'T

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1167,6 +1167,18 @@ const textSteerOk =
   !/find_references/.test(stPlain.text);                       // plain word → no steer
 try { fs.rmSync(stDir, { recursive: true, force: true }); } catch { /* ignore */ }
 
+// 59) edit-warn control-flow exclusion — a multi-line `if (…) {` / `for (…) {` block edited INSIDE a
+// function body must NOT be classified as a whole declaration (dogfood-found false positive: it suggested
+// `replace_symbol_body symbol="if"`, which is not a named symbol). A real function/class decl still counts.
+const { classifyDeclEdit } = await import("../server/edit-detect.js");
+const ifBlock = "if (Pawn && Pawn->IsValid())\n{\n    DoA();\n    DoB();\n    DoC();\n    DoD();\n    DoE();\n    DoF();\n}";
+const forBlock = "for (int i = 0; i < n; ++i)\n{\n    sum += i;\n    sum += i;\n    sum += i;\n    sum += i;\n    sum += i;\n    sum += i;\n}";
+const realFn = "void UMyClass::DoWork(int x)\n{\n    int a = x;\n    a += 1;\n    a += 2;\n    a += 3;\n    a += 4;\n    a += 5;\n    Helper(a);\n}";
+const ctrlFlowExclusionOk =
+  classifyDeclEdit("Edit", { file_path: "a.cpp", old_string: ifBlock, new_string: "x" }).replaceDecl === false &&
+  classifyDeclEdit("Edit", { file_path: "a.cpp", old_string: forBlock, new_string: "x" }).replaceDecl === false &&
+  classifyDeclEdit("Edit", { file_path: "a.cpp", old_string: realFn, new_string: "x" }).replaceDecl === true;
+
 await disposeClients();
 // 48) clean teardown (no orphaned child): disposeClients must terminate EVERY spawned language-server
 // child — evicted, swept, mid-warmup, or key-overwritten — via the master registry. A surviving child
@@ -1245,6 +1257,7 @@ const rows = [
   ["vts_setup genCompileDb: generates the compile DB in the setup step (dry)", setupGenOk, "true", setupGenOk],
   ["vts_setup clangdCmd: persists the clangd-binary path to config", setupClangdOk, "true", setupClangdOk],
   ["search_text → symbol steer (find_references on a `<Type>`/symbol hunt)", textSteerOk, "true", textSteerOk],
+  ["edit-warn control-flow exclusion (if/for block ≠ a whole decl)", ctrlFlowExclusionOk, "true", ctrlFlowExclusionOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -313,12 +313,14 @@ function editWarnOn() { const v = String(process.env.VTS_EDIT_WARN ?? "1").toLow
 function editMinLines() { const n = Number(process.env.VTS_EDIT_MIN_LINES); return Number.isFinite(n) && n > 0 ? n : 8; }
 // Best-effort declaration name from a code chunk, so the nudge can name the symbol (a ready call beats a
 // vague hint — the SkillOpt "actionable artifact" principle). null when no name is confidently found.
+const RESERVED_CALLEE = /^(?:if|for|while|switch|catch|return|sizeof|do|else|case|with)$/;
 function declSymbolName(chunk) {
   const c = String(chunk || "");
   let m;
   if ((m = c.match(/\b(?:class|struct|enum|interface|namespace)\s+([A-Za-z_]\w*)/))) return m[1];
   if ((m = c.match(/\b(?:def|function|func|fn)\s+([A-Za-z_]\w*)/))) return m[1];
-  if ((m = c.match(/^[^\n=;]*?\b([A-Za-z_]\w*)\s*\([^;{)]*\)\s*(?:const)?\s*\{?\s*$/m))) return m[1]; // a signature line
+  // a signature line — but a control-flow header (`if (…) {`, `for (…) {`) also matches it; never name those.
+  if ((m = c.match(/^[^\n=;]*?\b([A-Za-z_]\w*)\s*\([^;{)]*\)\s*(?:const)?\s*\{?\s*$/m)) && !RESERVED_CALLEE.test(m[1])) return m[1];
   return null;
 }
 function editNudgeFor(toolName, ti) {

--- a/server/edit-detect.js
+++ b/server/edit-detect.js
@@ -5,9 +5,25 @@
 // A sub-declaration tweak (a few lines inside a body — e.g. one more item in an array) is NOT a fit and is
 // deliberately ignored; built-in Edit stays correct there.
 const CODE_EXT = /\.(c|cc|cxx|cpp|h|hpp|hh|inl|ipp|tpp|cs|ts|tsx|mts|cts|js|jsx|mjs|cjs|py|pyi)\b/;
-// A declaration cue: a structural keyword, or a line that ends in `)` / `) {` (a signature/body opener).
-const DECL_HINT = /\b(class|struct|enum|interface|namespace|template|def|function|func|fn|public|private|protected|static|void|virtual|override|async|UFUNCTION|UCLASS|USTRUCT)\b|\)\s*(const)?\s*\{?\s*$/m;
-const isWholeDecl = (s, minLines) => (String(s).match(/\n/g) || []).length >= minLines && DECL_HINT.test(String(s));
+// A real declaration keyword — its presence alone marks a declaration.
+const DECL_KW = /\b(class|struct|enum|interface|namespace|template|def|function|func|fn|public|private|protected|static|void|virtual|override|async|UFUNCTION|UCLASS|USTRUCT)\b/;
+// Control-flow keywords whose header ALSO ends in `) {` — they must NOT count as a declaration opener.
+// (Dogfood-found false positive: an `if (cond) { … }` block edited inside a function body was flagged a
+// whole declaration and suggested `replace_symbol_body symbol="if"` — `if` is not a named symbol.)
+const RESERVED_CALLEE = new Set(["if", "for", "while", "switch", "catch", "return", "sizeof", "do", "else", "case", "with"]);
+// Signature/body opener on one line: `… name(args) {` where `name` is a callable identifier. Used only when
+// no DECL_KW is present, and the callee must be a real name, not a control-flow keyword.
+const SIG_OPENER = /([A-Za-z_]\w*)\s*\([^;]*\)\s*(?:const|noexcept|override|final|=>)?\s*\{?\s*$/;
+function isWholeDecl(s, minLines) {
+  const str = String(s);
+  if ((str.match(/\n/g) || []).length < minLines) return false;
+  if (DECL_KW.test(str)) return true;                       // an explicit declaration keyword
+  for (const line of str.split("\n")) {                     // else: a NAMED signature opener (not control flow)
+    const m = SIG_OPENER.exec(line);
+    if (m && !RESERVED_CALLEE.has(m[1])) return true;
+  }
+  return false;
+}
 
 // Classify a built-in edit tool call against the whole-declaration heuristic.
 //   replaceDecl — the text being REPLACED (old_string) is a whole declaration → replace_symbol_body fits.


### PR DESCRIPTION
## What
A multi-line `if`/`for`/`while`/`switch`/`catch` block edited **inside a function body** was mis-classified as a whole declaration — the `) {` opener cue also matches a control-flow header — so the edit-warn fired and suggested `replace_symbol_body symbol="if"`, which is not a named symbol (dogfood-found false positive).

## Fix
- `isWholeDecl` (server/edit-detect.js, shared by discover + the hook) now only counts a `name(...) {` signature opener when the callee identifier is **not** a reserved control-flow keyword (`if`/`for`/`while`/`switch`/`catch`/`return`/`sizeof`/`do`/`else`/`case`). A real declaration keyword (`class`/`void`/`def`/...) still counts on its own.
- The hook's `declSymbolName` likewise refuses a reserved keyword as the symbol name.

## Verify
- End-to-end: an `if`-block Edit no longer warns; a real function still warns, naming the function.
- eval **60/60** (new guard 59: if/for block ≠ whole decl, real fn still does), `npx eslint .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
