### PR TITLE
chore(glama): add glama.json + Dockerfile to raise the Glama MCP score

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# The Docker image only needs server/ (see Dockerfile). Keep the build context lean + reproducible:
+# node_modules are reinstalled in-image, and everything below is irrelevant to running the MCP server.
+.git
+.github
+.omc
+**/node_modules
+**/.cache
+eval
+benchmarks
+skills
+commands
+agents
+hooks
+docs
+*.md
+*.log
+.claude-plugin
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# vs-token-safer — container image for Glama's MCP tool-introspection / CI smoke.
+#
+# IMPORTANT — this is NOT the recommended runtime. vs-token-safer is a LOCAL-ONLY, zero-transmission MCP
+# server: it indexes YOUR codebase through local language servers (clangd / Roslyn / tsserver / pyright)
+# and returns a token-capped `file:line` list — nothing is sent anywhere. A hosted/containerized instance
+# has no access to your local files or toolchains, so it cannot do the actual work; install it as a Claude
+# Code plugin (see README) to run it next to your code over stdio. This image exists only so Glama (and CI)
+# can BUILD the server and enumerate its tool definitions — i.e. answer `tools/list` for server-coherence
+# and tool-definition-quality scoring. It opens no ports and makes no network egress.
+FROM node:20-slim
+
+WORKDIR /app/server
+# Only server/ is needed to start the stdio MCP server and list tools.
+COPY server/ ./
+
+# The MCP SDK and the JS/TS/Python language servers are declared as optionalDependencies (resolved at
+# runtime in a normal install); install them here so the image is self-contained and fully functional for
+# introspection. (clangd / Roslyn are external toolchains, not npm — not needed to enumerate tools.)
+RUN npm install --omit=dev --no-audit --no-fund
+
+# Newline-delimited JSON-RPC over stdio (standard MCP stdio transport). No ports.
+CMD ["node", "index.js"]

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["JSungMin"]
+}


### PR DESCRIPTION
## Why

The [Glama listing](https://glama.ai/mcp/servers/JSungMin/vs-token-safer/score) scores **25%**. Two unmet criteria are fixable in-repo; the rest are Glama-admin / usage actions.

| Glama criterion | Status | This PR |
|---|---|---|
| No glama.json | ❌ | ✅ adds `glama.json` (`$schema` + `maintainers: JSungMin`) |
| No Glama "release" (Docker build) | ❌ | ✅ adds a `Dockerfile` so Glama can build + introspect |
| Server coherence | ❌ | unlocked once the release/Docker is deployed |
| Tool definition quality | ❌ | unlocked once the release/Docker is deployed |
| No related servers | ❌ | maintainer adds in Glama admin (rider-mcp-enforcer, gamedev-log-analyzer) |
| No recent usage (30d) | ❌ | needs real Glama-proxied usage — can't be set in-repo |
| License / README / maintenance / author | ✅ | already pass |

## Key point: Glama's "release" ≠ GitHub release

Glama's "release" is a **Docker image it builds and deploys to introspect the server** (enumerate tools → score coherence + tool-definition quality). It is NOT a tagged GitHub release (those already exist and don't satisfy it).

## Local-only preserved

The `Dockerfile` is documented as **NOT the runtime**: vs-token-safer is local-only / zero-transmission and must run next to the user's code over stdio — a hosted instance can't see local files or toolchains. The image **opens no ports and makes no network egress**; it exists solely so Glama (and CI) can run `tools/list`.

## Verified

- `tools/list` over stdio returns all **21 tools** (the introspection Glama performs).
- `glama.json` is valid JSON; `claude plugin validate --strict` passes; eval **61/61**.
- No plugin runtime change.

## Maintainer follow-up (Glama admin UI, not in this repo)

1. Deploy the Docker build (Dockerfile admin page → configure build spec → Deploy) to create the Glama release → unlocks coherence + tool-quality scoring.
2. Add related servers (rider-mcp-enforcer, gamedev-log-analyzer).
3. Usage (30d) accrues from real Glama-proxied tool calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
