### PR TITLE
fix(edit-warn): control-flow block with DECL_KW in body is not a decl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,8 +81,11 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   (dogfood-found FP): a `) {` opener also matches `if/for/while/switch/catch (…) {`, so `isWholeDecl` now only
   counts the opener when the callee identifier is NOT a reserved control-flow keyword (else a multi-line
   `if(…){…}` block edited inside a body was flagged a whole decl → suggested `replace_symbol_body symbol="if"`,
-  not a named symbol); the hook's `declSymbolName` likewise refuses a reserved keyword as the symbol name. Eval
-  guard 59. It attributes that
+  not a named symbol); the hook's `declSymbolName` likewise refuses a reserved keyword as the symbol name. v0.26.2
+  GENERALIZED it: the construct is decided by the chunk's FIRST meaningful line — a `CTRL_FLOW_FIRST` header
+  short-circuits to false BEFORE the DECL_KW check, so an `if(…){ (void)x; … }` / `if(…){ static int n; … }`
+  block (DECL_KW `void`/`static` in the BODY) no longer false-positives (the v0.26.1 callee guard only covered
+  the signature-opener branch). Eval guard 59. It attributes that
   file's PRIOR Read tokens [`reads`/`readUse` Read↔Edit correlation in `scanBypasses`, read counted ONCE] = the
   read a symbol-edit would've skipped → `edit habit:` line; ALSO `editUnreached` = how many had NO prior vts
   search on that file [`searchUse`/`searchedBn` basename match] = the fraction the search-result steer CAN'T

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1173,10 +1173,17 @@ try { fs.rmSync(stDir, { recursive: true, force: true }); } catch { /* ignore */
 const { classifyDeclEdit } = await import("../server/edit-detect.js");
 const ifBlock = "if (Pawn && Pawn->IsValid())\n{\n    DoA();\n    DoB();\n    DoC();\n    DoD();\n    DoE();\n    DoF();\n}";
 const forBlock = "for (int i = 0; i < n; ++i)\n{\n    sum += i;\n    sum += i;\n    sum += i;\n    sum += i;\n    sum += i;\n    sum += i;\n}";
+// control-flow block whose BODY contains a DECL_KW token (`(void)` cast / `static` local) — the construct is
+// still control flow (decided by the FIRST line), so it must NOT count as a whole declaration (v0.26.2 fix;
+// the v0.26.1 fix only guarded the signature-opener branch and these still false-positived).
+const ifVoid = "if (Pawn && Pawn->IsValid())\n{\n    (void)Pawn;\n    DoA();\n    DoB();\n    DoC();\n    DoD();\n    DoE();\n}";
+const ifStatic = "if (ready)\n{\n    static int n = 0;\n    n++;\n    n++;\n    n++;\n    n++;\n    n++;\n}";
 const realFn = "void UMyClass::DoWork(int x)\n{\n    int a = x;\n    a += 1;\n    a += 2;\n    a += 3;\n    a += 4;\n    a += 5;\n    Helper(a);\n}";
 const ctrlFlowExclusionOk =
   classifyDeclEdit("Edit", { file_path: "a.cpp", old_string: ifBlock, new_string: "x" }).replaceDecl === false &&
   classifyDeclEdit("Edit", { file_path: "a.cpp", old_string: forBlock, new_string: "x" }).replaceDecl === false &&
+  classifyDeclEdit("Edit", { file_path: "a.cpp", old_string: ifVoid, new_string: "x" }).replaceDecl === false &&
+  classifyDeclEdit("Edit", { file_path: "a.cpp", old_string: ifStatic, new_string: "x" }).replaceDecl === false &&
   classifyDeclEdit("Edit", { file_path: "a.cpp", old_string: realFn, new_string: "x" }).replaceDecl === true;
 
 await disposeClients();

--- a/server/edit-detect.js
+++ b/server/edit-detect.js
@@ -14,11 +14,18 @@ const RESERVED_CALLEE = new Set(["if", "for", "while", "switch", "catch", "retur
 // Signature/body opener on one line: `… name(args) {` where `name` is a callable identifier. Used only when
 // no DECL_KW is present, and the callee must be a real name, not a control-flow keyword.
 const SIG_OPENER = /([A-Za-z_]\w*)\s*\([^;]*\)\s*(?:const|noexcept|override|final|=>)?\s*\{?\s*$/;
+// The CONSTRUCT being edited is decided by its FIRST meaningful line, not by a keyword appearing anywhere.
+// A chunk that STARTS with a control-flow header is a control-flow block — even if its body contains a
+// DECL_KW token like a `(void)` cast or a `static` local (the v0.26.1 fix missed these: it only guarded the
+// signature-opener branch, so `if(…){ (void)x; … }` still matched DECL_KW `void` and false-positived).
+const CTRL_FLOW_FIRST = /^\s*(?:\}\s*)?(?:if|for|while|switch|catch|do|else)\b/;
 function isWholeDecl(s, minLines) {
   const str = String(s);
   if ((str.match(/\n/g) || []).length < minLines) return false;
-  if (DECL_KW.test(str)) return true;                       // an explicit declaration keyword
-  for (const line of str.split("\n")) {                     // else: a NAMED signature opener (not control flow)
+  const first = str.split("\n").find((l) => l.trim()) || "";  // first non-blank line = the construct edited
+  if (CTRL_FLOW_FIRST.test(first)) return false;              // a control-flow block, never a whole declaration
+  if (DECL_KW.test(str)) return true;                         // an explicit declaration keyword
+  for (const line of str.split("\n")) {                       // else: a NAMED signature opener (not control flow)
     const m = SIG_OPENER.exec(line);
     if (m && !RESERVED_CALLEE.has(m[1])) return true;
   }


### PR DESCRIPTION
## What
Follow-up to #89/v0.26.1. That control-flow exclusion only guarded the **signature-opener** branch, so a control-flow block whose **body** contains a `DECL_KW` token — `if (…) { (void)x; … }` or `if (…) { static int n; … }` — still hit the `DECL_KW` branch (`void`/`static`) and **false-positived** the edit-warn.

## Fix
Generalize: the construct is decided by the chunk's **first meaningful line**. A `CTRL_FLOW_FIRST` header (`if`/`for`/`while`/`switch`/`catch`/`do`/`else`) short-circuits `isWholeDecl` to `false` **before** the `DECL_KW` check. A real declaration (first line is the signature) is unaffected.

## Verify
- Dogfood: `if + (void)` and `if + static` blocks → `replaceDecl=false`; a real function → `true` and the hook still warns naming it.
- eval **60/60** (guard 59 extended with the void/static-in-if cases), `npx eslint .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
