### PR TITLE
fix(viz): call hierarchy fast-fails on non-callable symbols (no 8s retry burn)

### DIFF
--- a/eval/_mock-lsp.mjs
+++ b/eval/_mock-lsp.mjs
@@ -26,6 +26,9 @@ process.stdin.on("data", (d) => {
       // "MISS" returns no symbols — exercises search_symbol's ts/pyright text-search fallback for a name
       // the workspace/symbol index doesn't surface (e.g. a non-exported local / unopened file).
       if (q === "MISS") { send({ jsonrpc: "2.0", id: msg.id, result: [] }); continue; }
+      // "VARSYM" resolves to a const (kind 14) — a NON-callable symbol, so a call-hierarchy trace must
+      // fail FAST with a clear "not a function/method" message (no prepareCallHierarchy retry burn).
+      if (q === "VARSYM") { send({ jsonrpc: "2.0", id: msg.id, result: [{ name: "VARSYM", kind: 14, location: { uri: "file:///proj/src/V.cpp", range: { start: { line: 3, character: 6 }, end: { line: 3, character: 12 } } } }] }); continue; }
       let result;
       if (q === "ALL") {
         // big result set with verbose container names — to exercise the token cap

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1438,6 +1438,13 @@ const anCh = anchorOnName(anFile, 1, "resolveX", 0); // line 1 (0-based) = the a
 const anFallback = anchorOnName(anFile, 1, "nope_not_here", 7); // name absent → fallback char
 const anchorOnNameOk = anCh >= 15 && anCh <= 16 && anFallback === 7; // anchors inside "resolveX", not col 0; fallback honored
 try { fs.rmSync(anDir, { recursive: true, force: true }); } catch { /* ignore */ }
+// 73c) non-callable kind → call hierarchy fails FAST + clear (not an 8s prepareCallHierarchy retry burn).
+// VARSYM resolves to a const (kind 14); both buildCallGraph and find_references(direction) must reject it.
+const cgVar = await buildCallGraph({ symbol: "VARSYM", direction: "callers", projectPath: process.cwd(), backend: "clangd" });
+const frVar = await runTool("find_references", { symbol: "VARSYM", direction: "callers", projectPath: process.cwd(), backend: "clangd" });
+const nonCallableOk =
+  !!cgVar.error && /not a function\/method\/class/.test(cgVar.error) && cgVar.nodes.length === 0 &&
+  !frVar.isError && /not a function\/method/.test(frVar.text) && /needs a callable/.test(frVar.text);
 const cgCallers = await buildCallGraph({ symbol: "Target", direction: "callers", projectPath: process.cwd(), backend: "clangd" });
 const cgCallersOk = !cgCallers.error && cgCallers.nodes.some((n) => n.label === "CallerA") && !cgCallers.nodes.some((n) => n.label === "Callee"); // callers-only excludes the callee
 // /callgraph route
@@ -1455,7 +1462,7 @@ const symHttp = await new Promise((res, rej) => { http.get({ host: "127.0.0.1", 
 let symParsed = {}; try { symParsed = JSON.parse(symHttp.body); } catch { /* leave empty */ }
 const symRouteOk = symHttp.status === 200 && Array.isArray(symParsed.symbols) && symParsed.symbols.some((x) => x.name === "SpawnHandler");
 await new Promise((r) => cgSrv.server.close(r));
-const callGraphAllOk = callGraphOk && cgCallersOk && cgRouteOk && lsOk && symRouteOk && anchorOnNameOk;
+const callGraphAllOk = callGraphOk && cgCallersOk && cgRouteOk && lsOk && symRouteOk && anchorOnNameOk && nonCallableOk;
 // guards 66/68/70/73 spawn backends AFTER the teardown above — dispose again so the process exits (no hang).
 await disposeClients();
 

--- a/server/core.js
+++ b/server/core.js
@@ -1059,16 +1059,26 @@ export function anchorOnName(file, line, name, fallbackChar) {
 }
 async function prepareCallHierReady(c, p, line, ch, capMs = envInt("VTS_CALLHIER_WAIT_MS", 8000)) {
   let items = (await c.prepareCallHierarchy(p, line, ch)) || [];
-  if (items.length) return items;
+  if (items.length) { c.callHierWarm = true; return items; }
+  // Once this client has EVER produced a hierarchy item, the index is proven warm → an empty result is a
+  // GENUINE "not callable here" (a variable, a non-function position), not index lag. Don't burn the retry
+  // window (live-found: tracing a `const` or an off-function position waited the full 8s before failing).
+  if (c.callHierWarm) return items;
   const t0 = Date.now(); let delay = 400;
   while (Date.now() - t0 < capMs) {
     await sleep(Math.min(delay, Math.max(0, capMs - (Date.now() - t0))));
     items = (await c.prepareCallHierarchy(p, line, ch)) || [];
-    if (items.length) return items;
+    if (items.length) { c.callHierWarm = true; return items; }
     delay = Math.min(Math.round(delay * 1.5), 2000);
   }
   return items;
 }
+// LSP SymbolKinds that can anchor a call hierarchy (have callers/callees): method, ctor, func — plus the
+// type kinds whose ctor is the hook (class/interface/struct). A variable/const/field/property/module/etc.
+// can never produce a hierarchy item, so a by-name trace of one fails FAST with a clear reason instead of
+// burning the retry. (kind from workspace/symbol; null → allow and let prepareCallHierarchy decide.)
+const CALLABLE_KIND = new Set([5, 6, 9, 11, 12, 23]);
+const isCallableKind = (k) => k == null || CALLABLE_KIND.has(k);
 // ON-DEMAND call graph for the dashboard (the comparable-to-codebase-memory-mcp "call graph" view, but the
 // official-LSP way: NO persistent semantic graph DB — we resolve a focused symbol and walk LSP callHierarchy
 // live, returning a {nodes,links} object shaped like the include-graph so the 3D viz renders it the same).
@@ -1092,6 +1102,7 @@ export async function buildCallGraph(a = {}) {
     const want = String(a.symbol);
     const pick = syms.slice().sort((x, y) => (x.name === want ? 0 : 1) - (y.name === want ? 0 : 1))[0];
     if (!pick) return { error: `no indexed declaration for "${want}"`, focus: want, nodes: [], links: [] };
+    if (!isCallableKind(pick.kind)) return { error: `"${want}" is a ${SYMBOL_KIND[pick.kind] || "symbol"}, not a function/method/class — call hierarchy needs a callable symbol.`, focus: want, nodes: [], links: [] };
     pos = { path: fromUri(pick.location.uri), line: pick.location.range.start.line, character: pick.location.range.start.character };
     focusLabel = pick.name;
   } else if (a.path && a.line != null && a.character != null) {
@@ -1739,7 +1750,7 @@ export async function runTool(name, a = {}) {
       // from a NAME, not a 0-based position. Accept `symbol` and resolve the declaration position via the
       // index first (search_symbol → best match → its location), then find references there — so
       // "where is FooBar used" is ONE call, not the locate→position→refs dance that pushes the model to grep.
-      let pos = null, originLabel = "";
+      let pos = null, originLabel = "", pickKind = null;
       if (a.symbol) {
         const persisted = backendName === "clangd" && hasPersistedIndex(root);
         const syms = await symbolReady(c, String(a.symbol), persisted, envInt("VTS_CLANGD_PERSISTED_WAIT_MS", 60000));
@@ -1764,6 +1775,7 @@ export async function runTool(name, a = {}) {
         }
         const pp = fromUri(pick.location.uri);
         pos = { path: pp, line: pick.location.range.start.line, character: pick.location.range.start.character };
+        pickKind = pick.kind;
         c.didOpen(pp, langIdForPath(pp, backendName)); // ensure the resolved TU is open for the references query
         originLabel = `"${want}" (${SYMBOL_KIND[pick.kind] || "sym"} @ ${locLine(pick.location.uri, pick.location.range)})`;
       } else {
@@ -1777,6 +1789,10 @@ export async function runTool(name, a = {}) {
       // "who uses this", reuses the symbol→position resolution above, and adds no fixed tool-surface cost.
       const dirRaw = String(a.direction || "").toLowerCase();
       const traceDir = (dirRaw === "callers" || dirRaw === "incoming") ? "callers" : (dirRaw === "callees" || dirRaw === "outgoing") ? "callees" : null;
+      if (traceDir && a.symbol && !isCallableKind(pickKind)) {
+        // a variable/const/field has no call hierarchy — say so FAST (don't burn the prepareCallHierarchy retry)
+        return finishOut([], backendAdvisory(backendName, root) + `${originLabel} is a ${SYMBOL_KIND[pickKind] || "symbol"}, not a function/method — call hierarchy (direction=${traceDir}) needs a callable. Omit direction for plain references.`);
+      }
       if (traceDir) {
         if (a.symbol) pos.character = anchorOnName(pos.path, pos.line, String(a.symbol), pos.character); // anchor ON the name for callHierarchy
         c.didOpen(pos.path, langIdForPath(pos.path, backendName));


### PR DESCRIPTION
Tree-traversal dogfood found two ways a call-hierarchy trace burned the full 8s retry before failing:

- **Non-callable symbol** (variable/const/field): `prepareCallHierarchy` can never anchor one, but the retry kept trying 8s. A by-name trace now gates on the resolved symbol KIND and returns instantly with a clear message ("X is a const, not a function/method — omit direction for plain references").
- **Non-function position / callee-less node**: `prepareCallHierReady` now tracks a per-client `callHierWarm` flag — once the index has produced any hierarchy item it's proven warm, so a later empty result is a GENUINE miss and returns at once (the retry stays only for a truly cold index = lag).

## Verify (live)
- var trace 8040ms -> **482ms**; bad-position 8077ms -> **140ms**.
- cycles/recursion, depth-clamp, bogus-direction(->plain refs), missing-symbol(->text) all still correct.
- eval guard 73c (non-callable fast-fail); 73 guards PASS; lint clean.

Bump: `fix:` -> **patch (v0.32.2)**.
