### PR TITLE
fix(grep-steer): route declaration-keyword outline grep to document_symbols

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1186,6 +1186,31 @@ const ctrlFlowExclusionOk =
   classifyDeclEdit("Edit", { file_path: "a.cpp", old_string: ifStatic, new_string: "x" }).replaceDecl === false &&
   classifyDeclEdit("Edit", { file_path: "a.cpp", old_string: realFn, new_string: "x" }).replaceDecl === true;
 
+// 60) outline-hunt Grep steer — a declaration-KEYWORD alternation (`^(function|const|export)`) is the model
+// enumerating a file's STRUCTURE, not hunting one named symbol → warn pointing at document_symbols (warn-ONLY:
+// keyword alts are FP-prone so never blocked). Was previously invisible (no code path/glob → no warn at all,
+// a top measured bypass). A CamelCase/snake identifier means a specific symbol → the symbol-hunt block path
+// owns it (not this); an ALL-CAPS keyword alt (TODO|FIXME) is neither → stays silent (no false steer).
+const oWarn = (p, extra) => nudgeCtx(runHook({ tool_name: "Grep", tool_input: { pattern: p, ...(extra || {}) } }));
+const outlineWarn = oWarn("^(function|const|export)", { path: "server/core.js" });
+const outlineSteerOk =
+  /document_symbols/.test(outlineWarn) && /server\/core\.js/.test(outlineWarn) && // keyword-alt + path → document_symbols warn naming the file
+  /document_symbols/.test(oWarn("^(function|const|async function|export)")) &&     // multi-word branch ("async function") reduced to its keyword
+  /document_symbols/.test(oWarn("^(export|import)")) &&                            // import is a structure keyword (kw≥2)
+  /document_symbols/.test(oWarn("^[ \\t]*(function|const)")) &&                    // anchor+charclass+group glued to 1st branch, per-branch cleanup
+  /document_symbols/.test(oWarn("^(function|const)$")) &&                          // trailing $ anchor stripped
+  // a keyword-only alternation that the symbol-hunt cue (`\bclass\b`) would otherwise BLOCK is steered to the
+  // outline path FIRST (it carries no specific identifier → it's an outline, not a named hunt).
+  /document_symbols/.test(oWarn("^(class|struct|enum)")) &&
+  /document_symbols/.test(oWarn("^(def|class)")) &&
+  // FP-safe: ALL-CAPS / prose / control-flow keyword alternations do NOT steer.
+  (() => { const r = runHook({ tool_name: "Grep", tool_input: { pattern: "TODO|FIXME" } }); return r.status === 0 && !/document_symbols/.test(r.out + r.err); })() &&
+  (() => { const r = runHook({ tool_name: "Grep", tool_input: { pattern: "error|warning|info" } }); return r.status === 0 && !/document_symbols/.test(r.out + r.err); })() &&
+  // CamelCase / snake alternation stays a symbol-hunt BLOCK (owned by isSymbolHuntGrep, excluded from outline).
+  (() => { const r = runHook({ tool_name: "Grep", tool_input: { pattern: "MaxWalkSpeed|MaxExcessSpeed" } }); return r.status === 2 && !/document_symbols/.test(r.err); })() &&
+  // malformed (nested paren) → 2nd branch fails the exact keyword match → kw<2 → no steer, no crash.
+  (() => { const r = runHook({ tool_name: "Grep", tool_input: { pattern: "^(function|const(nested))" } }); return r.status === 0; })();
+
 await disposeClients();
 // 48) clean teardown (no orphaned child): disposeClients must terminate EVERY spawned language-server
 // child — evicted, swept, mid-warmup, or key-overwritten — via the master registry. A surviving child
