### PR TITLE
perf(output): factor search_symbol paths + drop document_symbols path repetition

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -38,7 +38,9 @@ const lspOk = syms.length === 2 && syms[0].name === "SpawnHandler";
 
 // 2) runTool search_symbol — compact file:line, no bodies.
 const r1 = await runTool("search_symbol", { q: "Spawn", projectPath: process.cwd(), backend: "clangd" });
-const fmtOk = !r1.isError && /class SpawnHandler {2}@ \/proj\/src\/Foo\.cpp:42/.test(r1.text) && !/character|range|"kind"/.test(r1.text);
+// (search_symbol now factors the common dir prefix across rows, so the path may be relative under an
+// `under <prefix>/` header — assert the symbol + its file:line without requiring a contiguous absolute path.)
+const fmtOk = !r1.isError && /class SpawnHandler {2}@ /.test(r1.text) && /Foo\.cpp:42/.test(r1.text) && !/character|range|"kind"/.test(r1.text);
 
 // 3) token cap — a 1000-symbol index response collapses to a capped file:line list.
 const big = await runTool("search_symbol", { q: "ALL", projectPath: process.cwd(), backend: "clangd", maxResults: 60 });
@@ -148,7 +150,7 @@ const docSymOk =
   !ds.isError && /Foo/.test(ds.text) && /:5/.test(ds.text) &&
   /keepMethod/.test(ds.text) &&                  // real method kept
   /realInner/.test(ds.text) &&                   // real decl inside a hidden wrapper NOT orphaned
-  /func callback {2}@/.test(ds.text) &&          // top-level symbol named 'callback' kept (depth-0, not noise)
+  /func callback {2}:\d/.test(ds.text) &&        // top-level symbol named 'callback' kept (depth-0); path dropped (single-file outline) → `:line`
   !/map\(\) callback/.test(ds.text) && !/localTmp/.test(ds.text) && // anonymous + nested local hidden
   !/noiseKey/.test(ds.text) &&                   // object-literal prop key (kind 7 under a func) hidden
   /keepProp/.test(ds.text) && /Cls/.test(ds.text) && // but a class property (kind 7 under a class) is KEPT

--- a/server/core.js
+++ b/server/core.js
@@ -810,13 +810,21 @@ function backendAdvisory(backendName, root) {
 const locLine = (uri, range) => `${fromUri(uri).replace(/\\/g, "/")}:${(range.start.line + 1)}`;
 function fmtSymbols(syms, max) {
   const shown = syms.slice(0, max);
-  const body = shown.map((s) => {
+  const more = syms.length - shown.length;
+  const tail = more > 0 ? `\n… ${more} more (raise maxResults or narrow the query).` : "";
+  const rows = shown.map((s) => {
     const kind = SYMBOL_KIND[s.kind] || `k${s.kind}`;
     const container = s.containerName ? ` (in ${s.containerName})` : "";
-    return `${kind} ${s.name}${container}  @ ${locLine(s.location.uri, s.location.range)}`;
-  }).join("\n");
-  const more = syms.length - shown.length;
-  return body + (more > 0 ? `\n… ${more} more (raise maxResults or narrow the query).` : "");
+    return { head: `${kind} ${s.name}${container}`, loc: locLine(s.location.uri, s.location.range) };
+  });
+  // Factor the common directory prefix out of the `@ path:line` tails (same token-saver as find_references /
+  // find_files): a project-wide symbol search repeats the long absolute root on every row. Printed once as
+  // `under <prefix>/`; full path recoverable as `<prefix>/<tail>`. VTS_COMPACT_RESULTS=0 → classic per-row.
+  if (compactResults() && rows.length > 1) {
+    const prefix = commonDirPrefix(rows.map((r) => r.loc));
+    if (prefix) return `under ${prefix}/\n` + rows.map((r) => `  ${r.head}  @ ${r.loc.slice(prefix.length + 1)}`).join("\n") + tail;
+  }
+  return rows.map((r) => `${r.head}  @ ${r.loc}`).join("\n") + tail;
 }
 // Output-cap v2 (caveman "collapse repetition"): a refs-heavy result repeats the same long path on every
 // line. Collapse it — one line per FILE with all its line numbers joined, then factor a common DIRECTORY
@@ -896,7 +904,7 @@ function fmtHover(h) {
 // `callback` or `registerCallback`. Only applied at depth>0 (see walk) — a top-level entry is always a
 // real declaration, whatever its name/kind.
 const OUTLINE_NOISE = /\(\)\s*callback$|^<[^>]*>$/i;
-function fmtDocSymbols(syms, max, file) {
+function fmtDocSymbols(syms, max) {
   const raw = process.env.VTS_OUTLINE_RAW === "1" || process.env.VTS_OUTLINE_RAW === "true";
   const maxDepth = envInt("VTS_OUTLINE_DEPTH", 4);
   const rows = [];
@@ -918,8 +926,9 @@ function fmtDocSymbols(syms, max, file) {
       }
       const r = s.range || (s.location && s.location.range);
       const ln = r ? r.start.line + 1 : 1;
-      const loc = s.location ? fromUri(s.location.uri).replace(/\\/g, "/") : file;
-      rows.push(`${SYMBOL_KIND[s.kind] || `k${s.kind}`} ${parent ? parent + "::" : ""}${s.name}  @ ${loc}:${ln}`);
+      // Single-file outline → the path is constant (named once in the caller's "outline of <file>" header),
+      // so emit only the line number, not the full path repeated on every row (was ~path×rows of pure waste).
+      rows.push(`${SYMBOL_KIND[s.kind] || `k${s.kind}`} ${parent ? parent + "::" : ""}${s.name}  :${ln}`);
       if (s.children && depth < maxDepth) walk(s.children, (parent ? parent + "::" : "") + s.name, depth + 1, s.kind);
     }
   };
@@ -1457,7 +1466,7 @@ export async function runTool(name, a = {}) {
       c.didOpen(a.path, lang);
       const syms = (await c.documentSymbol(a.path)) || [];
       try { recordQueryResults(root, [a.path]); } catch { /* best-effort */ }
-      return finishOut(syms, backendAdvisory(backendName, root) + `outline of ${a.path} (backend: ${backendName}):\n` + fmtDocSymbols(syms, max, a.path.replace(/\\/g, "/")));
+      return finishOut(syms, backendAdvisory(backendName, root) + `outline of ${a.path} (backend: ${backendName}):\n` + fmtDocSymbols(syms, max));
     }
     if (name === "rename") {
       if (!a.path || a.line == null || a.character == null || !a.newName) return err("rename needs path, line, character (0-based), newName.");


### PR DESCRIPTION
Measuring **real per-call tool output** (not the fixed schema cost) found two formatters that v0.26.4's common-prefix factoring missed — they put the absolute path *mid-row* (`@ path:line`), so the line-leading `factorCommonPrefix` didn't apply.

| tool | before | after |
|---|--:|--:|
| document_symbols (server/core.js) | 657 tok | **417** (-37%) |
| search_symbol ("runTool") | 220 tok | **165** (-25%) |

## Changes
- **search_symbol** (`fmtSymbols`): factors the common dir across rows → `under <prefix>/` + relative tails (same saver `find_references`/`find_files` use).
- **document_symbols** (`fmtDocSymbols`): a single-file outline repeated the file path on every row — the caller already names it in the `outline of <file>` header, so rows now emit just `:line`.

`find_references` (already factored) unchanged; gated by `VTS_COMPACT_RESULTS`.

## Test
eval **63/63** (guards 2/3/12 exercise the new format via the mock backend; assertions updated), lint clean.
