### PR TITLE
release: HOT-tool Glama quality + hover line cap (v0.26.7)

### DIFF
--- a/eval/_mock-lsp.mjs
+++ b/eval/_mock-lsp.mjs
@@ -41,7 +41,8 @@ process.stdin.on("data", (d) => {
       }
       send({ jsonrpc: "2.0", id: msg.id, result });
     } else if (msg.method === "textDocument/hover") {
-      send({ jsonrpc: "2.0", id: msg.id, result: { contents: { kind: "plaintext", value: "int Foo(int x)" } } });
+      // 2nd line is a pathological 300-char "type" — fmtHover must trim each line to ≤200 (not just cap lines).
+      send({ jsonrpc: "2.0", id: msg.id, result: { contents: { kind: "plaintext", value: "int Foo(int x)\n" + "T".repeat(300) } } });
     } else if (msg.method === "textDocument/documentSymbol") {
       // Foo (top-level func) with children: a real method (kept), an anonymous callback + a nested local
       // var (both outline noise → hidden by default; shown under VTS_OUTLINE_RAW=1).

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1256,7 +1256,8 @@ const toolsBudgetOk =
   TOOL_DEFS.every((t) => t.name && (t.description || "").length > 10 && t.inputSchema) && // routing signal intact
   JSON.stringify(adminTool?.inputSchema?.properties?.op?.enum || []) === JSON.stringify([...ADMIN_OPS]) && // enum matches the dispatch set
   !cfgViaOp.isError && /settings/i.test(cfgViaOp.text) && // op→vts_config resolves to a real handler
-  toolsTok <= 2700; // ~2420 now; headroom blocks prose creep
+  toolsTok <= 3000; // ~2899: fold floor was ~2420; +~480 is the deliberate Glama tool-quality re-add
+                    // (side-effect/output-format disclosure + terse param descriptions). Cap blocks prose creep.
 
 await disposeClients();
 // 48) clean teardown (no orphaned child): disposeClients must terminate EVERY spawned language-server
@@ -1339,7 +1340,7 @@ const rows = [
   ["edit-warn control-flow exclusion (if/for block ≠ a whole decl)", ctrlFlowExclusionOk, "true", ctrlFlowExclusionOk],
   ["outline-hunt Grep steer (decl-keyword alt → document_symbols; FP-safe)", outlineSteerOk, "true", outlineSteerOk],
   ["common-prefix factoring: find_files + search_text (toggle)", prefixFactoringOk, "true", prefixFactoringOk],
-  ["tool-def budget + vts_admin fold: hot tools named, cold folded, ≤ 2700 tok", toolsBudgetOk, "true", toolsBudgetOk],
+  ["tool-def budget + vts_admin fold: hot tools named, cold folded, ≤ 3000 tok", toolsBudgetOk, "true", toolsBudgetOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -141,7 +141,9 @@ try { fs.rmSync(cdir, { recursive: true, force: true }); } catch { /* ignore */ 
 // 12) new read-only tools — hover + document_symbols (mock LSP), find_files + search_text (filesystem).
 const someFile = path.join(process.cwd(), "eval", "run.mjs");
 const hv = await runTool("hover", { path: someFile, line: 0, character: 0, backend: "clangd" });
-const hoverOk = !hv.isError && /Foo/.test(hv.text);
+// hover keeps the signature AND trims a pathological long line to ≤200 chars + "…" (per-line cap, not just
+// the ≤8-line cap) — a complex TS/C++ hover can be one multi-thousand-char type.
+const hoverOk = !hv.isError && /Foo/.test(hv.text) && /…/.test(hv.text) && !/T{250}/.test(hv.text);
 const ds = await runTool("document_symbols", { path: someFile, backend: "clangd" });
 process.env.VTS_OUTLINE_RAW = "1";
 const dsRaw = await runTool("document_symbols", { path: someFile, backend: "clangd" });

--- a/server/core.js
+++ b/server/core.js
@@ -891,7 +891,10 @@ function fmtHover(h) {
   if (Array.isArray(c)) c = c.map((x) => (typeof x === "string" ? x : x.value || "")).join("\n");
   else if (typeof c === "object") c = c.value || "";
   c = String(c).replace(/```[a-z]*\n?/gi, "").trim();
-  const lines = c.split(/\r?\n/).filter(Boolean).slice(0, 8);
+  // Cap BOTH dimensions: ≤8 lines AND ≤200 chars/line (trimMatchLine). The 8-line cap alone left a
+  // pathological single huge line uncapped — a complex TS/C++ hover can be one multi-thousand-char type
+  // signature/union. Trim each line so "a few lines, no walls" holds even then.
+  const lines = c.split(/\r?\n/).filter(Boolean).slice(0, 8).map(trimMatchLine);
   return lines.join("\n") || "(no hover info)";
 }
 // document symbols (hierarchical DocumentSymbol[] or flat SymbolInformation[]) → kind name @ file:line.

--- a/server/tools.js
+++ b/server/tools.js
@@ -33,24 +33,24 @@ export const TOOLS = [
         line: { type: "number", description: "0-based line." },
         character: { type: "number", description: "0-based column." },
         includeDeclaration: { type: "boolean", description: "Include the declaration." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
     },
   },
   {
     name: "goto_definition",
-    description: "Definition of the symbol at a 0-based position (semantic). → token-capped `file:line`.",
+    description: "Definition of the symbol at a 0-based position (semantic, read-only). → token-capped `file:line` (empty if it can't resolve). For all usages instead, use find_references.",
     inputSchema: {
       type: "object",
       properties: {
         path: { type: "string", description: "Source file containing the symbol." },
         line: { type: "number", description: "0-based line of the symbol position." },
         character: { type: "number", description: "0-based character/column of the symbol position." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["path", "line", "character"],
     },
@@ -64,22 +64,22 @@ export const TOOLS = [
         path: { type: "string", description: "Source file." },
         line: { type: "number", description: "0-based line." },
         character: { type: "number", description: "0-based character/column." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
       },
       required: ["path", "line", "character"],
     },
   },
   {
     name: "document_symbols",
-    description: "Outline one file (classes/functions/types) → `kind name @ file:line`. Cheaper than reading it.",
+    description: "Outline one file — its classes/functions/types as a token-capped `kind name :line` list (the file is named once in the header; read-only, capped at maxResults). Cheaper than reading the whole file to see its structure.",
     inputSchema: {
       type: "object",
       properties: {
         path: { type: "string", description: "File to outline." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["path"],
     },
@@ -97,9 +97,9 @@ export const TOOLS = [
         character: { type: "number", description: "0-based character/column of the symbol." },
         newName: { type: "string", description: "New name for the symbol." },
         apply: { type: "boolean", description: "Write the edits to disk (default false = preview only)." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["path", "line", "character", "newName"],
     },
@@ -108,7 +108,8 @@ export const TOOLS = [
     name: "replace_symbol_body",
     description:
       "Replace a whole declaration (signature + body) by NAMING it — the outline gives the exact span, so no " +
-      "Read-the-file + line-counting for an exact-match Edit. PREVIEW by default; apply=true writes.",
+      "Read-the-file + line-counting for an exact-match Edit. PREVIEW by default returns the affected " +
+      "`file:line`; apply=true OVERWRITES the declaration on disk.",
     inputSchema: {
       type: "object",
       properties: {
@@ -117,9 +118,9 @@ export const TOOLS = [
         path: { type: "string", description: "File holding the symbol (pins the outline; else resolved via the index)." },
         line: { type: "number", description: "0-based line to disambiguate same-named symbols (optional)." },
         apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["symbol", "body"],
     },
@@ -128,7 +129,7 @@ export const TOOLS = [
     name: "insert_after_symbol",
     description:
       "Insert text after a named declaration (e.g. a sibling function/method) — outline gives the point, no " +
-      "Read needed. PREVIEW by default; apply=true writes.",
+      "Read needed. PREVIEW by default returns the affected `file:line`; apply=true WRITES to the file on disk.",
     inputSchema: {
       type: "object",
       properties: {
@@ -137,9 +138,9 @@ export const TOOLS = [
         path: { type: "string", description: "File holding the symbol (else resolved via the index)." },
         line: { type: "number", description: "0-based line to disambiguate same-named symbols (optional)." },
         apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["symbol", "text"],
     },
@@ -148,7 +149,8 @@ export const TOOLS = [
     name: "insert_before_symbol",
     description:
       "Insert text before a named declaration (e.g. an import/attribute/decorator above it). PREVIEW by " +
-      "default; apply=true writes.",
+      "default returns the affected `file:line`; apply=true WRITES to the file on disk. Use instead of " +
+      "Read-then-Edit to add a declaration.",
     inputSchema: {
       type: "object",
       properties: {
@@ -157,9 +159,9 @@ export const TOOLS = [
         path: { type: "string", description: "File holding the symbol (else resolved via the index)." },
         line: { type: "number", description: "0-based line to disambiguate same-named symbols (optional)." },
         apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["symbol", "text"],
     },
@@ -177,9 +179,9 @@ export const TOOLS = [
         line: { type: "number", description: "0-based line to disambiguate same-named symbols (optional)." },
         force: { type: "boolean", description: "Delete even if references remain (default false = refuse when referenced)." },
         apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
-        projectPath: { type: "string" },
-        backend: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        backend: { type: "string", description: "clangd|roslyn|typescript|pyright (auto)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["symbol"],
     },
@@ -188,13 +190,13 @@ export const TOOLS = [
     name: "find_files",
     description:
       "Find files by name (substring or glob like *Manager.cpp) — replaces Bash `find -name`. → token-capped " +
-      "file list. No backend needed.",
+      "file list; walk-bounded (skips node_modules/Intermediate/Binaries, time-boxed). Read-only, no backend needed.",
     inputSchema: {
       type: "object",
       properties: {
         q: { type: "string", description: "Filename substring or glob (* ? supported)." },
-        projectPath: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
       },
       required: ["q"],
     },
@@ -211,8 +213,8 @@ export const TOOLS = [
         q: { type: "string", description: "String or regular expression to find." },
         path: { type: "string", description: "Search ONE file (any extension auto-included; relative or absolute)." },
         glob: { type: "string", description: "Only files matching this basename glob (e.g. *.md) — any extension it covers." },
-        projectPath: { type: "string" },
-        maxResults: { type: "number" },
+        projectPath: { type: "string", description: "Project root (default cwd)." },
+        maxResults: { type: "number", description: "Result cap (default 60)." },
         docs: { type: "boolean", description: "With no path/glob, widen the sweep to docs/config text (md/json/yaml/…), not just source." },
       },
       required: ["q"],


### PR DESCRIPTION
`dev → main` release. Theme: tool-definition quality + the last output token-cap gap.

## Contents
- **#104 `docs(tools)`** — raise Glama tool-quality on the weak HOT tools: describe the bare shared params (projectPath/backend/maxResults), disclose disk writes + output format on the mutating tools, read-only/output notes on goto/document_symbols/find_files. Concise (search_symbol-style). tools/list 2420→2899 tok (still -29% vs the original 4088); budget guard 2700→3000.
- **#105 `perf(output)`** — cap hover LINE LENGTH (≤200 chars + "…" via trimMatchLine), not just the ≤8-line cap; a complex TS/C++ hover can be one multi-thousand-char type. Self-audit also verified the vts_admin fold dispatches all 9 ops correctly + edit/rename previews are lean.

## Review points
- Token↔Glama trade is deliberate (#104): re-added ~480 tok of param/behavior/output disclosure for tool-quality.
- hover cap reuses the existing trimMatchLine; eval guard 12 extended.
- eval **63/63**, lint + `plugin validate` clean, CI green.

Bump: `docs:`/`perf:` → **patch (v0.26.7)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
