### PR TITLE
fix(viz): call hierarchy anchors on the symbol name (async functions traced empty)

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1428,6 +1428,16 @@ const callGraphOk =
   (() => { const t = cg.nodes.find((n) => n.label === "Target"); return t && t.calledBy === 2 && t.calls === 1 && t.weight === 3; })() &&
   cg.totalCallSites >= 4 &&
   cg.nodes.every((n) => typeof n.repo === "string");              // repo grouping: each node tagged with its repository
+// 73b) anchorOnName — a call-hierarchy query must anchor ON the symbol NAME, not workspace/symbol's range
+// start (which can land on a leading `async`/`function` keyword → prepareCallHierarchy returns [] even though
+// references works there; live-found: async functions traced empty). Unit: the name's column is found.
+const { anchorOnName } = await import("../server/core.js");
+const anDir = path.join(os.tmpdir(), `vts-eval-${process.pid}-anchor`); fs.mkdirSync(anDir, { recursive: true });
+const anFile = path.join(anDir, "a.js"); fs.writeFileSync(anFile, "// c\nasync function resolveX(a, b) {\n  return a;\n}\n");
+const anCh = anchorOnName(anFile, 1, "resolveX", 0); // line 1 (0-based) = the async decl; name at col 15
+const anFallback = anchorOnName(anFile, 1, "nope_not_here", 7); // name absent → fallback char
+const anchorOnNameOk = anCh >= 15 && anCh <= 16 && anFallback === 7; // anchors inside "resolveX", not col 0; fallback honored
+try { fs.rmSync(anDir, { recursive: true, force: true }); } catch { /* ignore */ }
 const cgCallers = await buildCallGraph({ symbol: "Target", direction: "callers", projectPath: process.cwd(), backend: "clangd" });
 const cgCallersOk = !cgCallers.error && cgCallers.nodes.some((n) => n.label === "CallerA") && !cgCallers.nodes.some((n) => n.label === "Callee"); // callers-only excludes the callee
 // /callgraph route
@@ -1445,7 +1455,7 @@ const symHttp = await new Promise((res, rej) => { http.get({ host: "127.0.0.1", 
 let symParsed = {}; try { symParsed = JSON.parse(symHttp.body); } catch { /* leave empty */ }
 const symRouteOk = symHttp.status === 200 && Array.isArray(symParsed.symbols) && symParsed.symbols.some((x) => x.name === "SpawnHandler");
 await new Promise((r) => cgSrv.server.close(r));
-const callGraphAllOk = callGraphOk && cgCallersOk && cgRouteOk && lsOk && symRouteOk;
+const callGraphAllOk = callGraphOk && cgCallersOk && cgRouteOk && lsOk && symRouteOk && anchorOnNameOk;
 // guards 66/68/70/73 spawn backends AFTER the teardown above — dispose again so the process exits (no hang).
 await disposeClients();
 

--- a/server/core.js
+++ b/server/core.js
@@ -1044,6 +1044,19 @@ function repoLabelFor(file) {
     return label;
   } catch { return "external"; }
 }
+// Anchor a call-hierarchy query ON the symbol NAME. workspace/symbol's location.range.start can land on a
+// leading keyword (e.g. `async`/`function`) rather than the identifier — textDocument/references tolerates
+// that, but textDocument/prepareCallHierarchy returns [] unless the position is on the name (live-found:
+// `async function X` traced empty while a sync `function Y` worked). Read the resolved line, find the name's
+// column, and anchor a char INTO it; fall back to the given char if the line/name can't be read.
+export function anchorOnName(file, line, name, fallbackChar) {
+  try {
+    const ln = (fs.readFileSync(file, "utf8").split(/\r?\n/)[line] || "");
+    const i = name ? ln.indexOf(String(name)) : -1;
+    if (i >= 0) return i + Math.min(1, String(name).length); // one char inside the identifier
+  } catch { /* unreadable → fallback */ }
+  return fallbackChar;
+}
 async function prepareCallHierReady(c, p, line, ch, capMs = envInt("VTS_CALLHIER_WAIT_MS", 8000)) {
   let items = (await c.prepareCallHierarchy(p, line, ch)) || [];
   if (items.length) return items;
@@ -1084,6 +1097,7 @@ export async function buildCallGraph(a = {}) {
   } else if (a.path && a.line != null && a.character != null) {
     pos = { path: String(a.path), line: Number(a.line), character: Number(a.character) };
   } else { return { error: "needs `symbol` (a name) or `path`+`line`+`character`", nodes: [], links: [] }; }
+  if (a.symbol) pos.character = anchorOnName(pos.path, pos.line, String(a.symbol), pos.character); // anchor ON the name for callHierarchy
   c.didOpen(pos.path, langIdForPath(pos.path, backendName));
   const items = (await prepareCallHierReady(c, pos.path, pos.line, pos.character)).filter(Boolean);
   if (!items.length) return { error: "no call-hierarchy anchor at the symbol (point at a function/method, or the backend may lack callHierarchy)", focus: focusLabel, nodes: [], links: [] };
@@ -1764,6 +1778,7 @@ export async function runTool(name, a = {}) {
       const dirRaw = String(a.direction || "").toLowerCase();
       const traceDir = (dirRaw === "callers" || dirRaw === "incoming") ? "callers" : (dirRaw === "callees" || dirRaw === "outgoing") ? "callees" : null;
       if (traceDir) {
+        if (a.symbol) pos.character = anchorOnName(pos.path, pos.line, String(a.symbol), pos.character); // anchor ON the name for callHierarchy
         c.didOpen(pos.path, langIdForPath(pos.path, backendName));
         const depthMax = Math.max(1, Math.min(Number(a.depth) || 2, envInt("VTS_TRACE_MAX_DEPTH", 5)));
         const nodeCap = Math.min(Number(a.maxResults) || MAX_RESULTS, envInt("VTS_TRACE_MAX_NODES", 80));


### PR DESCRIPTION
Bug in v0.32.0: the call-graph trace returned "no call-hierarchy anchor" for **`async function`** declarations (and any symbol whose workspace/symbol range starts on a leading keyword).

## Cause
buildCallGraph / find_references(direction=) anchored prepareCallHierarchy at workspace/symbol's `range.start`, which can land on the `async`/`function` keyword. `textDocument/references` tolerates that position, but `textDocument/prepareCallHierarchy` returns [] unless the cursor is ON the identifier — so async functions traced empty while sync ones worked.

## Fix
`anchorOnName(file,line,name,fallback)` reads the resolved line, finds the symbol name's column, and anchors a char into the identifier before prepareCallHierarchy (both the MCP `find_references` trace and the dashboard `/callgraph`). Falls back to the resolved char if the line/name can't be read.

## Verify
- Live: `resolveSymbolForEdit` (async) now traces callers (`runTool` <- cli.js, index.js); `recordSavings` (sync) still works.
- eval guard 73b unit-tests `anchorOnName`; 73 guards PASS; lint clean.

Bump: `fix:` -> **patch (v0.32.1)**.
