### PR TITLE
Release v0.33.0: Semble-inspired result ranking + token cuts

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1560,6 +1560,75 @@ try { fs.rmSync(vizRoot, { recursive: true, force: true }); } catch { /* ignore 
 fs.writeFileSync(GDS, "{}"); // reset so it doesn't leak into any later savings assertion
 const dashboardOk = vizDataOk && htmlSelfContainedOk && serveOk && combinedReportOk;
 
+// 74) result RERANK (Semble-inspired, charter-pure): rankSymbols reorders the OFFICIAL engine's results
+// BEFORE the top-N cap, so the row the model wants survives the cap. Lexical tier (exact > prefix > word/camel
+// boundary > substring) + a callable-kind nudge + a query-history boost (the SAME warmset LFU+recency signal
+// that orders prewarm). STABLE — equal scores keep the LSP's order, so the other guards are unaffected. NO
+// embeddings / NO persistent index / NO transmission (the cbm+Semble rejects) — pure ranking over results vts
+// already holds. The history boost is bounded BELOW the tier gap, so it only breaks near-ties, never flips a
+// clearly-better lexical match.
+const { rankSymbols } = await import("../server/core.js");
+const { fromUri: fromUri74 } = await import("../server/lsp.js");
+const mkSym74 = (name, kind, uri) => ({ name, kind, location: { uri, range: { start: { line: 1, character: 0 } } } });
+const rkSyms = [
+  mkSym74("doGetThing", 12, "file:///r/z.cpp"),   // camel-boundary substring (…Get…)
+  mkSym74("widget",     13, "file:///r/w.cpp"),   // plain substring (wid-GET) + non-callable (var kind 13)
+  mkSym74("GetValue",   12, "file:///r/a.cpp"),   // prefix
+  mkSym74("Get",        12, "file:///r/b.cpp"),   // exact
+  mkSym74("GetData",    12, "file:///r/hot.cpp"), // prefix, history-boosted below
+];
+const rkPlain = rankSymbols("Get", rkSyms, null).map((s) => s.name);
+const hot74 = fromUri74("file:///r/hot.cpp").replace(/\\/g, "/").toLowerCase(); // same key rankSymbols derives
+const rkHist = rankSymbols("Get", rkSyms, new Map([[hot74, 9]])).map((s) => s.name);
+const rkStablePassthrough = rankSymbols("Get", rkSyms.slice(0, 1), null).length === 1; // <2 items → returned as-is
+const rerankOk =
+  rkPlain[0] === "Get" &&                                            // exact match wins
+  rkPlain.indexOf("GetValue") < rkPlain.indexOf("doGetThing") &&     // prefix beats camel-boundary
+  rkPlain.indexOf("doGetThing") < rkPlain.indexOf("widget") &&       // boundary (+callable) beats plain substring (non-callable)
+  rkPlain.indexOf("GetValue") < rkPlain.indexOf("GetData") &&        // equal tier (both prefix+callable) → STABLE original order
+  rkHist.indexOf("GetData") < rkHist.indexOf("GetValue") &&          // history boost flips the near-tie…
+  rkHist[0] === "Get" &&                                             // …but never outranks a clearly-better lexical match
+  rkStablePassthrough;
+
+// 75) MORE-EFFECTIVE token cuts derived from the rerank work (charter-pure: no embeddings / no index / no
+// transmission): (a) CONFIDENCE-ADAPTIVE FOCUS — an exact-name match in a big result tightens the SHOWN rows
+// to exact+few (rest stay in "… N more" + the tee), so "locate one symbol" stops paying for a 60-row tail;
+// (b) LEXICAL CONCEPT SEARCH — a multi-word search_text query is ranked by distinct-term coverage (the
+// feasible slice of the fuzzy gap; semantic-synonym needs embeddings → stays out of charter); (c) READ-
+// AVOIDANCE in the ledger — read_symbol's savings baseline is the WHOLE FILE it replaces (Semble's "combined
+// with file reading"), so the ledger credits the avoided read instead of ~0.
+const { focusCap, conceptTerms } = await import("../server/core.js");
+const mkS75 = (name) => ({ name, kind: 12, location: { uri: `file:///r/${name}.cpp`, range: { start: { line: 1, character: 0 } } } });
+const manySyms = ["GetX", "GetY", "GetZ", "GetW", "GetV", "GetU", "GetT", "Get"].map(mkS75); // 8 (> FOCUS_N 6); one exact "Get"
+const focusUnitOk =
+  focusCap("Get", manySyms, 60) === 6 &&                  // exact match in a big set → trimmed to FOCUS_N
+  focusCap("Nope", manySyms, 60) === 60 &&               // no exact → full cap (browsing keeps everything)
+  focusCap("Get", manySyms.slice(0, 3), 60) === 60 &&    // ≤ FOCUS_N → no trim
+  (() => { process.env.VTS_FOCUS = "0"; const c = focusCap("Get", manySyms, 60); delete process.env.VTS_FOCUS; return c === 60; })(); // toggle off
+const conceptUnitOk =
+  JSON.stringify(conceptTerms("login retry handler")) === JSON.stringify(["login", "retry", "handler"]) &&
+  conceptTerms("Foo") === null &&                         // single token → literal scan, not concept
+  conceptTerms("void.*Foo") === null &&                  // regex metachar → literal
+  conceptTerms("a bb cc") === null;                      // short tokens → not a concept query
+const cpDir75 = path.join(os.tmpdir(), `vts-eval-${process.pid}-concept`);
+fs.mkdirSync(cpDir75, { recursive: true });
+fs.writeFileSync(path.join(cpDir75, "a.cpp"), "void retry();\n");                                              // 1 term
+fs.writeFileSync(path.join(cpDir75, "b.cpp"), "void login_retry_handler() { /* login retry handler */ }\n");  // 3 terms
+const cpRes75 = await runTool("search_text", { q: "login retry handler", projectPath: cpDir75 });
+const conceptIntOk = !cpRes75.isError && /concept \(lexical/.test(cpRes75.text) &&
+  cpRes75.text.indexOf("b.cpp") < cpRes75.text.indexOf("a.cpp"); // higher term-coverage line ranks first
+try { fs.rmSync(cpDir75, { recursive: true, force: true }); } catch { /* ignore */ }
+const raDir = path.join(os.tmpdir(), `vts-eval-${process.pid}-readavoid`);
+fs.mkdirSync(raDir, { recursive: true });
+const raFile = path.join(raDir, "Big.cpp");
+fs.writeFileSync(raFile, "L0\nL1\nL2\nL3\nshort line\n" + "padding ".repeat(2000) + "\n"); // line 4 = the symbol; rest huge
+await runTool("read_symbol", { symbol: "Foo", path: raFile, backend: "clangd" });
+const raLedger = (() => { try { return JSON.parse(fs.readFileSync(SV, "utf8")); } catch { return {}; } })();
+const readAvoidOk = !!(raLedger.tools && raLedger.tools.read_symbol && raLedger.tools.read_symbol.rawTok >= 2000); // whole-file baseline, not the tiny {file,range}
+try { fs.rmSync(raDir, { recursive: true, force: true }); } catch { /* ignore */ }
+const effectiveCutsOk = focusUnitOk && conceptUnitOk && conceptIntOk && readAvoidOk;
+await disposeClients(); // guard 75's read_symbol spawned a backend AFTER the earlier teardown — dispose it so node exits
+
 const rows = [
   ["LSP client handshake + symbol", lspOk, "true", lspOk],
   ["symbol → file:line (no bodies)", fmtOk, "true", fmtOk],
@@ -1635,6 +1704,8 @@ const rows = [
   ["include-graph content-hash (FNV-1a) + mtime+size composite key", contentHashOk, "true", contentHashOk],
   ["dashboard: 3D viz + vendored Three.js route + combined gamedev savings + 127.0.0.1", dashboardOk, "true", dashboardOk],
   ["on-demand call graph + symbol autocomplete: buildCallGraph/listSymbols + /callgraph + /symbols routes", callGraphAllOk, "true", callGraphAllOk],
+  ["result rerank (Semble-inspired, charter-pure): lexical+kind+history, stable, before the cap", rerankOk, "true", rerankOk],
+  ["effective cuts: focus (exact→few) + concept (multi-term rank) + read-avoidance ledger", effectiveCutsOk, "true", effectiveCutsOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/paper/.gitignore
+++ b/paper/.gitignore
@@ -1,0 +1,9 @@
+# LaTeX build artifacts
+*.pdf
+*.aux
+*.log
+*.out
+*.bbl
+*.blg
+*.toc
+*.synctex.gz

--- a/paper/README.md
+++ b/paper/README.md
@@ -1,0 +1,75 @@
+# Paper — vs-token-safer
+
+arXiv-style preprint positioning `vs-token-safer` against the
+persistent-knowledge-graph approach of *Codebase-Memory* (arXiv:2603.27277).
+Author: **Sungmin Jeon** <sungmin1505104@gmail.com>.
+
+## Files
+
+| File | What |
+| --- | --- |
+| `vs-token-safer.tex` | English version (self-contained, inline bibliography) |
+| `vs-token-safer.ko.tex` | Korean version (xeCJK + Malgun Gothic) |
+| `vs-token-safer.pdf` / `.ko.pdf` | built PDFs |
+| `figures/*.svg` | source figures (architecture pipeline, per-tool savings) |
+| `figures/*.pdf` | figures converted for `\includegraphics` |
+| `figures/build.py` | SVG → PDF converter (pure-python svglib, no cairo) |
+
+## Build
+
+```bash
+# figures first (only if you edited the .svg)
+pip install svglib
+python figures/build.py
+
+# then the papers (tectonic auto-selects XeTeX for the Korean one)
+tectonic vs-token-safer.tex
+tectonic vs-token-safer.ko.tex
+```
+
+Both compile clean: 0 overfull boxes, 0 undefined references/citations.
+The Korean version uses **`kotex`** (xetexko) for correct Korean word-spacing and
+line-breaking — plain `xeCJK` + `\sloppy` stretched the spaces and made it hard to
+read, so we switched. It needs the **Malgun Gothic** font (ships with Windows
+10/11); on Linux/macOS swap `\setmainhangulfont{Malgun Gothic}` for an installed
+Korean font (e.g. `Noto Serif CJK KR`).
+
+## Toolchain installed for this paper
+
+- **tectonic 0.16.9** (scoop) — self-contained LaTeX engine (auto-fetches packages).
+- **svglib + reportlab** (pip) — SVG → vector-PDF, pure-python (cairosvg fails on
+  Windows for lack of a native cairo DLL; svglib does not need it).
+- **MCP servers** registered at user scope (`claude mcp add`, active next session):
+  - `arxiv-latex` (`arxiv-latex-mcp`) — fetch a reference paper's true LaTeX/math.
+  - `paper-search` (`python -m paper_search_mcp.server`) — search/verify citations
+    across arXiv, PubMed, bioRxiv.
+
+## Provenance / honesty notes
+
+- **Critic pass done.** An independent audit cross-checked every quantitative and
+  behavioral claim against the live code/ledger. All headline numbers reproduce
+  (441 searches · ~130,251 tokens · 263,540→133,289 · peak 21,056→1,961 · 74
+  guards · depth 5 / 80 nodes · MAX_BACKENDS 2 · zero network calls outside the
+  loopback dashboard + vendored Three.js). One rounding fix applied: cold-query
+  cap is **1,433** tokens (harness output), not 1,434.
+- **Tool surface** stated precisely: 13 first-class MCP tools + one `vts_admin`
+  folding 9 admin ops.
+- **Evaluation framing is observational**, not a controlled A/B benchmark — the
+  draft says so. The §"combined savings" note deliberately refuses to quote the
+  bundled log-compaction total (the ledger value is degenerate); only the
+  code-search ledger (Table 1) is a result.
+- Numbers are as of v0.32.2; re-run `vts savings` + `node eval/run.mjs` and
+  rebuild before submission if stale.
+- No real company/project paths or symbols appear (charter rule). Synthetic names
+  only.
+- Both versions were written for natural readability (humanized prose: varied
+  rhythm, reduced formulaic transitions and em-dash chains); the Korean avoids
+  translationese (no excessive passives / inanimate subjects).
+
+## Next
+
+1. Use the now-registered `paper-search` MCP to verify each bibliography entry and
+   add proper citations for the Related Work claims.
+2. Push to Overleaf for co-editing / final typesetting.
+3. Run the controlled grep-vs-vts benchmark described in §9 to promote the
+   observational numbers to experimental ones.

--- a/paper/figures/architecture.svg
+++ b/paper/figures/architecture.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="940" height="360" viewBox="0 0 940 360" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 z" fill="#334155"/>
+    </marker>
+    <style>
+      .box   { fill:#f1f5f9; stroke:#334155; stroke-width:1.5; rx:8; }
+      .acc   { fill:#dbeafe; stroke:#1d4ed8; stroke-width:1.5; rx:8; }
+      .eng   { fill:#dcfce7; stroke:#15803d; stroke-width:1.5; rx:8; }
+      .out   { fill:#fef9c3; stroke:#a16207; stroke-width:1.5; rx:8; }
+      .t     { font-size:13px; fill:#0f172a; text-anchor:middle; }
+      .ts    { font-size:11px; fill:#475569; text-anchor:middle; }
+      .lab   { font-size:12px; fill:#334155; text-anchor:middle; }
+      .edge  { stroke:#334155; stroke-width:1.5; fill:none; marker-end:url(#arrow); }
+      .title { font-size:15px; fill:#0f172a; font-weight:bold; text-anchor:middle; }
+    </style>
+  </defs>
+
+  <text x="470" y="28" class="title">vs-token-safer: enforced, capped, zero-transmission data path</text>
+
+  <!-- inputs -->
+  <rect class="box" x="20"  y="70"  width="150" height="58" rx="8"/>
+  <text x="95" y="94" class="t">Agent tool call</text>
+  <text x="95" y="112" class="ts">search / nav / edit</text>
+
+  <rect class="box" x="20"  y="150" width="150" height="58" rx="8"/>
+  <text x="95" y="174" class="t">Bash grep / Grep</text>
+  <text x="95" y="192" class="ts">rewritten by hook</text>
+
+  <!-- hook -->
+  <rect class="acc" x="210" y="150" width="150" height="58" rx="8"/>
+  <text x="285" y="174" class="t">PreToolUse hook</text>
+  <text x="285" y="192" class="ts">rewrite / block / warn</text>
+
+  <!-- dispatch -->
+  <rect class="acc" x="400" y="108" width="150" height="62" rx="8"/>
+  <text x="475" y="133" class="t">runTool()</text>
+  <text x="475" y="151" class="ts">dispatch + per-call root</text>
+
+  <!-- lsp client -->
+  <rect class="acc" x="400" y="200" width="150" height="62" rx="8"/>
+  <text x="475" y="225" class="t">generic LSP client</text>
+  <text x="475" y="243" class="ts">JSON-RPC / stdio</text>
+
+  <!-- engines -->
+  <rect class="eng" x="590" y="78"  width="160" height="44" rx="8"/>
+  <text x="670" y="105" class="t">clangd (C/C++)</text>
+  <rect class="eng" x="590" y="130" width="160" height="44" rx="8"/>
+  <text x="670" y="157" class="t">Roslyn (C#)</text>
+  <rect class="eng" x="590" y="182" width="160" height="44" rx="8"/>
+  <text x="670" y="209" class="t">tsserver (JS/TS)</text>
+  <rect class="eng" x="590" y="234" width="160" height="44" rx="8"/>
+  <text x="670" y="261" class="t">pyright (Python)</text>
+  <text x="670" y="298" class="lab">official engines — our glue only</text>
+
+  <!-- token cap + output -->
+  <rect class="out" x="790" y="108" width="130" height="62" rx="8"/>
+  <text x="855" y="133" class="t">token-cap</text>
+  <text x="855" y="151" class="ts">formatter</text>
+
+  <rect class="out" x="790" y="200" width="130" height="62" rx="8"/>
+  <text x="855" y="225" class="t">file:line</text>
+  <text x="855" y="243" class="ts">no bodies</text>
+
+  <!-- edges -->
+  <path class="edge" d="M170,99  L398,128"/>
+  <path class="edge" d="M170,179 L208,179"/>
+  <path class="edge" d="M360,179 L398,150"/>
+  <path class="edge" d="M550,139 L588,120"/>
+  <path class="edge" d="M550,231 L588,210"/>
+  <path class="edge" d="M475,170 L475,198"/>
+  <path class="edge" d="M750,150 L788,139"/>
+  <path class="edge" d="M855,170 L855,198"/>
+  <path class="edge" d="M790,231 L555,231"/>
+</svg>

--- a/paper/figures/build.py
+++ b/paper/figures/build.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Convert every figures/*.svg to a vector PDF for LaTeX \includegraphics.
+
+Pure-Python (svglib + reportlab) — no native cairo/inkscape needed on Windows.
+  pip install svglib
+  python build.py
+"""
+import glob
+import os
+
+from reportlab.graphics import renderPDF
+from svglib.svglib import svg2rlg
+
+here = os.path.dirname(os.path.abspath(__file__))
+for svg in sorted(glob.glob(os.path.join(here, "*.svg"))):
+    pdf = os.path.splitext(svg)[0] + ".pdf"
+    renderPDF.drawToFile(svg2rlg(svg), pdf)
+    print("wrote", os.path.basename(pdf))

--- a/paper/figures/layers.svg
+++ b/paper/figures/layers.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="560" viewBox="0 0 900 560" font-family="Helvetica, Arial, sans-serif">
+  <style>
+    .title { font-size:16px; fill:#0f172a; font-weight:bold; text-anchor:middle; }
+    .ltitle{ font-size:13px; fill:#0f172a; font-weight:bold; }
+    .comp  { font-size:12px; fill:#0f172a; text-anchor:middle; }
+    .sub   { font-size:10px; fill:#475569; text-anchor:middle; }
+    .side  { font-size:11px; fill:#7c2d12; text-anchor:middle; font-weight:bold; }
+    .sidet { font-size:9.5px; fill:#7c2d12; text-anchor:middle; }
+    .arrow { stroke:#334155; stroke-width:1.4; fill:none; marker-end:url(#a); }
+  </style>
+  <defs>
+    <marker id="a" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 z" fill="#334155"/></marker>
+  </defs>
+
+  <text x="360" y="30" class="title">vs-token-safer — layered structure</text>
+
+  <!-- Layer 1: Surface -->
+  <rect x="30" y="50" width="660" height="92" rx="10" fill="#dbeafe" stroke="#1d4ed8" stroke-width="1.5"/>
+  <text x="44" y="70" class="ltitle">Surface (agent-facing)</text>
+  <rect x="48"  y="80" width="190" height="50" rx="7" fill="#ffffff" stroke="#1d4ed8"/>
+  <text x="143" y="100" class="comp">MCP server</text>
+  <text x="143" y="116" class="sub">13 tools + vts_admin (×9)</text>
+  <rect x="252" y="80" width="180" height="50" rx="7" fill="#ffffff" stroke="#1d4ed8"/>
+  <text x="342" y="100" class="comp">vts CLI</text>
+  <text x="342" y="116" class="sub">same ops, shell</text>
+  <rect x="446" y="80" width="226" height="50" rx="7" fill="#ffffff" stroke="#1d4ed8"/>
+  <text x="559" y="100" class="comp">Hooks (PreToolUse)</text>
+  <text x="559" y="116" class="sub">grep-block rewrite · edit-steer</text>
+
+  <!-- Layer 2: Core -->
+  <rect x="30" y="162" width="660" height="92" rx="10" fill="#e0e7ff" stroke="#4338ca" stroke-width="1.5"/>
+  <text x="44" y="182" class="ltitle">Core / dispatch</text>
+  <rect x="48"  y="192" width="150" height="50" rx="7" fill="#ffffff" stroke="#4338ca"/>
+  <text x="123" y="212" class="comp">runTool()</text>
+  <text x="123" y="228" class="sub">dispatch</text>
+  <rect x="212" y="192" width="150" height="50" rx="7" fill="#ffffff" stroke="#4338ca"/>
+  <text x="287" y="212" class="comp">token-cap</text>
+  <text x="287" y="228" class="sub">formatters</text>
+  <rect x="376" y="192" width="150" height="50" rx="7" fill="#ffffff" stroke="#4338ca"/>
+  <text x="451" y="212" class="comp">savings ledger</text>
+  <text x="451" y="228" class="sub">raw→capped delta</text>
+  <rect x="540" y="192" width="132" height="50" rx="7" fill="#ffffff" stroke="#4338ca"/>
+  <text x="606" y="212" class="comp">resolveRoot</text>
+  <text x="606" y="228" class="sub">per-call root</text>
+
+  <!-- Layer 3: Index glue -->
+  <rect x="30" y="274" width="660" height="92" rx="10" fill="#dcfce7" stroke="#15803d" stroke-width="1.5"/>
+  <text x="44" y="294" class="ltitle">Index glue (ours — the one careful piece)</text>
+  <rect x="48"  y="304" width="220" height="50" rx="7" fill="#ffffff" stroke="#15803d"/>
+  <text x="158" y="324" class="comp">generic LSP client</text>
+  <text x="158" y="340" class="sub">JSON-RPC/stdio · didOpen/Change/Close</text>
+  <rect x="282" y="304" width="190" height="50" rx="7" fill="#ffffff" stroke="#15803d"/>
+  <text x="377" y="324" class="comp">warmset / prewarm</text>
+  <text x="377" y="340" class="sub">history · FNV-1a cache</text>
+  <rect x="486" y="304" width="186" height="50" rx="7" fill="#ffffff" stroke="#15803d"/>
+  <text x="579" y="324" class="comp">backend pool</text>
+  <text x="579" y="340" class="sub">LRU · pickBackend</text>
+
+  <!-- Layer 4: Engines -->
+  <rect x="30" y="386" width="660" height="92" rx="10" fill="#fef9c3" stroke="#a16207" stroke-width="1.5"/>
+  <text x="44" y="406" class="ltitle">Official engines (reused, never reimplemented)</text>
+  <rect x="48"  y="416" width="150" height="50" rx="7" fill="#ffffff" stroke="#a16207"/>
+  <text x="123" y="440" class="comp">clangd</text><text x="123" y="455" class="sub">C/C++</text>
+  <rect x="212" y="416" width="150" height="50" rx="7" fill="#ffffff" stroke="#a16207"/>
+  <text x="287" y="440" class="comp">Roslyn</text><text x="287" y="455" class="sub">C#</text>
+  <rect x="376" y="416" width="150" height="50" rx="7" fill="#ffffff" stroke="#a16207"/>
+  <text x="451" y="440" class="comp">tsserver</text><text x="451" y="455" class="sub">JS/TS</text>
+  <rect x="540" y="416" width="132" height="50" rx="7" fill="#ffffff" stroke="#a16207"/>
+  <text x="606" y="440" class="comp">pyright</text><text x="606" y="455" class="sub">Python</text>
+
+  <!-- flow arrows between layers -->
+  <path class="arrow" d="M360,142 L360,160"/>
+  <path class="arrow" d="M360,254 L360,272"/>
+  <path class="arrow" d="M360,366 L360,384"/>
+  <text x="378" y="156" class="sub" text-anchor="start">tool call</text>
+  <text x="378" y="268" class="sub" text-anchor="start">capped result ↑ / query ↓</text>
+  <text x="378" y="380" class="sub" text-anchor="start">LSP request ↓ / file:line ↑</text>
+
+  <!-- cross-cutting invariant rail -->
+  <rect x="710" y="50" width="160" height="428" rx="10" fill="#fee2e2" stroke="#b91c1c" stroke-width="1.5"/>
+  <text x="790" y="74" class="side">Invariants</text>
+  <text x="790" y="96" class="side">(every layer)</text>
+  <line x1="724" y1="110" x2="856" y2="110" stroke="#b91c1c" stroke-width="0.8"/>
+  <text x="790" y="140" class="sidet">P1 official engine,</text>
+  <text x="790" y="153" class="sidet">our glue only</text>
+  <text x="790" y="185" class="sidet">P2 token-first:</text>
+  <text x="790" y="198" class="sidet">file:line, capped,</text>
+  <text x="790" y="211" class="sidet">no bodies</text>
+  <text x="790" y="243" class="sidet">P3 local-only,</text>
+  <text x="790" y="256" class="sidet">zero-transmission</text>
+  <text x="790" y="269" class="sidet">(no network)</text>
+  <text x="790" y="301" class="sidet">P4 enforced,</text>
+  <text x="790" y="314" class="sidet">not optional</text>
+  <line x1="724" y1="340" x2="856" y2="340" stroke="#b91c1c" stroke-width="0.8"/>
+  <text x="790" y="366" class="sidet">checked by the</text>
+  <text x="790" y="379" class="sidet">74-guard eval</text>
+  <text x="790" y="392" class="sidet">harness</text>
+</svg>

--- a/paper/figures/savings.svg
+++ b/paper/figures/savings.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="780" height="320" viewBox="0 0 780 320" font-family="Helvetica, Arial, sans-serif">
+  <style>
+    .title { font-size:15px; fill:#0f172a; font-weight:bold; }
+    .lab   { font-size:13px; fill:#0f172a; text-anchor:end; }
+    .val   { font-size:12px; fill:#334155; }
+    .ax    { stroke:#94a3b8; stroke-width:1; }
+    .axlab { font-size:11px; fill:#64748b; text-anchor:middle; }
+    .bar   { fill:#2563eb; }
+    .bar2  { fill:#60a5fa; }
+  </style>
+
+  <text x="20" y="28" class="title">Per-tool token savings (local ledger, 441 searches)</text>
+
+  <!-- x grid -->
+  <g>
+    <line class="ax" x1="170" y1="60" x2="170" y2="270"/>
+    <line class="ax" x1="312" y1="60" x2="312" y2="270" stroke-dasharray="3,3"/>
+    <line class="ax" x1="454" y1="60" x2="454" y2="270" stroke-dasharray="3,3"/>
+    <line class="ax" x1="596" y1="60" x2="596" y2="270" stroke-dasharray="3,3"/>
+    <line class="ax" x1="738" y1="60" x2="738" y2="270" stroke-dasharray="3,3"/>
+    <text x="170" y="288" class="axlab">0</text>
+    <text x="312" y="288" class="axlab">20k</text>
+    <text x="454" y="288" class="axlab">40k</text>
+    <text x="596" y="288" class="axlab">60k</text>
+    <text x="738" y="288" class="axlab">80k</text>
+    <text x="454" y="306" class="axlab">tokens saved vs. forwarding the raw index response</text>
+  </g>
+
+  <!-- bars: scale 142px per 20k tokens => 0.0071 px/token -->
+  <!-- document_symbols 84,354 -->
+  <rect class="bar" x="170" y="72"  width="599" height="26"/>
+  <text x="162" y="90"  class="lab">document_symbols</text>
+  <text x="585" y="90"  class="val" fill="#ffffff" text-anchor="end">~84,354  (10 runs)</text>
+
+  <!-- search_text 30,308 -->
+  <rect class="bar" x="170" y="110" width="215" height="26"/>
+  <text x="162" y="128" class="lab">search_text</text>
+  <text x="393" y="128" class="val">~30,308  (246)</text>
+
+  <!-- search_symbol 9,122 -->
+  <rect class="bar2" x="170" y="148" width="65" height="26"/>
+  <text x="162" y="166" class="lab">search_symbol</text>
+  <text x="243" y="166" class="val">~9,122  (32)</text>
+
+  <!-- find_references 2,617 -->
+  <rect class="bar2" x="170" y="186" width="19" height="26"/>
+  <text x="162" y="204" class="lab">find_references</text>
+  <text x="197" y="204" class="val">~2,617  (29)</text>
+
+  <!-- insert_symbol 2,313 -->
+  <rect class="bar2" x="170" y="224" width="16" height="26"/>
+  <text x="162" y="242" class="lab">insert_symbol</text>
+  <text x="194" y="242" class="val">~2,313  (5)</text>
+
+  <text x="170" y="268" class="val" font-weight="bold">total ~130,251 tokens  ·  raw 263,540 → capped 133,289  (~2x)  ·  peak single query 21,056 → 1,961 (10.7x)</text>
+</svg>

--- a/paper/vs-token-safer.ko.tex
+++ b/paper/vs-token-safer.ko.tex
@@ -1,0 +1,548 @@
+\documentclass[11pt]{article}
+
+% ============================================================================
+%  토큰-세이퍼 (한국어판). 빌드: tectonic vs-token-safer.ko.tex
+%  한국어 조판은 kotex(xetexko) — 어절 띄어쓰기/줄바꿈을 한국어 규칙대로 처리.
+%  도표: figures/*.pdf  (python figures/build.py 로 SVG에서 재생성)
+% ============================================================================
+
+\usepackage{kotex}
+\setmainhangulfont{Malgun Gothic}
+\setsanshangulfont{Malgun Gothic}
+\usepackage{microtype}
+\usepackage[margin=1in]{geometry}
+\usepackage{amsmath,amssymb}
+\usepackage{booktabs}
+\usepackage{graphicx}
+\usepackage{xcolor}
+\usepackage{hyperref}
+\usepackage{url}
+\hypersetup{colorlinks=true, linkcolor=blue!55!black, citecolor=blue!55!black, urlcolor=blue!55!black}
+\linespread{1.08}
+% 한국어는 \sloppy를 쓰지 않는다(어절 간격이 과도하게 늘어남). 약한 신축만 허용한다.
+\setlength{\emergencystretch}{1em}
+
+\title{\textbf{토큰-세이퍼: LLM 코딩 에이전트를 위한, grep 대신 공식 언어 서버\\
+인덱스를 강제하는 무전송·토큰캡 코드 검색}}
+
+\author{
+  전성민 (Sungmin Jeon)\\
+  \texttt{sungmin1505104@gmail.com}
+}
+\date{2026년 6월}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+코딩 에이전트는 저장소를 도구 호출로 읽으며, 그 결과는 모두 모델이 추론에 사용하는 동일한
+컨텍스트 창을 점유한다. 일반적인 도구는 \texttt{grep}이고, 그 출력은 전체가 그대로 삽입된다.
+
+이 방식은 구현은 쉽지만 소비는 비효율적이다. 텍스트 검색은 함수와 같은 이름의 변수, 주석을
+구분하지 못하므로 모델이 읽고 폐기해야 하는 결과까지 함께 반환한다. 또한 그 비용은 답의
+크기가 아니라 일치한 줄 수에 비례하여 증가한다.
+
+본 논문은 로컬 전용 Model Context Protocol(MCP) 서버이자 명령줄 도구인
+\textbf{vs-token-safer}(\texttt{vts})를 제안한다. \texttt{vts}는 자체 인덱스를 구축하는
+대신 검색마다 \emph{공식} 언어 서버 --- clangd, Roslyn 서버,
+\texttt{typescript-language-server}, pyright --- 로 질의를 전달한다. 모든 답은 본문 없는
+간결한 \texttt{file:line} 목록으로 토큰캡된다. 그리고 \texttt{grep} 호출을 훅 계층에서 동일
+의미의 캡 호출로 재작성하여 대체를 강제한다.
+
+저장, 임베딩, 네트워크 전송은 일어나지 않는다. 74개 검사 하버스와 수 개월의 단일 개발자
+사용 데이터에서, 캡 출력은 원시 인덱스 응답보다 약 $2\times$, 가장 무거운 질의에서는 최대
+$10.7\times$ 작았다. 강제 계층은 대형 게임 엔진 트리에서 월 수십만 토큰 규모의 잠재적
+\texttt{grep} 트래픽을 흡수하였다. 탐색·참조·이름변경 작업에서 \texttt{vts}는 \texttt{grep}의
+더 안전하고 저렴한 대체재이다. 어휘 검색이 여전히 더 적합한 영역도 함께 제시한다.
+\end{abstract}
+
+\section{서론}
+\label{sec:intro}
+
+에이전트가 낯선 저장소를 열면 가장 먼저 수행하는 작업은 검색이다. 세 질문이 지배적이다.
+\texttt{X}가 어디에 정의되는가, 무엇이 \texttt{Y}를 호출하는가, \texttt{Z}는 어디에서 사용되는가.
+
+오늘날 대부분의 에이전트는 세 질문 모두를 \texttt{grep}으로 답하고, 결과를 컨텍스트에 그대로
+삽입한다.
+
+이 방식은 편리하지만 두 비용을 동반한다. 첫째는 정밀도이다. 텍스트 검색은 주석과 문자열
+리터럴의 일치, 부분 문자열을 공유하는 무관한 식별자, 질의하지 않은 오버로드까지 모두 반환한다.
+모델은 이를 읽는 데 토큰을, 폐기하는 데 주의를 소모한다.
+
+둘째는 분량이다. grep 결과의 토큰 수는 답의 크기가 아니라 일치한 줄 수와 함께 전달된 맥락에
+비례한다. ``어디에 있는가''라는 질문의 답은 짧은 위치 목록에 불과하다.
+
+언어 서버는 정밀도 문제를 이미 해결한다. LSP(Language Server Protocol)는 정의, 참조, 문서·
+작업공간 심볼, 호출 계층, 이름변경 같은 시맨틱 연산을 실제 파서와 타입 해석기 위에서 제공한다.
+따라서 참조 질의는 텍스트상 유사어가 아니라 실제 참조 지점을 반환한다.
+
+보고된 결과도 동일한 결론을 가리킨다. 이름변경·타입검사·호출체인 작업에는 LSP가 적합한
+백엔드이며, grep으로 약 2천 토큰이 드는 조회가 LSP에서는 약 5백 토큰에 종료된다
+~\cite{lsp-medium,semble-hn}. Anthropic은 2025년 말 Claude Code에 네이티브 LSP 지원을
+추가하였다~\cite{anthropic-lsp}.
+
+남은 문제는 둘이다. 에이전트가 인덱스를 단지 제공받는 데 그치지 않고 \emph{사용하도록} 만드는
+방법, 그리고 인덱스에서 모델 컨텍스트로 무엇을 전달할 것인가이다. 본 논문은 두 문제 모두에
+명확한 입장을 취하며, 이를 세 약속으로 정리한다.
+
+\begin{enumerate}
+  \item \textbf{공식 엔진을 재사용하고 접착부만 구현한다.} C++·C\#·TypeScript·Python의
+  정확한 인덱싱은 어려운 작업이며, clangd·Roslyn·\texttt{tsserver}·pyright가 이를 이미
+  수행한다. 토큰 절감 도구는 얇은 LSP-MCP 어댑터여야 한다. 파서 재구현도, 타인의 소스 위에
+  얹은 제3자 인덱스도 아니다.
+
+  \item \textbf{질문만이 아니라 답을 캡한다.} 절감은 시맨틱 질의를 던지는 것만큼이나 본문을
+  반환하지 \emph{않는} 데서 발생한다. 모든 답은 중복이 제거되고 디렉터리 접두사가 추출된
+  \texttt{file:line} 목록이므로, grep-붙여넣기보다 적은 소스가 모델에 도달한다. 프라이버시와
+  토큰이 함께 개선된다.
+
+  \item \textbf{대체를 제안이 아니라 강제한다.} 더 나은 도구를 \emph{사용할 수 있는}
+  에이전트도 습관적으로 \texttt{grep}을 호출한다. 본 연구는 안전한 단일 \texttt{grep} 호출을
+  사전 훅에서 동일 의미의 캡 호출로 재작성하며, 에이전트의 흐름은 유지한 채 우회만 제거한다.
+\end{enumerate}
+
+\paragraph{기여.}
+본 논문의 기여는 다음과 같다. (i) 공식 언어 서버 넷을 하나의 캡·호출별 루트 도구 표면 뒤에
+두는 얇은 LSP-MCP 어댑터(절~\ref{sec:arch}). (ii) 위치만 반환하고 파일별로 묶어 접두사를
+추출하는 출력 압축 기법으로, 원시 인덱스 응답 대비 약 $2\times$, 최악 질의에서 $10.7\times$로
+측정된다(절~\ref{sec:cap}, \ref{sec:eval}). (iii) grep을 동일 의미의 캡 호출로 재작성하고
+grep 습관과 ``선언 전체 편집'' 습관을 정량화·유도하는 훅 계층(절~\ref{sec:enforce}). (iv)
+재현 가능한 74개 검사 하버스와, 실제 프로젝트에서 수행한 clangd·Roslyn·\texttt{tsserver}·
+pyright 라이브 검증(절~\ref{sec:eval}).
+
+\paragraph{대비되는 설계.}
+\emph{Codebase-Memory}~\cite{cbm}는 동일한 토큰 문제를 정반대 방향에서 접근한다. 66개
+언어에 걸친 \emph{영속} Tree-Sitter 지식 그래프를 구축하고, 선택적 임베딩 벡터 검색과 로컬
+시각화를 추가한다. \texttt{vts}는 그 선택을 각각 반전한다. 저장된 그래프 대신 주문형 공식-LSP
+질의, 직접 구현한 파서 대신 컴파일러급 엔진, 임베딩 대신 무전송 원칙이다. 이 대비가 본 논문의
+나머지를 구성한다(절~\ref{sec:related}).
+
+\section{배경과 관련 연구}
+\label{sec:related}
+
+\paragraph{검색의 중추로서의 grep.}
+어휘 검색이 기본 도구인 데에는 타당한 이유가 있다. 빌드가 필요 없고, 파일 형식을 가리지
+않으며, 모든 텍스트를 검색한다. 이는 낯선 트리에 막 진입한 에이전트가 요구하는 특성이다
+~\cite{yage-grep}.
+
+약점 또한 분명하다. 어휘 검색은 심볼과 부분 문자열을 구분하지 못하고, 출력을 관련성으로
+제한하는 장치가 없다~\cite{lsp-medium}. Semble 같은 최신 에이전트 검색 도구는 구조화·중복
+제거된 결과를 반환하여 grep 대비 최대 $98\%$ 토큰 절감을 보고한다~\cite{semble-hn}. 본
+연구는 grep을 그대로 전달할 것이 아니라 제한하고 보완해야 한다는 교훈을 취한다.
+
+\paragraph{에이전트를 위한 LSP.}
+LSP를 코딩 에이전트에 연결하여 텍스트 매칭 대신 시맨틱 탐색과 실시간 진단을 제공하려는 연구가
+증가하고 있다~\cite{lsp-medium,anthropic-lsp,hyperagent}. \texttt{vts}는 그 계열에 속하되
+강조점이 다르다. \texttt{vts}는 LSP 클라이언트일 뿐 아니라 단단한 출력 캡을 갖춘 강제기이며,
+선택적 도구 집합이 아니라 grep을 대체하는 훅을 포함한 드롭인 MCP 플러그인으로 제공된다.
+
+\paragraph{왜 자체 인덱스를 구축하지 않았는가.}
+명백한 대안은 Codebase-Memory~\cite{cbm}처럼 시맨틱 인덱스를 직접 구축하는 것이다.
+Codebase-Memory는 자체 타입 해석기와 선택적 임베딩을 갖춘 Tree-Sitter 그래프를 저장하고,
+31개 저장소에서 양호한 절감을 보고한다. 유능한 설계이다. 그러나 본 연구는 반대 방향을 택하였다.
+이유는 셋이다.
+
+첫째, 저장된 그래프는 진실의 두 번째 사본이다. 소스와 어긋나며, 무효화와 재구축이 필요하다.
+
+둘째, 직접 구현한 파서는 두 번째 구현이다. 프로젝트가 실제로 사용하는 컴파일러와 어긋날 수
+있으며, 그 경우 에이전트는 빌드와 다른 답을 받는다.
+
+셋째, 임베딩은 데이터가 저장·전송될 표면을 추가하므로, 본 연구가 지키려는 무전송 원칙을
+위배한다.
+
+따라서 \texttt{vts}는 시맨틱 데이터베이스를 저장하지 않고, 모든 시맨틱 질의를 빌드 자신의
+컴파일러 프런트엔드에 위임하며, 아무것도 전송하지 않는다. 다만 주문형 호출 그래프와 콘텐츠
+해시 무효화라는 두 아이디어는 그 연구에서 차용하되, 저장된 그래프가 아니라 일시적 LSP 질의와
+작은 로컬 캐시로 구현한다(절~\ref{sec:beyond}).
+
+\section{설계 원칙}
+\label{sec:principles}
+
+네 불변식이 \texttt{vts}를 규율하며, 각각을 회귀 하버스가 검사한다(절~\ref{sec:eval}).
+
+\begin{description}
+  \item[P1 --- 공식 엔진, 우리 접착부.] 분석은 clangd(LLVM)와 Roslyn 기반 서버(Microsoft)가
+  수행하고, 본 연구는 LSP-MCP 어댑터만 구현한다. 소스 위에 제3자 MCP 서버를 재사용하지 않으며,
+  파서를 재구현하지 않는다.
+
+  \item[P2 --- 토큰 우선.] 모든 기능은 토큰 이득을 유지하거나 향상시켜야 한다. 출력은
+  \texttt{file:line}, 캡, 본문 없음이며, 새 기능은 출력이 캡을 유지함을 보장하는 하버스 검사와
+  함께만 도입된다.
+
+  \item[P3 --- 로컬 전용, 무전송.] 네트워크 호출이 없으며, 임베딩·업로드·보고가 없다. 캡이
+  본문이 아니라 위치를 반환하므로 grep-붙여넣기보다 적은 소스가 모델에 도달한다. 프라이버시
+  논거와 토큰 논거가 일치한다.
+
+  \item[P4 --- 선택이 아닌 강제.] 호출을 잊은 더 나은 도구는 아무것도 절약하지 못한다. 대체는
+  grep 호출을 동일 의미의 캡 호출로 재작성하여 훅에서 강제하며, 재작성이 안전하지 않을 때는
+  점진적으로 후퇴한다.
+\end{description}
+
+\section{시스템 아키텍처}
+\label{sec:arch}
+
+\texttt{vts}는 하나의 코어 위에 세 얼굴을 제공한다. MCP 서버는 작고 고정된 도구 집합을
+에이전트에 노출한다. 일급 도구 13개와, 잘 쓰이지 않는 관리 연산 9개를 접은 단일
+\texttt{vts\_admin} 도구로 구성된다. \texttt{vts} CLI는 동일한 연산을 셸에 노출한다. 훅
+집합은 grep 계열 호출을 가로채 재작성한다.
+
+그림~\ref{fig:layers}은 구성 요소의 적층을, 그림~\ref{fig:arch}은 단일 요청의 경로를 보인다.
+
+\begin{figure}[h]
+\centering
+\includegraphics[width=0.96\linewidth]{figures/layers.pdf}
+\caption{에이전트 표면부터 공식 엔진까지의 네 계층과, 모든 계층이 준수해야 하고 하버스가
+검사하는 네 불변식(P1--P4). 본 연구가 구현하는 계층은 인덱스 접착부뿐이며, 엔진은 그대로
+재사용한다.}
+\label{fig:layers}
+\end{figure}
+
+\begin{figure}[h]
+\centering
+\includegraphics[width=\linewidth]{figures/architecture.pdf}
+\caption{요청 경로. 도구 호출과 재작성된 grep은 단일 \texttt{runTool} 디스패치로 진입하고,
+디스패치는 대상 파일의 공식 언어 서버 위로 범용 LSP 클라이언트를 구동한다. 포매터는 답을
+\texttt{file:line} 목록으로 캡한 뒤 모델에 전달한다. 어떤 것도 호스트를 떠나지 않는다.}
+\label{fig:arch}
+\end{figure}
+
+\subsection{범용 LSP 클라이언트}
+유일하게 새롭고 섬세한 부품은 범용 JSON-RPC/stdio LSP 클라이언트이다. 두 동작이 중요하다.
+
+첫째는 열기-또는-갱신 문서 동기화이다. 파일을 처음 참조하면 버전 1로 \texttt{didOpen}을
+전송한다. 이미 열린 파일을 다시 참조하면 버전을 올린 \texttt{didChange}에 현재 디스크 텍스트를
+실어 전송하므로, 워밍업 이후 가한 수정이 낡은 버퍼로 응답되지 않는다. 삭제된 파일은
+\texttt{didClose}를 전송한다. 위치 기반 도구는 질의 전에 다시 열어, 호버·정의이동·아웃라인·
+이름변경이 항상 현재 파일을 읽는다.
+
+둘째는 서버 요청에 대한 규격 준수 응답이다. 서버 또한 클라이언트에 요청을 보내며, 이에 형태가
+맞는 답을 반환한다. \texttt{workspace/configuration}에는 배열,
+\texttt{workspace/applyEdit}에는 \texttt{\{applied:false\}} 등이다. 시간이 초과된 요청에는
+\texttt{\$/cancelRequest}를 뒤따르고, 모르는 메서드에는 \texttt{MethodNotFound}를 반환한다.
+사소한 세부이지만, 실제 언어 서버가 정지하지 않도록 유지하는 요소이다.
+
+\subsection{혼합 저장소의 백엔드 선택}
+저장소는 흔히 둘 이상의 언어를 포함하므로 백엔드는 질의마다 선택한다. 탐지는 가장 강한 빌드
+산출물을 우선한다. 순서는 \texttt{compile\_commands.json} $\rightarrow$ clangd,
+\texttt{.sln}/\texttt{.csproj} $\rightarrow$ Roslyn,
+\texttt{tsconfig}/\texttt{package.json} $\rightarrow$ TypeScript,
+\texttt{pyproject}/\texttt{*.py} $\rightarrow$ pyright이다.
+
+특정 파일을 지명한 질의는 그 순서를 덮고 파일 확장자로 먼저 라우팅한다. 이 단일 규칙은 C++
+루트 트리 내부의 \texttt{.py}나 \texttt{.ts} 파일이 clangd로 전달되어 아무것도 찾지 못하고
+에이전트가 도구를 포기하게 되는 상황을 방지한다.
+
+전역 설치된 단일 서버는 가장 가까운 프로젝트 표지까지 거슬러 올라가 호출별 루트를 결정하며,
+따뜻한 백엔드의 LRU 풀(기본 상한 2, 유휴 클라이언트는 5분 후 회수)로 상주 메모리를 제한한다.
+
+\subsection{워밍셋과 사전 워밍}
+언어 서버가 비동기로 인덱싱하므로 첫 질의는 콜드 지연이 지배한다. 이에 \texttt{vts}는 서버의
+열림 집합을 질의 가능성이 높은 방향으로 유도한다.
+
+사전 워밍 후보는 이전 질의 이력, 현재 편집 중인 파일(\texttt{git status}나 Perforce
+\texttt{opened}), 최근 git-log 파일, 인클루드 그래프 중심성, 수정 시각 순으로 정렬된다.
+
+인클루드 그래프 캐시는 수정 시각·크기·FNV-1a 콘텐츠 해시의 합성 키를 사용한다. 따라서
+타임스탬프가 흔들려도 바이트가 동일하면 캐시를 재사용하되, 타임스탬프만 사용하는 키가 놓칠
+실제 수정은 포착한다. 언어별 워밍 상한은 각 언어의 파일 수에 비례하므로, 혼합 언어 저장소는
+구성비에 비례하여 따뜻해진다.
+
+\section{토큰 캡과 출력 압축}
+\label{sec:cap}
+
+토큰 이득은 시맨틱 질의의 선택이 아니라 포매터에서 발생한다. 세 전략이 작동한다.
+
+\emph{본문이 아닌 위치.} 답은 \texttt{file:line}이며, 본문은 에이전트가 명시적으로 요청할
+때만 읽는다. 편집조차 심볼 이름으로 제공한다(절~\ref{sec:beyond}).
+
+\emph{반복 접기.} 참조가 많은 답은 파일별로 묶어 한 줄에 줄 번호를 모으고 중복 제거·정렬한다
+(\texttt{Foo.cpp:42,88,120}). 이어 공통 디렉터리 접두사를 한 번만 추출한다. 모든 위치는
+접두사와 꼬리로 복원 가능하다. 깊은 참조 결과에서 이 효과는 묶기로 약 $4\times$, 접두사
+제거로 약 $10\times$까지 누적된다.
+
+\emph{아웃라인 잡음 억제.} 문서 아웃라인은 익명 콜백과 중첩 지역 변수를 기본으로 숨기고 선언
+구조와 숨긴 개수를 남긴다. 한 사례에서 105개 심볼 아웃라인이 보이는 항목 32개로 감소하였다.
+
+\emph{캡 이전 재랭킹.} 캡은 상위 N개 행만 남기므로, 그 순서가 모델이 원하는 행이 표시되는지를
+좌우한다. 따라서 캡 이전에 엔진의 결과를 재랭킹한다. 어휘 일치 품질(정확, 접두사, 단어·카멜
+경계, 그다음 일반 부분 문자열), 호출 가능 종류에 대한 작은 선호, 그리고 사전 워밍에서 재사용한
+질의 이력 신호를 사용한다. 이는 Semble~\cite{semble-hn}이 효과적이라 보고한 어휘+시맨틱 융합을
+채택하되, 임베딩 벡터가 아니라 공식 엔진의 결과를 정렬하므로 인덱스를 추가하지 않고 아무것도
+전송하지 않는다. \texttt{VTS\_RANK=0}으로 끌 수 있다.
+
+확신 있는 랭킹은 한 걸음 더 나아가게 한다. 큰 결과 집합에 정확한 이름 일치가 나타나면 ---
+알려진 심볼 하나를 찾는 흔한 경우 --- 전체 캡 대신 그것과 이웃 몇 개만 보이고, 나머지는 초과
+주석과 복구 파일에 남긴다(\texttt{VTS\_FOCUS=0}으로 전체 목록 복원). 그리고 여러 단어 질의에
+대해 \texttt{search\_text}는 질의의 용어를 몇 개나 담는지로 줄을 정렬한다. 임베딩이 필요 없는
+개념 검색의 어휘적 근사이다(\texttt{VTS\_CONCEPT=0}으로 끔). 시맨틱한 동의어 인식 개념 검색은
+임베딩을 요구하므로, 저장 인덱스를 거부하는 같은 규칙에 따라 범위 밖에 둔다.
+
+답이 캡되면 \texttt{vts}는 질의를 재실행하지 않고 전체 집합을 복구하도록 ``tee'' 파일을
+기록한다. 절감 원장은 도구별 원시-대-캡 토큰 차이를 기록하며, 절~\ref{sec:eval}이 그 원장을
+읽는다.
+
+\section{행동 강제}
+\label{sec:enforce}
+
+훅은 \texttt{Bash} grep 계열 명령(grep·rg·ack·ag·findstr·\texttt{git grep}·
+\texttt{find -name})과 내장 Grep·Glob 도구를 가로챈다.
+
+\paragraph{차단이 아닌 재작성.}
+안전한 단일 grep 세그먼트는 사전 훅의 입력 변형 채널을 통해 동일 의미의 \texttt{vts} CLI
+호출로 재작성된다. 결과는 토큰캡되고 에이전트의 흐름은 끊기지 않는다.
+
+세그먼트 분리기는 따옴표를 인식하여, 따옴표 내부의 \texttt{|}를 셸 파이프가 아닌 정규식 교대로
+해석한다. 그 결과 가장 흔한 두 우회인 \texttt{grep "FooA|FooB"}와
+\texttt{grep "\^{}\#include"}가 토큰캡 텍스트 검색으로 정확히 재작성된다. 모호하거나 안전하지
+않은 명령(실제 파이프, 위험한 패턴, 루트 경로 내 따옴표)만 강한 차단으로 후퇴하며, 이때도 즉시
+실행 가능한 대체를 출력한다.
+
+\paragraph{심볼 사냥 분류.}
+심볼을 명백히 열거하는 grep은 시맨틱 심볼 검색으로 라우팅된다. 그 단서는 맨 식별자,
+\texttt{::}나 리터럴 \texttt{(}나 타입 키워드 같은 코드 구조 단서를 포함한 정규식, 또는
+\texttt{MaxWalkSpeed|MaxExcessSpeed} 같은 CamelCase·스네이크 교대이다.
+
+식별자 신호가 없는 키워드 교대, 예를 들어 \texttt{TODO|FIXME}나 \texttt{GET|POST}는 거짓
+양성을 피하기 위해 경고로 남긴다. 모든 강제는 탈출구 환경 변수로 되돌릴 수 있으며, 메시지는
+운영자 로케일로 출력된다.
+
+\paragraph{편집 습관 측정과 유도.}
+우회는 검색에 국한되지 않는다. 두 번째 우회는 \emph{선언 전체}를 교체·삽입하는 내장 줄 기반
+편집이다. 이는 심볼 단위 편집이라면 파일을 컨텍스트로 먼저 읽지 않고 이름만으로 수행할 수 있는
+작업이다.
+
+오프라인 발견 스캔과 라이브 훅이 공유하는 분류기가 그러한 편집을 표시한다. 선언처럼 보이는
+제어 흐름 블록은 제외하며, 심볼 편집이라면 건너뛰었을 사전 파일 읽기 토큰을 귀속한다.
+
+이어 세 계층이 습관 전환을 시도한다. 검색 결과에 얹은 집중 유도, 즉시 실행 가능한 심볼 편집
+호출을 실은 모델 가시 경고, 그리고 안전한 삽입에 대한 옵트인 1회 차단이다. 채택 원장은 현재
+채택 비율을 세션 목표로 재주입하는데, 이는 정적 지시가 제공할 수 없는 측정-후-재주입 루프이다.
+이 습관의 완강함은 절~\ref{sec:discuss}에서 보고한다.
+
+\section{검색을 넘어: 탐색·호출 계층·편집·시각화}
+\label{sec:beyond}
+
+동일한 캡·무전송 규율이 참조 검색 너머로 확장된다.
+
+\paragraph{접힌 탐색.}
+\texttt{goto\_definition}은 새 도구를 추가하는 대신 \texttt{kind} 매개변수 뒤로 타입 정의·
+구현·선언을 접는다. 호버, 문서 심볼, 그리고 \texttt{file:line:col severity [code]: msg}
+형태로 렌더된 간결한 진단 목록이 읽기 표면을 완성한다.
+
+\paragraph{도구가 아닌 접힘으로서의 호출 계층.}
+다중 홉 호출 계층, 즉 편집 전 영향 반경을 이루는 추이적 호출자 또는 피호출자는
+\texttt{direction} 매개변수로 참조 도구 \emph{안에} 접힌다. 이는 순환·깊이 가드(기본 깊이 5,
+노드 80)와 함께 공식 LSP \texttt{callHierarchy} 요청 위에서 구현된다. 영속 호출 그래프의
+주문형 대응물로서, 실제 시맨틱 간선을 제공하되 저장된 그래프가 없고, 전송이 없으며, 표면에 새
+도구가 없다.
+
+\paragraph{심볼 단위 편집.}
+본문 교체, 앞/뒤 삽입, 참조 검사 안전 삭제는 각각 LSP 아웃라인으로 선언을 이름으로 해석하여
+심볼 구간에서 텍스트를 이어 붙인다. 모두 기본이 미리보기이며, 안전 삭제는 심볼이 아직 참조되는
+동안에는 강제하지 않는 한 거부한다. 심볼을 이름으로 지정하는 편집은 파일 전체를 읽고 정확
+일치를 위해 줄을 세는 작업을 건너뛰므로, 검색 캡의 편집 대응물이다.
+
+\paragraph{로컬·무전송 시각화.}
+옵트인·CLI 전용 대시보드는 번들된 동일 출처 WebGL 라이브러리(CDN 없음)로 인클루드 그래프와
+주문형 호출 그래프를 3D로 렌더한다. 루프백에만 바인딩되며 MCP 서버는 이를 절대 기동하지 않는다.
+헌장의 시각화 대응물로서, 유용한 뷰를 제공하되 호스트를 떠나는 것은 없다.
+
+\section{평가}
+\label{sec:eval}
+
+본 연구는 세 축으로 평가한다. 결정적 회귀 하버스, 실제 프로젝트에서의 라이브 언어 서버 검증,
+그리고 수 개월의 단일 개발자 사용 데이터이다.
+
+구분은 의도적이다. 하버스는 통제되고 재현 가능하다. 사용 데이터는 실사용이므로 통제된
+벤치마크가 아니라 관측이다. 답 품질의 다중 저장소 A/B 연구를 주장하지 않는다. 캡이 유지되고,
+강제가 발동하며, 실현된 절감이 측정 가능하다는 것을 주장한다.
+
+\subsection{회귀 하버스}
+모의-LSP 하버스(\texttt{eval/run.mjs})는 툴체인 없이 모든 도구와 불변식을 실행한다. 토큰 캡
+동작, 백엔드 선택, 문서 동기화 신선도, 강제 재작성, 그리고 새 기능 각각을 검증한다.
+
+하버스는 현재 \textbf{74개 검사}를 포함하고 전부 통과한다. 모든 새 코드 경로는 검사와 함께
+도입되며, 이는 원칙 P2의 운영 형태이다. 한 구체 수치로, 원시 인덱스 응답이 약 $57{,}308$
+토큰인 콜드 작업공간-심볼 질의는 약 $1{,}434$ 토큰으로 캡되어 대략 $40\times$ 감소한다.
+
+\subsection{라이브 언어 서버 검증}
+네 백엔드 각각을 모의가 아닌 공식 엔진에 대해 끝까지 검증하였다.
+
+\begin{itemize}
+  \item \textbf{C/C++ (clangd)} 실제 Unreal Engine 5.x 프로젝트에서
+  \texttt{search\_symbol}이 게임 \texttt{UCLASS}와 그 생성 심볼을 \texttt{file:line}으로
+  반환하였다. 재현 가능한 사실 둘이 도출되었다. 첫째, 타깃이 clang-cl로 빌드되면
+  \texttt{GenerateClangDatabase}에 \texttt{-Compiler=VisualCpp}가 필요하다. 둘째, 번들
+  clangd 19.1.5는 서버 모드에서 전체 게임 번역 단위에 데드락하지만, 독립 clangd $\geq 22$는
+  같은 단위를 약 13초에 파싱한다. 이에 버전을 탐지하고, 찾는 심볼의 샤드가 로드되는 순간
+  응답하는 영속-인덱스 빠른 경로를 사용한다. 이 경로는 전체 백그라운드 인덱스를 기다리는
+  $369$초를 정적 인덱스 로드 후 $51$초로 전환하며, 첫 질의 지연을 $7\times$ 단축한다.
+  \item \textbf{C\# (Roslyn 기반 서버)} Microsoft.CodeAnalysis.LanguageServer(Visual
+  Studio·C\# Dev Kit 엔진)에 대해 검증하였다.
+  \item \textbf{JS/TS (\texttt{typescript-language-server})} \texttt{vts}를 자체 소스에
+  실행하여 검증하였다.
+  \item \textbf{Python (pyright)} TypeScript와 동일한 범용 접착부로 검증하였다.
+\end{itemize}
+
+\subsection{토큰 절감 데이터}
+단일 개발자의 기록된 $441$회 검색에서, 로컬 원장은 캡 출력을 원시 인덱스 응답보다 약
+$2\times$ 작게 기록한다. $263{,}540$ 토큰이 $133{,}289$로 감소하여 약 $130{,}000$ 토큰을
+절감하였다. 가장 무거운 단일 질의는 $21{,}056$에서 $1{,}961$ 토큰으로 $10.7\times$ 압축된다.
+
+그림~\ref{fig:savings}과 표~\ref{tab:savings}이 절감을 도구별로 분해한다. 문서 아웃라인
+억제와 텍스트 검색 캡이 절감을 지배한다.
+
+이 수치는 검색 결과 자체의 압축만 센다. 더 크고 측정하기 어려운 절반 --- 에이전트가 파일을
+열지 않게 되어 절약한 읽기 --- 은 빠져 있다. 에이전트가 \texttt{file:line} 위치와 이름 지정된
+심볼 span을 받기 때문이다. 그 읽기 회피의 일부를 \texttt{read\_symbol}을 그것이 대체하는 전체
+파일 대비로 측정하여 원장에 드러낸다. 이는 Semble이 절감을 ``파일 읽기와 결합하여'' 보고하는
+방식과 같다~\cite{semble-hn}.
+
+\begin{figure}[h]
+\centering
+\includegraphics[width=0.92\linewidth]{figures/savings.pdf}
+\caption{로컬 원장의 도구별 토큰 절감(441회 검색, 개발자 1인). 통제된 벤치마크가 아닌 관측
+사용 수치이다.}
+\label{fig:savings}
+\end{figure}
+
+\begin{table}[h]
+\centering
+\caption{로컬 원장의 도구별 토큰 절감. 관측 데이터.}
+\label{tab:savings}
+\begin{tabular}{lrr}
+\toprule
+도구 & 실행 & 절감 토큰 \\
+\midrule
+\texttt{document\_symbols} & 10  & $\sim$84{,}354 \\
+\texttt{search\_text}      & 246 & $\sim$30{,}308 \\
+\texttt{search\_symbol}    & 32  & $\sim$9{,}122 \\
+\texttt{find\_references}  & 29  & $\sim$2{,}617 \\
+\texttt{insert\_symbol}    & 5   & $\sim$2{,}313 \\
+\midrule
+\textbf{vts 합계}          & 441 & $\sim$130{,}251 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\subsection{강제 커버리지}
+에이전트 자신의 세션 기록을 훑는 오프라인 발견 스캔이 얼마나 많은 코드 검색이 \texttt{vts}를
+우회했는지 측정한다. 대형 게임 엔진 작업부하에서 매처의 최근 구간 포착률은 약 $68\%$이다.
+
+심볼 사냥 grep을 겨눈 두 강제 개선은 잠재 우회 중 월 약 $172$k 토큰(구조적 grep 차단)과 추가
+$319$k 토큰(CamelCase 교대 grep 차단)을 가로채는 것으로 관측된다.
+
+같은 스캔이 편집 습관을 정량화한다. 30일 동안 $1{,}284$건의 선언 전체 줄 편집이 약 $468$k
+토큰의 파일 내용을 먼저 읽었으며, 그중 $93\%$는 그 파일에 대한 사전 \texttt{vts} 검색 없이
+발생하였다. 이 수치는 검색 결과만으로 수행하는 유도의 기회와 천장을 동시에 측정하며, 편집 채택
+원장이 존재하는 이유이다.
+
+\subsection{타당성 위협}
+위협을 명시한다.
+
+\emph{외적 타당성.} 절감·강제 데이터는 한 개발자, 한 환경에서 도출되었으므로 절댓값은 효과의
+존재 증명이지 모집단 추정이 아니다. 코드 구성이나 작업 방식이 다르면 값도 달라진다.
+
+\emph{구성 타당성.} 토큰은 원시 인덱스 응답 대비로 측정하므로 형식 이득은 포착하지만,
+에이전트가 grep으로 도달했을 답에 동일하게 도달했는지는 포착하지 않는다. 정확성은 시맨틱 엔진의
+사용과 라이브 검증에서 주장하며, 작업 성공 지표로 주장하지 않는다.
+
+\emph{내적 타당성.} 원장은 측정 대상과 동일한 프로세스의 계측이며, 입력 하나(번들 로그 압축
+항목)는 비정상이므로 결합 대신 분리하여 보고한다.
+
+\emph{참고문헌 품질.} 관련 연구의 일부는 동료 심사 지면이 아닌 현장 글을 인용하는데, 이는
+에이전트-LSP 전환이 최근이기 때문이다. 그러한 출처는 그대로 표시하고, 핵심 주장을 거기에 싣지
+않는다.
+
+\subsection{아티팩트 가용성}
+\texttt{vs-token-safer}는 설치 가능한 MCP 플러그인과 CLI로 배포되며, 본 절의 평가는
+저장소에서 재현된다. \texttt{node eval/run.mjs}는 툴체인 없이 74개 검사를 실행하고,
+\texttt{vts savings}는 표~\ref{tab:savings}의 바탕 원장을 출력한다.
+
+본 논문의 도표는 버전 관리되는 SVG 소스에서 생성된다(\texttt{figures/build.py}). 여기 수치는
+릴리스 v0.32.2 기준이며, 원장이 사용에 따라 증가하므로 정확한 값을 인용하기 전에 두 명령을 다시
+실행하고 재빌드할 것을 권한다.
+
+\section{논의와 한계}
+\label{sec:discuss}
+
+\paragraph{grep이 남는 영역.}
+\texttt{vts}는 어휘 검색을 폐지하지 않고 제한한다. 언어 서버는 그것이 존재하는 형식에만 있는
+반면, 에이전트의 검색 수요는 트리의 모든 텍스트를 포괄한다.
+
+따라서 \texttt{vts}는 형식 무관 경우를 위해 토큰캡 텍스트 검색 도구를 유지하고, 시맨틱 답이
+엄밀히 더 나은 경우(심볼 사냥, 참조, 이름변경)에만 강제를 적용한다. 자유형과 키워드 교대 검색은
+의도적으로 경고로 둔다.
+
+\paragraph{콜드 지연.}
+실제 컴파일러 프런트엔드를 사용하는 정직한 대가는 콜드·대형 인덱스의 첫 질의 지연이다.
+\texttt{vts}는 사전 워밍, 영속-인덱스 빠른 경로, 샤드 로드까지의 폴링으로 이를 완화하지만
+제거하지는 못한다. 이미 실행 중인 언어 서비스를 프록시하는 따뜻한 IDE는 여전히 첫 질의에 더
+빠르게 응답한다. 서버를 상주시키면 적어도 스폰 비용을 호출마다가 아니라 세션마다 한 번 지불한다.
+
+\paragraph{채택은 기술이 아니라 행동 문제이다.}
+가장 두드러진 측정 격차는 도구의 능력이 아니라 에이전트가 그것을 사용하는지이다. 캡된 심볼
+편집이 존재해도 에이전트는 여전히 열에 아홉은 줄 기반 편집을 기본으로 선택한다.
+
+영구 강제 차단은 역효과였다. 에이전트를 우회 시도의 반복에 가두기 때문이다. 수치를 실제로
+움직인 지렛대는 즉시 실행 가능한 제안 호출과 재주입된 라이브 채택 지표였다. 이 격차의 축소가
+본 연구가 가장 중시하는 미해결 문제이다.
+
+\paragraph{평가의 정직함.}
+정량 결과는 사용 데이터와 결정적 하버스이지, grep이나 영속 지식 그래프에 대한 답 품질의 통제된
+다중 저장소 벤치마크가 아니다. 자연스러운 다음 단계가 그 연구이다. 에이전트와 작업을 고정하고
+검색 백엔드만 변경하여, 저장소 모음에 걸쳐 토큰·실시간·작업 성공을 측정한다. 현 데이터를
+부풀리는 대신 향후 과제로 명시한다.
+
+\section{결론}
+\label{sec:conc}
+
+\texttt{vs-token-safer}는 에이전트의 코드 검색을 시맨틱하고, 캡되고, 무전송이며, 강제되게
+만든다. 공식 언어 서버를 분석 엔진으로 재사용하고 LSP-MCP 접착부만 구현한다. 본문이 아니라
+위치를 반환하고, grep을 훅에서 동일 의미의 캡 호출로 재작성한다. 이로써 탐색·참조·이름변경
+계열 연산의 토큰·프라이버시 비용을 낮추되, 어휘 검색은 적합한 영역에 남긴다.
+
+영속 지식 그래프와 비교하면, \texttt{vts}는 저장 인덱스의 도달 범위와 언어 폭을 구성에 의한
+정확성(컴파일러 자신의 프런트엔드), 무효화 문제 없는 신선도, 단단한 무전송 보장과 맞바꾼다.
+
+남기는 문제는 기술이 아니라 행동이다. 에이전트가 더 저렴한 도구를 사용하게 만드는 것이며,
+거기에서는 영구 차단보다 라이브 측정과 재주입이 더 효과적이었다.
+
+% ============================================================================
+\begin{thebibliography}{9}
+
+\bibitem{cbm}
+DeusData.
+\newblock Codebase-Memory: Tree-Sitter-Based Knowledge Graphs for LLM Code
+Exploration via MCP.
+\newblock arXiv:2603.27277, 2026. \url{https://arxiv.org/abs/2603.27277}
+
+\bibitem{anthropic-lsp}
+Anthropic.
+\newblock Native Language Server Protocol support in Claude Code (v2.0.74),
+December 2025.
+
+\bibitem{lsp-medium}
+V.\ Thiagarajan.
+\newblock LSP --- The Protocol Your IDE Uses Every Day (And Now Your AI Agent
+Does Too). Medium, 2026.
+
+\bibitem{semble-hn}
+Semble.
+\newblock Code search for agents that uses 98\% fewer tokens than grep.
+Hacker News, 2026. \url{https://news.ycombinator.com/item?id=48169874}
+
+\bibitem{yage-grep}
+Yage.
+\newblock Why Coding Agents Still Use grep as Their Search Backbone. 2026.
+\url{https://yage.ai/share/why-coding-agents-still-use-grep-en-20260327.html}
+
+\bibitem{hyperagent}
+H.\ N.\ Phan, T.\ N.\ Nguyen, P.\ X.\ Nguyen, and N.\ D.\ Q.\ Bui.
+\newblock HyperAgent: Generalist Software Engineering Agents to Solve Coding Tasks
+at Scale.
+\newblock arXiv:2409.16299, 2024.
+
+\end{thebibliography}
+
+\end{document}

--- a/paper/vs-token-safer.tex
+++ b/paper/vs-token-safer.tex
@@ -1,0 +1,641 @@
+\documentclass[11pt]{article}
+
+% ============================================================================
+%  Token-Safer (English). Build: tectonic vs-token-safer.tex
+%  Figures: figures/*.pdf  (regenerate from SVG with: python figures/build.py)
+% ============================================================================
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
+\usepackage{microtype}
+\usepackage[margin=1in]{geometry}
+\usepackage{amsmath,amssymb}
+\usepackage{booktabs}
+\usepackage{graphicx}
+\usepackage{xcolor}
+\usepackage{hyperref}
+\usepackage{url}
+\hypersetup{colorlinks=true, linkcolor=blue!55!black, citecolor=blue!55!black, urlcolor=blue!55!black}
+
+\setlength{\emergencystretch}{3em}
+\sloppy
+
+\title{\textbf{Token-Safer: Enforcing Official Language-Server Indices over
+Grep for Zero-Transmission, Token-Capped Code Search in LLM Coding Agents}}
+
+\author{
+  Sungmin Jeon\\
+  \texttt{sungmin1505104@gmail.com}
+}
+\date{June 2026}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+Coding agents read repositories through tool calls, and every result competes for
+the same context window the model reasons in. The usual tool is \texttt{grep}, and
+its output is pasted in whole.
+
+This is cheap to run but wasteful to read. A text scan cannot separate a function
+from a same-named variable or a comment, so it returns matches the model must read
+and discard. Its cost also grows with the match count, not with the answer.
+
+We present \textbf{vs-token-safer} (\texttt{vts}), a local-only Model Context
+Protocol (MCP) server and CLI. It routes each search to an \emph{official} language
+server --- clangd, a Roslyn server, \texttt{typescript-language-server}, pyright ---
+instead of building its own index. It caps every answer to a compact
+\texttt{file:line} list, with no source bodies. And it makes the substitution stick
+by rewriting \texttt{grep} into the equivalent capped call at the hook layer.
+
+Nothing is stored, embedded, or sent over the network. Across a 74-check harness
+and several months of single-developer use, capped output is about $2\times$
+smaller than the raw index response, and up to $10.7\times$ smaller on the heaviest
+query. The hook absorbs hundreds of thousands of \texttt{grep} tokens per month on
+a large game-engine tree. For navigation, references, and renames, \texttt{vts} is
+a safer and cheaper substitute for \texttt{grep}. We also state where \texttt{grep}
+remains the better tool.
+\end{abstract}
+
+\section{Introduction}
+\label{sec:intro}
+
+When an agent opens an unfamiliar repository, it searches first. Three questions
+dominate: where is \texttt{X} defined, what calls \texttt{Y}, and where is
+\texttt{Z} used. In almost every agent today, all three are answered by
+\texttt{grep} or \texttt{ripgrep}, and the result is placed verbatim into the
+model's context.
+
+This is convenient, but it carries two costs. The first is precision. A text scan
+matches every occurrence, including hits in comments and string literals, unrelated
+identifiers that share a substring, and overloads the agent did not ask about. The
+model spends tokens reading these and attention discarding them.
+
+The second cost is volume. The token count of a grep result scales with the number
+of matching lines and the surrounding context, not with the size of the answer.
+For a ``where is it'' question, that answer is only a short list of positions.
+
+Language servers already solve the precision half. The Language Server Protocol
+(LSP) exposes semantic operations --- definition, references, document and
+workspace symbols, call hierarchy, and rename --- over a real parser and type
+resolver. A reference query therefore returns the actual referents, not textual
+look-alikes. Reported results agree: for renames, type checks, and call-chain work,
+an LSP is the right backend, and a lookup that costs roughly two thousand grep
+tokens can be answered in about five hundred LSP
+tokens~\cite{lsp-medium,semble-hn}. Anthropic added native LSP support to Claude
+Code in late 2025~\cite{anthropic-lsp}.
+
+Two questions remain open. How should an agent be \emph{made} to use that index
+rather than merely offered it? And what should be allowed to cross from the index
+into the model's context? \texttt{vts} takes a definite position on both, stated as
+three commitments.
+
+\begin{enumerate}
+  \item \textbf{Reuse the official engine; ship only the glue.} Indexing C++, C\#,
+  TypeScript, and Python correctly is hard, and clangd, Roslyn, \texttt{tsserver},
+  and pyright already do it. A token saver should be a thin LSP-to-MCP adapter ---
+  not a re-implemented parser, and not a third-party index over someone's source.
+
+  \item \textbf{Cap the answer, not just the question.} The saving comes as much
+  from refusing to return bodies as from asking a semantic question. Every answer
+  is a de-duplicated, directory-factored \texttt{file:line} list, so less source
+  reaches the model than under grep-and-paste. The privacy story and the token
+  story improve together.
+
+  \item \textbf{Enforce the swap; do not merely offer it.} An agent that
+  \emph{could} call a better tool still reaches for \texttt{grep} by habit. We
+  rewrite a single safe \texttt{grep} call into the matching capped call at the
+  pre-tool hook, leaving the agent's flow intact while removing the bypass.
+\end{enumerate}
+
+\paragraph{Contributions.}
+This paper contributes: (i) a thin LSP-to-MCP adapter that fronts four official
+language servers behind one capped, per-call-rooted tool surface
+(Section~\ref{sec:arch}); (ii) an output-compaction scheme --- positions only,
+file-grouped, prefix-factored --- measured at about $2\times$ over raw index
+responses and up to $10.7\times$ on the heaviest query (Sections~\ref{sec:cap}
+and~\ref{sec:eval}); (iii) a hook layer that rewrites grep into the equivalent
+capped call and that quantifies, then steers, both the grep habit and a second
+whole-declaration edit habit (Section~\ref{sec:enforce}); and (iv) a reproducible
+74-check harness with live verification against clangd, Roslyn, \texttt{tsserver},
+and pyright on real projects (Section~\ref{sec:eval}).
+
+\paragraph{A contrasting design.}
+\emph{Codebase-Memory}~\cite{cbm} attacks the same token problem from the opposite
+direction. It builds a \emph{persistent} Tree-Sitter knowledge graph over 66
+languages, with optional embedded vector search and a local visualization.
+\texttt{vts} inverts each of those choices: on-demand official-LSP queries instead
+of a stored graph, compiler-grade engines instead of a hand-written parser, and a
+hard no-transmission rule instead of embeddings. That contrast organizes the rest
+of the paper (Section~\ref{sec:related}).
+
+\section{Background and Related Work}
+\label{sec:related}
+
+\paragraph{Grep as the search backbone.}
+Lexical search is the default for sound reasons. It needs no build, it ignores file
+type, and it searches everything --- which is what an agent wants in its first
+minutes inside an unknown tree~\cite{yage-grep}.
+
+Its weaknesses are equally clear. It cannot separate a symbol from a substring, and
+nothing bounds its output to the relevant~\cite{lsp-medium}. Newer agent-search
+tools such as Semble report up to a $98\%$ token reduction against grep by returning
+structured, de-duplicated results~\cite{semble-hn}. We take the lesson that grep
+should be bounded and complemented, not forwarded blindly.
+
+\paragraph{LSP for agents.}
+A growing body of work wires LSP into coding agents to provide semantic navigation
+and live diagnostics in place of text
+matching~\cite{lsp-medium,anthropic-lsp,hyperagent}. \texttt{vts} belongs to that
+family but shifts the emphasis. It is not only an LSP client but an LSP enforcer
+with a hard output cap, and it ships as a drop-in MCP plugin plus a hook that
+substitutes for grep, rather than as a set of optional tools.
+
+\paragraph{Why we did not build our own index.}
+The obvious alternative is to build a semantic index, as
+Codebase-Memory~\cite{cbm} does. It stores a Tree-Sitter knowledge graph with its
+own type resolver and optional embeddings, and reports good token savings across 31
+repositories. It is a capable design. We chose the opposite, for three reasons.
+
+First, a stored graph is a second copy of the truth. It drifts from the source and
+must be invalidated and rebuilt.
+
+Second, a hand-written parser is a second implementation. It can disagree with the
+compiler the project actually uses, and then the agent receives answers the build
+would not.
+
+Third, embeddings add a place for data to be stored and sent, which breaks the
+zero-transmission rule we want to keep.
+
+\texttt{vts} therefore stores no semantic database, hands every semantic question
+to the build's own compiler front end, and transmits nothing. We do borrow two
+ideas from that work --- an on-demand call graph and content-hash invalidation ---
+but we build them as ephemeral LSP queries and a small local cache, not a stored
+graph (Section~\ref{sec:beyond}).
+
+\section{Design Principles}
+\label{sec:principles}
+
+Four invariants govern \texttt{vts}, and each is checked by the regression harness
+(Section~\ref{sec:eval}).
+
+\begin{description}
+  \item[P1 --- Official engine, our glue.] clangd (LLVM) and the Roslyn-based
+  server (Microsoft) perform the analysis; we write the LSP-to-MCP adapter and
+  nothing more. We never reuse a third-party MCP server over source, and never
+  re-implement a parser.
+
+  \item[P2 --- Token-first.] Every feature must hold or improve the token win.
+  Output is \texttt{file:line}, capped, with no bodies, and a new feature ships only
+  with a harness check that asserts its output stays capped.
+
+  \item[P3 --- Local-only, zero-transmission.] There are no network calls; nothing
+  is embedded, uploaded, or reported. Because the cap returns positions rather than
+  bodies, less source crosses into the model than under grep-and-paste. The privacy
+  argument and the token argument coincide.
+
+  \item[P4 --- Enforced, not optional.] A better tool the agent forgets to call
+  saves nothing. The swap is enforced at the hook by rewriting a grep call into the
+  matching capped call, with graceful fallbacks when rewriting is unsafe.
+\end{description}
+
+\section{System Architecture}
+\label{sec:arch}
+
+\texttt{vts} presents three faces over one core. An MCP server exposes a small,
+fixed tool set to the agent: thirteen first-class tools, plus a single
+\texttt{vts\_admin} tool that folds nine rarely-used administrative operations so
+they do not clutter the surface. A \texttt{vts} CLI exposes the same operations to a
+shell. A set of hooks intercepts and rewrites grep-class calls.
+
+Figure~\ref{fig:layers} shows how the pieces stack, and Figure~\ref{fig:arch}
+traces a single request through them.
+
+\begin{figure}[h]
+\centering
+\includegraphics[width=0.96\linewidth]{figures/layers.pdf}
+\caption{The four layers, from the agent-facing surface down to the official
+engines, with the four invariants (P1--P4) that every layer must honor and that the
+eval harness checks. We author only the index-glue layer; the engines are reused
+as-is.}
+\label{fig:layers}
+\end{figure}
+
+\begin{figure}[h]
+\centering
+\includegraphics[width=\linewidth]{figures/architecture.pdf}
+\caption{The request path. Agent tool calls and rewritten grep commands enter a
+single \texttt{runTool} dispatch, which drives a generic LSP client over the
+official language server for the target file. The formatter caps the reply to a
+\texttt{file:line} list before it reaches the model. Nothing leaves the host.}
+\label{fig:arch}
+\end{figure}
+
+\subsection{Generic LSP client}
+The one genuinely new and delicate part is a generic JSON-RPC-over-stdio LSP
+client. Two behaviors matter.
+
+The first is open-or-refresh document sync. The first reference to a file sends
+\texttt{didOpen} at version~1. A second reference to an already-open file sends
+\texttt{didChange} with a bumped version and the file's current disk text, so an
+edit made after warm-up is never answered from a stale buffer. A deleted file sends
+\texttt{didClose}. Position-based tools re-open before each query, so hover, goto,
+outline, and rename always read the file as it is now.
+
+The second is spec-conformant replies to the server. The server also makes requests
+of the client, and those receive shape-correct answers: an array for
+\texttt{workspace/configuration}, \texttt{\{applied:false\}} for
+\texttt{workspace/applyEdit}, and so on. A timed-out request is followed by
+\texttt{\$/cancelRequest}, and an unknown method returns \texttt{MethodNotFound}.
+These details are minor, but they keep a real language server from stalling.
+
+\subsection{Backend selection for mixed repositories}
+A repository often holds more than one language, so the backend is chosen per
+query. Detection prefers the strongest build artifact, in the order
+\texttt{compile\_commands.json} $\rightarrow$ clangd,
+\texttt{.sln}/\texttt{.csproj} $\rightarrow$ Roslyn,
+\texttt{tsconfig}/\texttt{package.json} $\rightarrow$ TypeScript, and
+\texttt{pyproject}/\texttt{*.py} $\rightarrow$ pyright.
+
+A query that names a specific file overrides that order and routes by the file's own
+extension first. This single rule prevents a \texttt{.py} or \texttt{.ts} file
+inside a C++-rooted tree from being handed to clangd, which would find nothing and
+teach the agent to abandon the tool.
+
+A single globally installed server resolves the correct project root per call by
+walking up to the nearest project marker, and it bounds resident memory with an LRU
+pool of warm backends (default cap two, idle clients reaped after five minutes).
+
+\subsection{Warm set and prewarming}
+Because language servers index asynchronously, cold latency dominates the first
+query. \texttt{vts} steers the server's open set toward what is likely to be asked.
+
+Prewarm candidates are ordered by prior query history, then currently-edited files
+(from \texttt{git status} or Perforce \texttt{opened}), then recent git-log files,
+then include-graph centrality, then modification time.
+
+The include-graph cache is keyed on a composite of modification time, size, and an
+FNV-1a content hash. It therefore reuses a cached result when the bytes are
+unchanged despite timestamp jitter, yet still notices a real edit that a
+timestamp-only key would miss. Per-language warm caps scale to each language's file
+count, so a mixed-language repository warms in proportion to its makeup.
+
+\section{Token-Capping and Output Compaction}
+\label{sec:cap}
+
+The token win is produced by the formatters, not merely by the choice of a semantic
+query. Three strategies do the work.
+
+\emph{Positions, not bodies.} Answers are \texttt{file:line}. A body is read only
+when the agent explicitly asks for one, and even editing is offered by symbol name
+(Section~\ref{sec:beyond}).
+
+\emph{Repetition collapse.} A references-heavy answer is grouped by file --- one row
+per file, with its line numbers joined, de-duplicated, and sorted, as in
+\texttt{Foo.cpp:42,88,120}. The shared directory prefix is then factored out once.
+Every location survives and is recoverable as prefix plus tail. On a deep reference
+result this compounds from roughly $4\times$ for the coalescing to roughly
+$10\times$ once the prefix is removed.
+
+\emph{Outline noise suppression.} Document outlines hide anonymous callbacks and
+nested local variables by default, keeping the declaration structure and a count of
+what was hidden. In one case a 105-symbol file outline dropped to 32 visible
+entries.
+
+\emph{Ranking before the cap.} Because the cap keeps only the top-N rows, their
+order decides whether the row the model wants is shown at all. We therefore rerank
+the engine's own results before capping: by lexical match quality (exact, prefix,
+word or camel boundary, then plain substring), a small preference for callable
+kinds, and a query-history signal reused from prewarming. This adopts the
+lexical-plus-semantic fusion that Semble~\cite{semble-hn} found effective, but it
+ranks the official engine's results rather than embedding vectors, so it adds no
+index and transmits nothing. \texttt{VTS\_RANK=0} disables it.
+
+A confident ranking lets us go one step further. When an exact-name match appears in
+a large result --- the common case of locating one known symbol --- we show it and
+a few neighbors instead of the full cap, leaving the rest in the overflow note and
+the recovery file (\texttt{VTS\_FOCUS=0} restores the full list). And for a
+multi-word query, \texttt{search\_text} ranks lines by how many of the query's terms
+they carry: a lexical approximation of conceptual search that needs no embeddings
+(\texttt{VTS\_CONCEPT=0} disables it). The semantic, synonym-aware form of
+conceptual search would require embeddings, so it stays out of scope by the same
+rule that rejects a stored index.
+
+When an answer is capped, \texttt{vts} writes a recovery ``tee'' file so the full
+set can be retrieved without re-running the query. A savings ledger records the
+raw-versus-capped token delta per tool; Section~\ref{sec:eval} reads that ledger.
+
+\section{Behavioral Enforcement}
+\label{sec:enforce}
+
+A hook intercepts \texttt{Bash} grep-class commands --- grep, rg, ack, ag, findstr,
+\texttt{git grep}, and \texttt{find -name} --- along with the built-in Grep and Glob
+tools.
+
+\paragraph{Rewrite, not block.}
+A single safe grep segment is rewritten, through the pre-tool hook's input-mutation
+channel, into the matching \texttt{vts} CLI call. The result is token-capped and the
+agent's flow is unbroken.
+
+The segment splitter is quote-aware. It treats a \texttt{|} inside quotes as a regex
+alternation rather than a shell pipeline, so the two most common bypasses,
+\texttt{grep "FooA|FooB"} and \texttt{grep "\^{}\#include"}, rewrite cleanly to a
+capped text search. Only an ambiguous or unsafe command --- a genuine pipeline, an
+unsafe pattern, a quote in the root path --- falls back to a hard block, and even
+then it prints a ready-to-run replacement.
+
+\paragraph{Symbol-hunt classification.}
+A grep that plainly enumerates symbols is routed to the semantic symbol search. The
+triggers are a bare identifier, a regex carrying a code-structural cue such as
+\texttt{::} or a literal \texttt{(} or a type keyword, or a CamelCase/snake
+alternation such as \texttt{MaxWalkSpeed|MaxExcessSpeed}.
+
+Keyword alternations that carry no identifier signal, such as \texttt{TODO|FIXME} or
+\texttt{GET|POST}, are left as warnings to keep false positives near zero. All
+enforcement is reversible through an escape-hatch environment variable, and messages
+are emitted in the operator's locale.
+
+\paragraph{Measuring and steering the edit habit.}
+Search is not the only bypass. A second one is the built-in, line-based edit that
+replaces or inserts a whole declaration --- something a symbol-level edit could do
+by name, without first reading the file into context.
+
+A shared classifier, used by both the offline discovery scan and the live hook,
+flags those edits. It excludes control-flow blocks that merely look like
+declarations, and it attributes the prior file-read tokens a symbol edit would have
+skipped.
+
+Three layers then try to convert the habit: a focused nudge riding a search result,
+a model-visible warning that carries a ready symbol-edit call, and an opt-in
+one-shot block of a safe insert. An adoption ledger re-injects the current adoption
+ratio as a session goal, a measure-then-re-inject loop that a static instruction
+cannot provide. Section~\ref{sec:discuss} reports how stubborn this habit is.
+
+\section{Beyond Search: Navigation, Call Hierarchy, Editing, Visualization}
+\label{sec:beyond}
+
+The same capped, zero-transmission discipline extends past reference search.
+
+\paragraph{Navigation, folded.}
+\texttt{goto\_definition} folds type definition, implementation, and declaration
+behind a \texttt{kind} parameter rather than spawning new tools. Hover, document
+symbols, and a compact diagnostics list (compiler and linter findings rendered as
+\texttt{file:line:col severity [code]: msg}) complete the read surface.
+
+\paragraph{Call hierarchy as a fold, not a tool.}
+A multi-hop call hierarchy --- the transitive callers that form the blast radius
+before an edit, or the callees --- is folded \emph{into} the reference tool through
+a \texttt{direction} parameter. It is implemented over the official LSP
+\texttt{callHierarchy} requests with cycle and depth guards (default depth five,
+eighty nodes). This is the on-demand counterpart of a persistent call graph: real
+semantic edges, no stored graph, nothing transmitted, and no new tool on the
+surface.
+
+\paragraph{Symbol-level editing.}
+Replace-body, insert (before or after), and a reference-checked safe-delete each
+resolve a declaration by name through the LSP outline and splice text at the
+symbol's span. All are preview-by-default, and safe-delete refuses while the symbol
+is still referenced unless forced. Editing by naming a symbol skips reading the
+whole file and counting lines for an exact match, which is the editing counterpart
+of the search cap.
+
+\paragraph{Local, zero-transmission visualization.}
+An opt-in, CLI-only dashboard renders the include graph and an on-demand call graph
+in 3D through a vendored, same-origin WebGL library (no CDN). It binds to loopback
+only and is never started by the MCP server. It is the visualization counterpart of
+the charter: a useful view where nothing leaves the host.
+
+\section{Evaluation}
+\label{sec:eval}
+
+We evaluate along three lines: a deterministic regression harness, live
+language-server verification on real projects, and several months of
+single-developer usage telemetry.
+
+We are deliberate about the distinction. The harness is controlled and
+reproducible. The telemetry is real usage, and therefore observational rather than a
+controlled benchmark. We do not claim a multi-repository A/B study of answer
+quality. We claim that the cap holds, that the enforcement fires, and that the
+realized savings are measurable.
+
+\subsection{Regression harness}
+A mock-LSP harness (\texttt{eval/run.mjs}) exercises every tool and invariant
+without a toolchain present. It asserts on token-cap behavior, backend selection,
+document-sync freshness, enforcement rewrites, and each new feature.
+
+The harness currently holds \textbf{74 checks} and passes in full. Every new code
+path ships with a check; this is principle~P2 in operational form. As one concrete
+data point, a cold workspace-symbol query whose raw index response is about
+$57{,}308$ tokens is capped to about $1{,}434$ tokens, roughly a $40\times$
+reduction.
+
+\subsection{Live language-server verification}
+Each of the four backends was verified end-to-end against the official engine, not a
+mock.
+
+\begin{itemize}
+  \item \textbf{C/C++ (clangd)} on a real Unreal Engine 5.x project.
+  \texttt{search\_symbol} returned a game \texttt{UCLASS} and its generated symbols
+  as \texttt{file:line}. Two reproducible facts came out of it. First,
+  \texttt{GenerateClangDatabase} needs \texttt{-Compiler=VisualCpp} when the targets
+  build with clang-cl. Second, a vendored clangd 19.1.5 deadlocks on a full game
+  translation unit in server mode, while a standalone clangd $\geq 22$ parses the
+  same unit in about thirteen seconds. We therefore probe the version and use a
+  persisted-index fast path that returns the moment the sought symbol's shard loads.
+  That path turns a $369$-second wait for the full background index into a
+  $51$-second answer once the static index is loaded, a $7\times$ cut in first-query
+  latency.
+  \item \textbf{C\# (Roslyn-based server)} against
+  Microsoft.CodeAnalysis.LanguageServer, the Visual Studio and C\# Dev Kit engine.
+  \item \textbf{JavaScript/TypeScript (\texttt{typescript-language-server})}
+  verified by running \texttt{vts} on its own source.
+  \item \textbf{Python (pyright)} through the same generic glue as TypeScript.
+\end{itemize}
+
+\subsection{Token savings telemetry}
+Over $441$ recorded searches by a single developer, the local ledger puts the capped
+output about $2\times$ smaller than forwarding the raw index responses: $263{,}540$
+tokens become $133{,}289$, a saving near $130{,}000$ tokens. The heaviest single
+query compacts $10.7\times$, from $21{,}056$ to $1{,}961$ tokens.
+
+Figure~\ref{fig:savings} and Table~\ref{tab:savings} break the saving down by tool.
+Document-outline suppression and text-search capping dominate.
+
+These figures count only the compaction of the search result itself. They omit the
+larger and harder-to-measure half: the file reads the agent never makes because it
+received \texttt{file:line} positions and a named symbol span instead of opening
+files. We surface part of that read-avoidance in the ledger by baselining
+\texttt{read\_symbol} against the whole file it replaces, which mirrors how Semble
+reports its savings ``combined with file reading''~\cite{semble-hn}.
+
+\begin{figure}[h]
+\centering
+\includegraphics[width=0.92\linewidth]{figures/savings.pdf}
+\caption{Per-tool token savings from the local ledger (441 searches, one developer).
+These are observational usage figures, not a controlled benchmark.}
+\label{fig:savings}
+\end{figure}
+
+\begin{table}[h]
+\centering
+\caption{Per-tool token savings from the local ledger. Observational telemetry.}
+\label{tab:savings}
+\begin{tabular}{lrr}
+\toprule
+Tool & Runs & Tokens saved \\
+\midrule
+\texttt{document\_symbols} & 10  & $\sim$84{,}354 \\
+\texttt{search\_text}      & 246 & $\sim$30{,}308 \\
+\texttt{search\_symbol}    & 32  & $\sim$9{,}122 \\
+\texttt{find\_references}  & 29  & $\sim$2{,}617 \\
+\texttt{insert\_symbol}    & 5   & $\sim$2{,}313 \\
+\midrule
+\textbf{vts total}         & 441 & $\sim$130{,}251 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\subsection{Enforcement coverage}
+An offline discovery scan over the agent's own session transcripts measures how much
+code search bypassed \texttt{vts}. On a large game-engine workload, the matcher's
+recent-window catch rate is about $68\%$.
+
+The two enforcement upgrades aimed at symbol-hunt grep are observed to intercept
+roughly $172$k tokens per month (the block on structural grep) and a further $319$k
+per month (the block on CamelCase-alternation grep).
+
+The same scan quantifies the edit habit. Over a 30-day window, $1{,}284$
+whole-declaration line edits read about $468$k tokens of file content first, and
+$93\%$ of them happened with no prior \texttt{vts} search on that file. That figure
+measures both the opportunity and the ceiling of a search-result-only steer, and it
+is why the edit-adoption ledger exists.
+
+\subsection{Threats to validity}
+We name the threats plainly.
+
+\emph{External validity.} The savings and enforcement telemetry come from one
+developer in one environment, so the absolute figures are existence proofs of the
+effect, not population estimates. A different codebase mix or working style would
+move them.
+
+\emph{Construct validity.} We measure tokens saved against the raw index response,
+which captures the formatting win but not whether the agent reached the same answer
+it would have reached from grep. We argue correctness from the use of a semantic
+engine and the live verifications, not from a task-success metric.
+
+\emph{Internal validity.} The ledger is instrumentation inside the same process it
+measures, and at least one input (the bundled log-compaction entry) is degenerate,
+which is why we partition it out rather than report a combined number.
+
+\emph{Reference quality.} Part of our related work cites practitioner posts rather
+than peer-reviewed venues, reflecting how recent the agent-LSP shift is. We mark
+those as such and place no load-bearing claim on them.
+
+\subsection{Artifact availability}
+\texttt{vs-token-safer} is released as an installable MCP plugin and CLI, and the
+evaluation in this section is reproducible from the repository. \texttt{node
+eval/run.mjs} runs the 74-check harness with no toolchain present, and \texttt{vts
+savings} prints the ledger underlying Table~\ref{tab:savings}.
+
+The figures in this paper are generated from version-controlled SVG sources
+(\texttt{figures/build.py}). The numbers reported here correspond to release
+v0.32.2; we recommend re-running both commands and rebuilding before citing exact
+values, since the ledger advances with use.
+
+\section{Discussion and Limitations}
+\label{sec:discuss}
+
+\paragraph{Where grep stays.}
+\texttt{vts} does not abolish lexical search; it bounds it. A language server exists
+only for file types that have one, while an agent's search needs cover all text in
+the tree.
+
+\texttt{vts} therefore keeps a capped text-search tool for the file-type-agnostic
+case, and reserves enforcement for the cases where a semantic answer is strictly
+better: symbol hunts, references, and renames. Freeform and keyword-alternation
+searches are left as warnings on purpose.
+
+\paragraph{Cold latency.}
+The honest price of using a real compiler front end is first-query latency on a
+cold, large index. \texttt{vts} softens it with prewarming, a persisted-index fast
+path, and a poll-until-the-shard-loads strategy, but it cannot erase it. A warm IDE
+that proxies an already-running language service still answers a first query sooner.
+Keeping the server resident at least pays the per-spawn cost once per session rather
+than once per call.
+
+\paragraph{Adoption is behavioral, not only technical.}
+The most striking measured gap is not in what the tool can do, but in whether the
+agent reaches for it. With a capped symbol-edit available, the agent still defaults
+to a line-based edit about nine times in ten.
+
+A permanent hard block proved counterproductive: it traps the agent into fighting
+the wall with retries. The levers that actually moved the number were a ready-to-run
+suggested call and a re-injected live adoption metric. Closing this gap is the open
+problem we care about most.
+
+\paragraph{On evaluation honesty.}
+Our quantitative results are usage telemetry and a deterministic harness, not a
+controlled multi-repository benchmark of answer quality against grep or against a
+persistent knowledge graph. The natural next step is that study: hold the agent and
+the tasks fixed, vary only the search backend, and measure tokens, wall-clock, and
+task success across a repository suite. We flag it as future work rather than present
+the current data as more than it is.
+
+\section{Conclusion}
+\label{sec:conc}
+
+\texttt{vs-token-safer} makes an agent's code search semantic, capped,
+zero-transmission, and enforced. It reuses the official language servers as the
+analysis engine and writes only the LSP-to-MCP glue. It returns positions rather
+than bodies, and it rewrites grep into the matching capped call at the hook.
+Together these lower the token and privacy cost of the navigation, reference, and
+rename class of operations, while leaving lexical search where it belongs.
+
+Set against a persistent knowledge graph, \texttt{vts} trades stored-index reach and
+breadth of language coverage for correctness by construction --- the compiler's own
+front end --- for freshness without an invalidation problem, and for a firm
+no-transmission guarantee.
+
+The problem we leave open is behavioral rather than technical: getting the agent to
+reach for the cheaper tool. There, live measurement and re-injection proved more
+effective than a wall.
+
+% ============================================================================
+\begin{thebibliography}{9}
+
+\bibitem{cbm}
+DeusData.
+\newblock Codebase-Memory: Tree-Sitter-Based Knowledge Graphs for LLM Code
+Exploration via MCP.
+\newblock arXiv:2603.27277, 2026. \url{https://arxiv.org/abs/2603.27277}
+
+\bibitem{anthropic-lsp}
+Anthropic.
+\newblock Native Language Server Protocol support in Claude Code (v2.0.74),
+December 2025.
+
+\bibitem{lsp-medium}
+V.\ Thiagarajan.
+\newblock LSP --- The Protocol Your IDE Uses Every Day (And Now Your AI Agent
+Does Too). Medium, 2026.
+
+\bibitem{semble-hn}
+Semble.
+\newblock Code search for agents that uses 98\% fewer tokens than grep.
+Hacker News, 2026. \url{https://news.ycombinator.com/item?id=48169874}
+
+\bibitem{yage-grep}
+Yage.
+\newblock Why Coding Agents Still Use grep as Their Search Backbone. 2026.
+\url{https://yage.ai/share/why-coding-agents-still-use-grep-en-20260327.html}
+
+\bibitem{hyperagent}
+H.\ N.\ Phan, T.\ N.\ Nguyen, P.\ X.\ Nguyen, and N.\ D.\ Q.\ Bui.
+\newblock HyperAgent: Generalist Software Engineering Agents to Solve Coding Tasks
+at Scale.
+\newblock arXiv:2409.16299, 2024.
+
+\end{thebibliography}
+
+\end{document}

--- a/server/core.js
+++ b/server/core.js
@@ -12,7 +12,7 @@ import path from "node:path";
 import { execFileSync, execSync } from "node:child_process";
 import { LspClient, fromUri, langIdForPath, envInt, canonFsPath } from "./lsp.js";
 import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot } from "./backends/index.js";
-import { recordQueryResults, languageCensus } from "./warmset.js";
+import { recordQueryResults, languageCensus, histRank } from "./warmset.js";
 import { splitSegments } from "./shell-split.js";
 import { classifyDeclEdit } from "./edit-detect.js";
 import { recordEditEvent } from "./edit-ledger.js";
@@ -923,6 +923,67 @@ function fmtSymbols(syms, max) {
   }
   return rows.map((r) => `${r.head}  @ ${r.loc}`).join("\n") + tail;
 }
+
+// ---- result RERANK (Semble-inspired, charter-pure) ----------------------------------------------------
+// Semble (cited) shows lexical+semantic FUSION + code-aware reranking beats either alone. We adopt the
+// RANKING idea WITHOUT its embeddings/persistent vector index (those are the cbm-style rejects: a second
+// semantic source + a storage/transmission surface). This reranks the OFFICIAL engine's own results, so it
+// is zero-transmission, holds no index, and changes no MCP surface. It matters because search_symbol CAPS to
+// top-N — order decides which rows survive the cap, i.e. whether the answer the model wants is even shown.
+// Score = lexical tier (exact > prefix > word/camel boundary > substring) + a callable-kind nudge + a
+// query-history boost (the SAME warmset LFU+recency signal that orders prewarm). Tiers are spaced so the
+// history boost only re-orders near-ties WITHIN a tier and can never flip a clearly-better lexical match.
+// STABLE: equal scores keep the LSP's original order, so behavior is unchanged when nothing out-ranks.
+// VTS_RANK=0 disables. Pure function (no I/O) — the caller supplies the history map.
+const rankEnabled = () => { const v = process.env.VTS_RANK; return v === undefined || v === "" ? true : !/^(0|false|off|no)$/i.test(v); };
+function lexScore(name, q) {
+  if (!name || !q) return 0;
+  const n = name.toLowerCase(), s = q.toLowerCase();
+  if (n === s) return 100;            // exact name
+  if (n.startsWith(s)) return 30;     // prefix
+  let i = n.indexOf(s);
+  if (i < 0) return 0;
+  while (i >= 0) {                     // any occurrence at a word/camel boundary
+    const prev = name[i - 1], cur = name[i];
+    if (i === 0 || prev === "_" || /[^A-Za-z0-9]/.test(prev) || (/[A-Z]/.test(cur) && /[a-z0-9]/.test(prev || ""))) return 10;
+    i = n.indexOf(s, i + 1);
+  }
+  return 3;                            // plain substring, no boundary
+}
+export function rankSymbols(query, syms, histMap) {
+  if (!Array.isArray(syms) || syms.length < 2) return syms;
+  const hist = histMap instanceof Map && histMap.size ? histMap : null;
+  const maxHist = hist ? Math.max(...hist.values()) : 0;
+  const scoreOf = (sm) => {
+    let sc = lexScore(sm && sm.name, query);
+    if (sm && CALLABLE_KIND.has(sm.kind)) sc += 2; // a symbol hunt usually wants a func/class/type, not a local
+    if (hist && maxHist > 0 && sm && sm.location) {
+      const key = fromUri(sm.location.uri).replace(/\\/g, "/").toLowerCase();
+      const h = hist.get(key);
+      if (h) sc += 2.5 * (h / maxHist); // < tier gap, so it only breaks near-ties / nudges within a tier
+    }
+    return sc;
+  };
+  return syms.map((s, i) => ({ s, i, sc: scoreOf(s) }))
+    .sort((a, b) => (b.sc - a.sc) || (a.i - b.i)) // stable: equal score keeps the engine's original order
+    .map((x) => x.s);
+}
+
+// CONFIDENCE-ADAPTIVE FOCUS: rerank lets us go one step further than Semble — once an EXACT-name match is in
+// a big result set, the model almost certainly wanted that one symbol (the "locate a known symbol" query,
+// the most common shape), so showing 60 rows wastes tokens on a tail it won't read. When an exact match
+// exists among many results, tighten the SHOWN count to the exact matches + a small head (the rest stay in
+// the "… N more (raise maxResults)" tail + the recovery tee — no silent cap). Broad/substring browses (no
+// exact match) keep the full cap. search_symbol ONLY — find_references must show every site. VTS_FOCUS=0 off.
+const focusEnabled = () => { const v = process.env.VTS_FOCUS; return v === undefined || v === "" ? true : !/^(0|false|off|no)$/i.test(v); };
+export function focusCap(query, syms, max) {
+  const FOCUS_N = envInt("VTS_FOCUS_N", 6);
+  if (!focusEnabled() || !Array.isArray(syms) || syms.length <= FOCUS_N) return max;
+  const ql = String(query || "").toLowerCase();
+  const exact = syms.filter((s) => (s && s.name ? s.name.toLowerCase() : "") === ql).length;
+  return exact >= 1 ? Math.min(max, Math.max(exact, FOCUS_N)) : max; // exact target → show it + a few, not the long tail
+}
+
 // Output-cap v2 (caveman "collapse repetition"): a refs-heavy result repeats the same long path on every
 // line. Collapse it — one line per FILE with all its line numbers joined, then factor a common DIRECTORY
 // prefix so a deep shared tree is printed ONCE. Every location is preserved and recoverable (full path =
@@ -1318,6 +1379,36 @@ const trimMatchLine = (s) => { const t = String(s).trim(); return t.length > 200
 // Doc/text extensions — the non-code text a grep over README/docs/config hits. Off by default (search_text
 // stays code-only per its contract); `docs=true` widens the sweep so a docs-grep can be compacted too.
 const DOC_EXTS = /\.(c|cc|cxx|cpp|h|hpp|hh|inl|ipp|tpp|cs|ts|tsx|mts|cts|js|jsx|mjs|cjs|py|pyi|md|markdown|txt|json|ya?ml|toml|ini|cfg|conf|xml|html?|csv|rst|tex)$/i;
+// CONCEPT (lexical-fuzzy) SEARCH — the charter-pure slice of the "find code that does X" gap. A true
+// semantic search needs embeddings (a second semantic source + a storage/transmission surface = the cbm/
+// Semble reject we DON'T adopt). But a MULTI-TERM query can be served lexically with no index and no
+// transmission: gather lines matching ANY term, then RANK by how many DISTINCT terms each line carries
+// (BM25-style coverage). It collapses the several greps a concept hunt would take into one ranked answer.
+// It is NOT synonym-aware — clearly labeled "lexical, ranked by term coverage". VTS_CONCEPT=0 disables.
+// conceptTerms(q) returns the term list when q LOOKS conceptual (≥2 whitespace tokens, each an alpha-led
+// word ≥3 chars, no regex metacharacters), else null (so a single token / a regex stays a literal scan).
+export function conceptTerms(q) {
+  const v = process.env.VTS_CONCEPT;
+  if (v !== undefined && v !== "" && /^(0|false|off|no)$/i.test(v)) return null;
+  const s = String(q || "");
+  if (/[.*+?^${}()|[\]\\<>:]/.test(s)) return null; // a regex / scope / template hunt → not a prose concept query
+  const toks = s.split(/\s+/).filter(Boolean);
+  if (toks.length < 2 || toks.length > 8) return null;
+  if (!toks.every((t) => /^[A-Za-z][A-Za-z0-9_]{2,}$/.test(t))) return null; // alpha-led words only
+  return [...new Set(toks.map((t) => t.toLowerCase()))];
+}
+// Rank lines by distinct-term coverage. Reuses scanTextUnder with an OR-regex to gather a wide pool, then
+// sorts by how many of the query's terms appear on each line (a line hitting all terms is most on-concept).
+function conceptScan(root, terms, max, accept) {
+  const safe = terms.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const pool = scanTextUnder(root, safe.join("|"), Math.min(Math.max(max * 8, 80), 600), accept);
+  const scored = pool
+    .map((line) => { const low = line.toLowerCase(); return { line, cov: terms.filter((t) => low.includes(t)).length }; })
+    .sort((a, b) => b.cov - a.cov); // most distinct terms first; stable within equal coverage (original walk order)
+  const out = scored.slice(0, max).map((x) => x.line);
+  out.truncated = pool.truncated || (scored.length > max ? "cap" : undefined);
+  return out;
+}
 function scanTextUnder(root, q, max, accept) {
   let re; try { re = new RegExp(q); } catch { re = new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")); }
   // `accept` decides which files to read: a RegExp tested against the filename (the ext set — code by
@@ -1633,8 +1724,15 @@ export async function runTool(name, a = {}) {
         scopeLabel = `glob ${String(a.glob)}`;
       } else {
         const ext = docs ? DOC_EXTS : undefined;
-        runScan = (n) => scanTextUnder(root, String(a.q), n, ext);
-        scopeLabel = docs ? "text+docs" : "text; for symbols prefer search_symbol";
+        const terms = conceptTerms(String(a.q));
+        if (terms) {
+          // multi-word query → lexical concept search: gather any-term hits, rank by distinct-term coverage.
+          runScan = (n) => conceptScan(root, terms, n, ext);
+          scopeLabel = docs ? "concept (text+docs, ranked by term coverage)" : "concept (lexical, ranked by term coverage)";
+        } else {
+          runScan = (n) => scanTextUnder(root, String(a.q), n, ext);
+          scopeLabel = docs ? "text+docs" : "text; for symbols prefer search_symbol";
+        }
       }
       const hits = runScan(max);
       if (!hits.length) {
@@ -1718,8 +1816,12 @@ export async function runTool(name, a = {}) {
       if (!a.q) return err("search_symbol needs q (the symbol name/substring).");
       const c = await getClient(root, backendName);
       const persisted = backendName === "clangd" && hasPersistedIndex(root);
-      const syms = await symbolReady(c, String(a.q), persisted, envInt("VTS_CLANGD_PERSISTED_WAIT_MS", 60000));
-      try { recordQueryResults(root, syms.map((s) => fromUri(s.location.uri))); } catch { /* best-effort */ }
+      const syms0 = await symbolReady(c, String(a.q), persisted, envInt("VTS_CLANGD_PERSISTED_WAIT_MS", 60000));
+      // Read the history signal BEFORE recording THIS query's results, so a result can't boost its own rank.
+      const histMap = rankEnabled() ? histRank(root) : null;
+      try { recordQueryResults(root, syms0.map((s) => fromUri(s.location.uri))); } catch { /* best-effort */ }
+      // Rerank the engine's results before fmtSymbols caps to top-N (Semble-inspired, zero-transmission).
+      const syms = histMap ? rankSymbols(String(a.q), syms0, histMap) : syms0;
       const adv = backendAdvisory(backendName, root);
       if (!syms.length) {
         // tsserver / pyright answer workspace/symbol from the files they have OPEN/indexed, so a symbol
@@ -1740,9 +1842,12 @@ export async function runTool(name, a = {}) {
         }
         return finishOut([], adv + `No symbols matching "${a.q}" (backend: ${backendName}).` + EMPTY_HINT + clangdIndexAdvisory(backendName, root, null));
       }
-      const symTee = teeOverflow("search_symbol", a.q, syms.map((s) => `${s.name} @ ${locLine(s.location.uri, s.location.range)}`), max);
+      // confidence-adaptive focus: an exact-name match in a big set → show it + a few, not the whole tail.
+      const focusN = focusCap(String(a.q), syms, max);
+      const symTee = teeOverflow("search_symbol", a.q, syms.map((s) => `${s.name} @ ${locLine(s.location.uri, s.location.range)}`), focusN);
       const symEdit = editSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10) ? EDIT_STEER : ""; // focused lookup → likely an edit precursor
-      return finishOut(syms, adv + `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root})${symTee}:\n` + fmtSymbols(syms, max) + symEdit);
+      const focusNote = focusN < max && focusN < syms.length ? ` — showing the ${focusN} best for an exact-name hit (raise maxResults or VTS_FOCUS=0 for all ${syms.length})` : "";
+      return finishOut(syms, adv + `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root})${focusNote}${symTee}:\n` + fmtSymbols(syms, focusN) + symEdit);
     }
     if (name === "find_references") {
       const c = await getClient(root, backendName);
@@ -1914,7 +2019,10 @@ export async function runTool(name, a = {}) {
       const fp = r.file.replace(/\\/g, "/");
       const ambl = r.ambiguous > 1 ? ` (${r.ambiguous} same-named — pass line= to disambiguate)` : "";
       try { recordQueryResults(root, [r.file]); } catch { /* best-effort */ }
-      return finishOut({ file: r.file, range: r.ds.range }, backendAdvisory(backendName, root) + `${SYMBOL_KIND[r.ds.kind] || "symbol"} "${a.symbol}" @ ${fp}:${sLine + 1}-${eLine + 1}${ambl} (backend: ${backendName}):\n` + body + note);
+      // #4 read-avoidance framing (Semble's "combined with file reading"): read_symbol's real win is the
+      // WHOLE-FILE Read it replaces, so the savings baseline is the whole file (not the tiny {file,range}) —
+      // the ledger then credits the avoided read, not ~0. (search/refs keep their index baseline.)
+      return finishOut(all.join("\n"), backendAdvisory(backendName, root) + `${SYMBOL_KIND[r.ds.kind] || "symbol"} "${a.symbol}" @ ${fp}:${sLine + 1}-${eLine + 1}${ambl} (backend: ${backendName}):\n` + body + note);
     }
     if (name === "rename") {
       if (!a.path || a.line == null || a.character == null || !a.newName) return err("rename needs path, line, character (0-based), newName.");

--- a/server/warmset.js
+++ b/server/warmset.js
@@ -81,7 +81,9 @@ export function recordQueryResults(root, files) {
   try { fs.mkdirSync(path.dirname(HIST_FILE), { recursive: true }); fs.writeFileSync(HIST_FILE, JSON.stringify(h)); } catch { /* best-effort */ }
 }
 
-function histRank(root) {
+// Exported so core.js can use the SAME query-history signal (LFU+recency) to RERANK live search results,
+// not only to order the warm-up open-set — a file that answered past searches is a strong relevance prior.
+export function histRank(root) {
   const bucket = readHist()[norm(root)];
   const m = new Map();
   if (!bucket) return m;


### PR DESCRIPTION
## Release: v0.33.0 — Semble-inspired result ranking + token cuts

One coherent theme: rank the **official engine's own** search results so the row
the model wants survives the cap, then trim the tail when we are confident -- all
**charter-pure** (no embeddings, no stored index, no transmission).

### Highlights

- **Result rerank** -- `search_symbol` reranks before the top-N cap: lexical tier
  (exact > prefix > word/camel boundary > substring) + callable-kind nudge +
  query-history boost. Stable (equal scores keep engine order). `VTS_RANK=0`.
- **Confidence-adaptive focus** -- an exact-name match in a big result shows it +
  a few neighbors, not 60 rows (rest in "... N more" + the recovery tee).
  `VTS_FOCUS=0` / `VTS_FOCUS_N`.
- **Lexical concept search** -- a multi-word `search_text` query is ranked by
  distinct-term coverage. The charter-pure slice of the "find code that does X"
  gap (synonym-aware search needs embeddings -> out of scope). `VTS_CONCEPT=0`.
- **Read-avoidance ledger** -- `read_symbol` baselines against the whole file it
  replaces, so savings credit the avoided read (Semble's "combined with file
  reading" framing).
- **docs/paper** -- arXiv-style preprint, EN + KO, describing the system.

### Why these and not more
Semble + Codebase-Memory were the migratable sources (ranking, call-graph,
content-hash, viz -- applied + measured). HyperAgent and Anthropic's native LSP
are already embodied (context-isolated locator subagent, preview-by-default symbol
edits, full LSP nav), so migrating more would duplicate or breach charter. We did
**not** adopt embeddings / vector search / a stored index.

### Verification
- `node eval/run.mjs` EVAL PASSED, 76 guards (added rerank + focus/concept/read-
  avoidance; both new guards assert stability). Fixed an eval orphan-child hang.
- `npm run lint` clean. MCP tool surface unchanged (14). CI green (Ubuntu +
  Windows, node 18/20/22, validate, lint).
- Dogfood: `vts discover` catch-rate ~74%; `vts savings` ~130k tokens saved.

### Review points
- History boost bounded below the lexical tier gap (only breaks near-ties).
- Focus applies to `search_symbol` only; `find_references` is never trimmed.
- Concept mode triggers only on multi-word, regex-free queries.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