@@ -1265,6 +1290,7 @@ const rows = [
   ["vts_setup clangdCmd: persists the clangd-binary path to config", setupClangdOk, "true", setupClangdOk],
   ["search_text → symbol steer (find_references on a `<Type>`/symbol hunt)", textSteerOk, "true", textSteerOk],
   ["edit-warn control-flow exclusion (if/for block ≠ a whole decl)", ctrlFlowExclusionOk, "true", ctrlFlowExclusionOk],
+  ["outline-hunt Grep steer (decl-keyword alt → document_symbols; FP-safe)", outlineSteerOk, "true", outlineSteerOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -357,6 +357,55 @@ function isSymbolHuntGrep(ti) {
   if (pat.includes("|") && /[a-z][A-Z]|[a-z][a-z0-9]*_[a-z]/.test(pat)) return true;        // (3) CamelCase/snake alternation
   return false;
 }
+// An OUTLINE hunt (vs a symbol hunt): an alternation built mostly of declaration KEYWORDS — `^(function|
+// const|async function|export|//\s*----)`, `^(void|class|struct)` — is the model enumerating the
+// DECLARATION STRUCTURE of a file, not hunting one named symbol. The right tool is `document_symbols` (the
+// token-capped, noise-filtered outline), not search_text. WARN-only, never block: keyword alternations are
+// FP-prone (`const` in config, `export` in shell), and document_symbols needs a target file the grep may not
+// name. Distinct from isSymbolHuntGrep — a CamelCase/snake_case identifier means a SPECIFIC symbol (that path
+// handles it), so it's excluded here. Measured: `^(function|const|...|//\s*----)` was a top bypass that the
+// hook didn't even warn on (no code path/glob → invisible). VTS_GREP_BLOCK has no bearing (warn-only).
+const OUTLINE_KW = /^(?:function|func|fn|def|class|struct|enum|interface|namespace|module|const|let|var|type|typedef|using|import|export|require|package|public|private|protected|static|async|void|template|impl|trait|proc|sub|abstract|final|override|virtual|extends|implements|pub)$/;
+// Reduce one alternation branch to the bare keyword it carries: strip a leading regex anchor (`^`), a
+// group-open (`(` / `(?:`), a whitespace matcher (`\s*`, `[ \t]*`), and a trailing `)`, then take the LAST
+// word (so `async function` / `export const` → `function` / `const`). The first branch of `^\s*(function|…)`
+// arrives glued to the anchor+group; without this it failed the keyword test and a 2-branch outline was
+// missed (real-case test: `^[ \t]*(function|const)`, `^(export|import)`).
+function outlineKeywordOf(branch) {
+  const s = String(branch).trim()
+    .replace(/^\^/, "")                                    // ^ anchor
+    .replace(/^\((?:\?:)?/, "")                            // ( or (?:
+    .replace(/^(?:\\s[*+?]?|\[[^\]]*\][*+?]?|\s)+/, "")    // \s* / [ \t]* / literal whitespace
+    .replace(/^\((?:\?:)?/, "")                            // a group-open that followed the whitespace
+    .replace(/[)$\s]+$/, "")                               // trailing ), $ anchor, whitespace (any order)
+    .trim();
+  const words = s.split(/\s+/).filter(Boolean);
+  return words.length ? words[words.length - 1] : s;
+}
+function isOutlineHuntGrep(ti) {
+  const pat = String(ti.pattern || "");
+  if (!pat.includes("|") || pat.length > 200) return false;
+  if (/[a-z][A-Z]|[a-z][a-z0-9]*_[a-z]/.test(pat)) return false; // a CamelCase/snake id → a specific symbol, not an outline
+  const branches = pat.split("|").map(outlineKeywordOf).filter(Boolean);
+  if (branches.length < 2) return false;
+  const kw = branches.filter((b) => OUTLINE_KW.test(b)).length;
+  return kw >= 2; // ≥2 declaration-keyword branches → a structure/outline hunt → document_symbols
+}
+function outlineNudgeFor(ti) {
+  const p = ti.path ? String(ti.path) : "";
+  const call = p && p.length <= 120
+    ? (KO ? ` 바로 쓸 수 있는 토큰캡 호출: document_symbols path="${p}".` : ` Equivalent token-capped call: document_symbols path="${p}".`)
+    : (KO ? ` 바로 쓸 수 있는 토큰캡 호출: document_symbols path="<파일>".` : ` Equivalent token-capped call: document_symbols path="<file>".`);
+  return KO
+    ? "[vs-token-safer] 선언 키워드(function/const/class/…)로 파일 구조를 훑고 있네요. 그건 '아웃라인' 요청이라 " +
+      "document_symbols가 정확합니다 — 언어 서버가 클래스/함수/메서드/필드 구조를 file:line으로 주고, 익명 콜백·중첩 " +
+      "로컬 노이즈를 걸러 토큰캡됩니다 (정규식이 주석·문자열을 긁는 거짓양성도 없음)." + call +
+      " 그냥 텍스트 확인이면 Grep 그대로 OK. 끄기: VTS_ENFORCE=0."
+    : "[vs-token-safer] Scanning a file's structure by declaration keyword (function/const/class/…). That's an " +
+      "OUTLINE request → document_symbols is exact — the language server returns the class/function/method/field " +
+      "structure as file:line, noise-filtered (anonymous callbacks / nested locals hidden) and token-capped (no " +
+      "regex false positives over comments/strings)." + call + " For a quick text peek, Grep is fine. Disable: VTS_ENFORCE=0.";
+}
 // Don't block a search explicitly aimed at non-code (a doc/asset glob or path) even if the pattern looks
 // symbol-ish — the symbol may legitimately be referenced in a .md/.json.
 function notTextLogTarget(ti) {
@@ -531,6 +580,13 @@ process.stdin.on("end", () => {
   // everything else stays warn-only (Grep is the sanctioned fallback for freeform text / just-edited files).
   if (toolName === "Grep") {
     if (isLogGrepTool(ti)) emitWarn(LOG_NUDGE + setup);
+    // OUTLINE hunt (declaration-KEYWORD alternation, e.g. `^(function|const|export)`, `^(class|struct|enum)`)
+    // → steer to document_symbols (warn-only; keyword alts are FP-prone so never blocked). Checked BEFORE the
+    // symbol-hunt block ON PURPOSE: a keyword-only alternation carries NO specific identifier, so it's an
+    // outline, not a named-symbol hunt — but `isSymbolHuntGrep` would otherwise BLOCK it via its `\bclass\b`/
+    // `\bstruct\b`/`\benum\b` cue (a mild pre-existing FP). `isOutlineHuntGrep` excludes CamelCase/snake, so a
+    // real named hunt (`MaxWalkSpeed|MaxExcessSpeed`, `class Foo|struct Bar`) still falls through to the block.
+    else if (isOutlineHuntGrep(ti) && notTextLogTarget(ti)) emitWarn(outlineNudgeFor(ti) + setup);
     else if (grepBlockOn() && isSymbolHuntGrep(ti) && notTextLogTarget(ti)) {
       process.stderr.write(grepBlockMsg(ti) + setup + "\n");
       process.exit(2); // block — route the symbol hunt to search_symbol / search_text


### PR DESCRIPTION
## What

A Grep-tool pattern that is a declaration-KEYWORD alternation (`^(function|const|export)`, `^(class|struct|enum)`, `^(def|class)`) is the model enumerating a file's **structure**, not hunting one named symbol. Such a grep previously either slipped through the hook with no steer at all (no code path/glob -> invisible) or was BLOCKED toward `search_text` by the symbol-hunt `\bclass\b` cue -- neither routed it to the right tool. `vts discover` (30d, this repo) surfaced `^(function|const|...|//\s*----)` as a top bypass.

Adds `isOutlineHuntGrep` + `outlineNudgeFor`: a >=2 declaration-keyword alternation now **warns toward `document_symbols`** (the token-capped, noise-filtered outline). Warn-only -- keyword alternations are FP-prone (`const` in config, `export` in shell) and `document_symbols` needs a target file the grep may not name.

## Why patch

Closes a measured enforcement gap (a bypass the hook didn't catch). Additive, warn-only refinement to existing Grep steering -- no behavior change for non-outline patterns.

## Robustness (hardened via a 25-pattern real-case matrix + independent review)

- **per-branch `outlineKeywordOf`** strips a leading `^` anchor / `[ \t]*`-`\s*` whitespace class / group-open and a trailing `)`/`$` from EACH branch, then takes the last word (`async function` -> `function`) -- handles `^[ \t]*(function|const)`, `^(function|const)$`.
- **`OUTLINE_KW` expanded** (import/using/typedef/extends/implements/virtual/override/abstract/final/...) and made an **exact (`^...$`) match**, so a malformed branch (`const(nested)`) fails and trailing crud can't sneak a non-keyword in.
- **checked BEFORE the symbol-hunt block**; the CamelCase/snake exclusion keeps real named hunts (`MaxWalkSpeed|MaxExcessSpeed`, `class Foo|struct Bar`) in the block path.
- ALL-CAPS / prose / control-flow keyword alts (`TODO|FIXME`, `error|warning|info`, `if|else`) do **not** steer.

## Review points

- `hooks/block-code-grep.js`: `OUTLINE_KW`, `outlineKeywordOf`, `isOutlineHuntGrep`, `outlineNudgeFor`, Grep-handler reorder (outline before symbol-hunt block).
- `eval/run.mjs`: guard 60 strengthened to 11 assertions.

## Test

- eval **61/61 pass**, lint clean.
- 25-pattern real-case matrix: ALL MATCH (0 false-positive, 0 false-negative, malformed/empty no-crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
