### PR TITLE
fix(diagnostics): match per-file diagnostics by canonical path (Windows uri)

### DIFF
--- a/eval/_mock-lsp.mjs
+++ b/eval/_mock-lsp.mjs
@@ -84,7 +84,10 @@ process.stdin.on("data", (d) => {
         ? [{ severity: 2, range: { start: { line: 9, character: 0 }, end: { line: 9, character: 4 } }, message: "unused variable 'x'" },
           { severity: 1, range: { start: { line: 4, character: 2 }, end: { line: 4, character: 8 } }, code: "E001", message: "use of undeclared identifier 'foo'" }]
         : [];
-      send({ jsonrpc: "2.0", method: "textDocument/publishDiagnostics", params: { uri, diagnostics: diags } });
+      // Publish with a SERVER-STYLE uri (lowercase, %3A-encoded Windows drive — like real clangd/tsserver) so
+      // the diagnostics lookup must canonicalize to match (regression net for the Win uri-spelling bug).
+      const pub = uri.replace(/^file:\/\/\/([A-Za-z]):/, (m, d) => `file:///${d.toLowerCase()}%3A`);
+      send({ jsonrpc: "2.0", method: "textDocument/publishDiagnostics", params: { uri: pub, diagnostics: diags } });
     } else if (msg.method === "textDocument/references") {
       // "Foo"'s name sits at line 4 (its selectionRange) — return one usage there so safe_delete sees a
       // referrer and refuses; any other position (e.g. the find_references guard at line 41) returns none.

--- a/server/core.js
+++ b/server/core.js
@@ -10,7 +10,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync, execSync } from "node:child_process";
-import { LspClient, fromUri, langIdForPath, envInt } from "./lsp.js";
+import { LspClient, fromUri, langIdForPath, envInt, canonFsPath } from "./lsp.js";
 import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot } from "./backends/index.js";
 import { recordQueryResults, languageCensus } from "./warmset.js";
 import { splitSegments } from "./shell-split.js";
@@ -1518,10 +1518,11 @@ export async function runTool(name, a = {}) {
         for (const f of files) c.didOpen(f, langIdForPath(f, backendName));
         await new Promise((r) => setTimeout(r, envInt("VTS_DIAG_DIR_WAIT_MS", 4000))); // let the server publish
         const agg = [];
+        const dirCanon = canonFsPath(dirRoot); // servers spell the Win drive differently (%3A/case) — compare canonically
         for (const [uri, ds] of c.diagnostics.entries()) {
           if (!ds || !ds.length) continue;
           let fp; try { fp = fromUri(uri).replace(/\\/g, "/"); } catch { continue; }
-          if (!fp.startsWith(dirRoot)) continue; // only files under the scanned dir
+          if (!canonFsPath(uri).startsWith(dirCanon)) continue; // only files under the scanned dir
           for (const x of ds) agg.push({ ...x, _file: fp });
         }
         const sweepNote = files.truncated ? ` — scan capped at ${files.length} file(s) (raise VTS_DIAG_DIR_MAX; more exist)` : ` (${files.length} file(s) scanned)`;

--- a/server/lsp.js
+++ b/server/lsp.js
@@ -18,6 +18,14 @@ export const toUri = (p) => pathToFileURL(path.resolve(p)).href;
 export const fromUri = (u) => {
   try { return fileURLToPath(u); } catch { return u.replace(/^file:\/\//, ""); }
 };
+// LSP servers disagree on file-uri spelling — clangd/tsserver emit a lowercase, %3A-encoded Windows drive
+// (`file:///g%3A/…`) while ours is `file:///G:/…`. Compare by the DECODED os path with a lowercased Windows
+// drive + forward slashes, so a per-file/diagnostics lookup matches regardless of the spelling.
+export const canonFsPath = (uriOrPath) => {
+  let p; try { p = fromUri(String(uriOrPath).startsWith("file:") ? uriOrPath : toUri(uriOrPath)); } catch { p = String(uriOrPath); }
+  p = p.replace(/\\/g, "/");
+  return /^[a-zA-Z]:/.test(p) ? p[0].toLowerCase() + p.slice(1) : p;
+};
 
 // LSP `textDocument/didOpen` wants a languageId. One backend can serve several extensions
 // (typescript-language-server handles .ts/.tsx/.js/.jsx; pyright handles .py/.pyi), so derive the id
@@ -282,10 +290,12 @@ export class LspClient {
   // first publish if none arrived yet. Returns [] for a clean file (server publishes an empty array). The
   // caller didOpens the file first so the parse is triggered.
   async diagnosticsFor(uriOrPath, timeoutMs = 8000) {
-    const uri = uriOrPath.startsWith("file:") ? uriOrPath : toUri(uriOrPath);
-    if (this.diagnostics.has(uri)) return this.diagnostics.get(uri);
-    const p = await this.waitForNotification("textDocument/publishDiagnostics", timeoutMs, (pp) => pp && pp.uri === uri);
-    return (p && Array.isArray(p.diagnostics) ? p.diagnostics : null) || this.diagnostics.get(uri) || [];
+    const want = canonFsPath(uriOrPath); // match by canonical path — servers spell the uri differently (Win drive case/%3A)
+    for (const [k, ds] of this.diagnostics) if (canonFsPath(k) === want) return ds;
+    const p = await this.waitForNotification("textDocument/publishDiagnostics", timeoutMs, (pp) => { try { return pp && canonFsPath(pp.uri) === want; } catch { return false; } });
+    if (p && Array.isArray(p.diagnostics)) return p.diagnostics;
+    for (const [k, ds] of this.diagnostics) if (canonFsPath(k) === want) return ds;
+    return [];
   }
   hover(uriOrPath, line, character) {
     return this.request("textDocument/hover", {


### PR DESCRIPTION
Self-improve loop on v0.27.0's `diagnostics`: live dogfood against tsserver on Windows found it ALWAYS returned "clean" even on files with blatant type errors. The mock-only eval passed (mock echoed vts's exact uri).

**Root cause**: servers spell file uris differently — tsserver/clangd publish `file:///g%3A/…` (lowercase, `%3A`-encoded Windows drive) vs vts's `file:///G:/…`. `diagnosticsFor` matched with `pp.uri === uri` (exact) → never matched → empty. File + directory scope both affected.

**Fix**: `canonFsPath` (decode → OS path → lowercase Win drive → fwd slashes); `diagnosticsFor` + directory filter compare canonically. **Live-verified**: now reports tsc errors ([2322] etc), file + directory scope.

**Guard**: mock now publishes a server-style uri (lowercase `%3A` drive) so guard 63 exercises the canonical match — a real Windows-CI regression net.

Other tools (goto/find_references/hover) only display uris, never compare → unaffected (live-verified insert_symbol + goto too). 64/64, lint clean.

Bump: `fix:` → **patch (v0.28.1)**.
