### PR TITLE
perf(output): cap hover line length (self-audit fix)

### DIFF
--- a/eval/_mock-lsp.mjs
+++ b/eval/_mock-lsp.mjs
@@ -41,7 +41,8 @@ process.stdin.on("data", (d) => {
       }
       send({ jsonrpc: "2.0", id: msg.id, result });
     } else if (msg.method === "textDocument/hover") {
-      send({ jsonrpc: "2.0", id: msg.id, result: { contents: { kind: "plaintext", value: "int Foo(int x)" } } });
+      // 2nd line is a pathological 300-char "type" — fmtHover must trim each line to ≤200 (not just cap lines).
+      send({ jsonrpc: "2.0", id: msg.id, result: { contents: { kind: "plaintext", value: "int Foo(int x)\n" + "T".repeat(300) } } });
     } else if (msg.method === "textDocument/documentSymbol") {
       // Foo (top-level func) with children: a real method (kept), an anonymous callback + a nested local
       // var (both outline noise → hidden by default; shown under VTS_OUTLINE_RAW=1).

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -141,7 +141,9 @@ try { fs.rmSync(cdir, { recursive: true, force: true }); } catch { /* ignore */ 
 // 12) new read-only tools — hover + document_symbols (mock LSP), find_files + search_text (filesystem).
 const someFile = path.join(process.cwd(), "eval", "run.mjs");
 const hv = await runTool("hover", { path: someFile, line: 0, character: 0, backend: "clangd" });
-const hoverOk = !hv.isError && /Foo/.test(hv.text);
+// hover keeps the signature AND trims a pathological long line to ≤200 chars + "…" (per-line cap, not just
+// the ≤8-line cap) — a complex TS/C++ hover can be one multi-thousand-char type.
+const hoverOk = !hv.isError && /Foo/.test(hv.text) && /…/.test(hv.text) && !/T{250}/.test(hv.text);
 const ds = await runTool("document_symbols", { path: someFile, backend: "clangd" });
 process.env.VTS_OUTLINE_RAW = "1";
 const dsRaw = await runTool("document_symbols", { path: someFile, backend: "clangd" });

--- a/server/core.js
+++ b/server/core.js
@@ -891,7 +891,10 @@ function fmtHover(h) {
   if (Array.isArray(c)) c = c.map((x) => (typeof x === "string" ? x : x.value || "")).join("\n");
   else if (typeof c === "object") c = c.value || "";
   c = String(c).replace(/```[a-z]*\n?/gi, "").trim();
-  const lines = c.split(/\r?\n/).filter(Boolean).slice(0, 8);
+  // Cap BOTH dimensions: ≤8 lines AND ≤200 chars/line (trimMatchLine). The 8-line cap alone left a
+  // pathological single huge line uncapped — a complex TS/C++ hover can be one multi-thousand-char type
+  // signature/union. Trim each line so "a few lines, no walls" holds even then.
+  const lines = c.split(/\r?\n/).filter(Boolean).slice(0, 8).map(trimMatchLine);
   return lines.join("\n") || "(no hover info)";
 }
 // document symbols (hierarchical DocumentSymbol[] or flat SymbolInformation[]) → kind name @ file:line.


### PR DESCRIPTION
Self-audit of every tool's real output footprint (search/nav/edit previews/vts_git/vts_admin) found the surface already well-optimized — **except** `fmtHover` capped to ≤8 lines but left each line's LENGTH uncapped. A complex TS/C++ hover can be one multi-thousand-char type signature/union on a single line, so the line cap alone didn't bound it.

## Fix
Trim each hover line with the existing `trimMatchLine` (≤200 chars + "…"), matching vts's "a few lines, no walls" contract. eval guard 12 extended (mock hover returns a 300-char line; asserts it's trimmed). **63/63**, lint clean.

## Also verified (no change needed)
- **vts_admin fold dispatches all 9 ops** with params passthrough (git/savings/discover/warmup/config end-to-end via the stdio server) — the fold shipped this session is correct.
- edit/rename previews lean (25–75 tok); search_symbol/document_symbols already factored (v0.26.6).
- Remaining token sink = the **edit habit** (~90k tok read-first, ~6% symbol-edit adoption) — a known attention problem, not a wording gap (SkillOpt-confirmed).
