### PR TITLE
docs(tools): raise Glama tool-quality on the weak HOT tools

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1256,7 +1256,8 @@ const toolsBudgetOk =
   TOOL_DEFS.every((t) => t.name && (t.description || "").length > 10 && t.inputSchema) && // routing signal intact
   JSON.stringify(adminTool?.inputSchema?.properties?.op?.enum || []) === JSON.stringify([...ADMIN_OPS]) && // enum matches the dispatch set
   !cfgViaOp.isError && /settings/i.test(cfgViaOp.text) && // op→vts_config resolves to a real handler
-  toolsTok <= 2700; // ~2420 now; headroom blocks prose creep
+  toolsTok <= 3000; // ~2899: fold floor was ~2420; +~480 is the deliberate Glama tool-quality re-add
+                    // (side-effect/output-format disclosure + terse param descriptions). Cap blocks prose creep.
 
 await disposeClients();
 // 48) clean teardown (no orphaned child): disposeClients must terminate EVERY spawned language-server
@@ -1339,7 +1340,7 @@ const rows = [
   ["edit-warn control-flow exclusion (if/for block ≠ a whole decl)", ctrlFlowExclusionOk, "true", ctrlFlowExclusionOk],
   ["outline-hunt Grep steer (decl-keyword alt → document_symbols; FP-safe)", outlineSteerOk, "true", outlineSteerOk],
   ["common-prefix factoring: find_files + search_text (toggle)", prefixFactoringOk, "true", prefixFactoringOk],
-  ["tool-def budget + vts_admin fold: hot tools named, cold folded, ≤ 2700 tok", toolsBudgetOk, "true", toolsBudgetOk],
+  ["tool-def budget + vts_admin fold: hot tools named, cold folded, ≤ 3000 tok", toolsBudgetOk, "true", toolsBudgetOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/tools.js
+++ b/server/tools.js
@@ -33,24 +33,24 @@ export const TOOLS = [
         line: { type: "number", description: "0-based line." },
         character: { type: "number", description: "0-based column." },
         includeDeclaration: { type: "boolean", description: "Include the declaration." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
     },
   },
   {
     name: "goto_definition",
-    description: "Definition of the symbol at a 0-based position (semantic). → token-capped `file:line`.",
+    description: "Definition of the symbol at a 0-based position (semantic, read-only). → token-capped `file:line` (empty if it can't resolve). For all usages instead, use find_references.",
     inputSchema: {
       type: "object",
       properties: {
         path: { type: "string", description: "Source file containing the symbol." },
         line: { type: "number", description: "0-based line of the symbol position." },
         character: { type: "number", description: "0-based character/column of the symbol position." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["path", "line", "character"],
     },
@@ -64,22 +64,22 @@ export const TOOLS = [
         path: { type: "string", description: "Source file." },
         line: { type: "number", description: "0-based line." },
         character: { type: "number", description: "0-based character/column." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
       },
       required: ["path", "line", "character"],
     },
   },
   {
     name: "document_symbols",
-    description: "Outline one file (classes/functions/types) → `kind name @ file:line`. Cheaper than reading it.",
+    description: "Outline one file — its classes/functions/types as a token-capped `kind name :line` list (the file is named once in the header; read-only, capped at maxResults). Cheaper than reading the whole file to see its structure.",
     inputSchema: {
       type: "object",
       properties: {
         path: { type: "string", description: "File to outline." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["path"],
     },
@@ -97,9 +97,9 @@ export const TOOLS = [
         character: { type: "number", description: "0-based character/column of the symbol." },
         newName: { type: "string", description: "New name for the symbol." },
         apply: { type: "boolean", description: "Write the edits to disk (default false = preview only)." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["path", "line", "character", "newName"],
     },
@@ -108,7 +108,8 @@ export const TOOLS = [
     name: "replace_symbol_body",
     description:
       "Replace a whole declaration (signature + body) by NAMING it — the outline gives the exact span, so no " +
-      "Read-the-file + line-counting for an exact-match Edit. PREVIEW by default; apply=true writes.",
+      "Read-the-file + line-counting for an exact-match Edit. PREVIEW by default returns the affected " +
+      "`file:line`; apply=true OVERWRITES the declaration on disk.",
     inputSchema: {
       type: "object",
       properties: {
@@ -117,9 +118,9 @@ export const TOOLS = [
         path: { type: "string", description: "File holding the symbol (pins the outline; else resolved via the index)." },
         line: { type: "number", description: "0-based line to disambiguate same-named symbols (optional)." },
         apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["symbol", "body"],
     },
@@ -128,7 +129,7 @@ export const TOOLS = [
     name: "insert_after_symbol",
     description:
       "Insert text after a named declaration (e.g. a sibling function/method) — outline gives the point, no " +
-      "Read needed. PREVIEW by default; apply=true writes.",
+      "Read needed. PREVIEW by default returns the affected `file:line`; apply=true WRITES to the file on disk.",
     inputSchema: {
       type: "object",
       properties: {
@@ -137,9 +138,9 @@ export const TOOLS = [
         path: { type: "string", description: "File holding the symbol (else resolved via the index)." },
         line: { type: "number", description: "0-based line to disambiguate same-named symbols (optional)." },
         apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["symbol", "text"],
     },
@@ -148,7 +149,8 @@ export const TOOLS = [
     name: "insert_before_symbol",
     description:
       "Insert text before a named declaration (e.g. an import/attribute/decorator above it). PREVIEW by " +
-      "default; apply=true writes.",
+      "default returns the affected `file:line`; apply=true WRITES to the file on disk. Use instead of " +
+      "Read-then-Edit to add a declaration.",
     inputSchema: {
       type: "object",
       properties: {
@@ -157,9 +159,9 @@ export const TOOLS = [
         path: { type: "string", description: "File holding the symbol (else resolved via the index)." },
         line: { type: "number", description: "0-based line to disambiguate same-named symbols (optional)." },
         apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["symbol", "text"],
     },
@@ -177,9 +179,9 @@ export const TOOLS = [
         line: { type: "number", description: "0-based line to disambiguate same-named symbols (optional)." },
         force: { type: "boolean", description: "Delete even if references remain (default false = refuse when referenced)." },
         apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["symbol"],
     },
@@ -188,13 +190,13 @@ export const TOOLS = [
     name: "find_files",
     description:
       "Find files by name (substring or glob like *Manager.cpp) — replaces Bash `find -name`. → token-capped " +
-      "file list. No backend needed.",
+      "file list; walk-bounded (skips node_modules/Intermediate/Binaries, time-boxed). Read-only, no backend needed.",
     inputSchema: {
       type: "object",
       properties: {
         q: { type: "string", description: "Filename substring or glob (* ? supported)." },
-        projectPath: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["q"],
     },
@@ -211,8 +213,8 @@ export const TOOLS = [
         q: { type: "string", description: "String or regular expression to find." },
         path: { type: "string", description: "Search ONE file (any extension auto-included; relative or absolute)." },
         glob: { type: "string", description: "Only files matching this basename glob (e.g. *.md) — any extension it covers." },
-        projectPath: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
         docs: { type: "boolean", description: "With no path/glob, widen the sweep to docs/config text (md/json/yaml/…), not just source." },
       },
       required: ["q"],


### PR DESCRIPTION
Glama's tool-definition-quality scorer (server 83%) flagged several HOT tools low on **Behavior** (disclose side-effects/limits), **Completeness** (output format + errors), and **Parameters** (shared `projectPath`/`backend`/`maxResults` were BARE — a pre-existing gap, not the recent trim). `search_symbol` (5.0) + `vts_git` (4.9) prove Conciseness-5 and Completeness-5 coexist, so this matches their concise style — no bloat.

## Changes
- Describe the shared params on the hot tools that had them bare — terse one-liners (Parameters).
- Disclose disk writes + output format on the mutating tools (`replace_symbol_body`/`insert_after`/`insert_before`: "PREVIEW returns the affected file:line; apply=true WRITES/OVERWRITES on disk") (Behavior + Completeness).
- `goto_definition`: read-only + "empty if it can't resolve" + cross-ref `find_references`.
- `document_symbols`: read-only + capped + reflects the v0.26.6 `:line` output shape.
- `find_files`: walk-bounded/read-only note.

## Token ↔ quality trade (deliberate)
tools/list **2420 → 2899 tok** (+~480, still **-29% vs the original 4088**). Cold admin tools unchanged (folded under `vts_admin`; their Glama scores drop out on the next rebuild). eval guard 62 budget raised 2700 → 3000 (documented).

eval **63/63**, lint clean.
