### PR TITLE
release: vs-token-safer 0.33.1 (A/B/C research features as a patch)

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1627,6 +1627,99 @@ const raLedger = (() => { try { return JSON.parse(fs.readFileSync(SV, "utf8")); 
 const readAvoidOk = !!(raLedger.tools && raLedger.tools.read_symbol && raLedger.tools.read_symbol.rawTok >= 2000); // whole-file baseline, not the tiny {file,range}
 try { fs.rmSync(raDir, { recursive: true, force: true }); } catch { /* ignore */ }
 const effectiveCutsOk = focusUnitOk && conceptUnitOk && conceptIntOk && readAvoidOk;
+
+// 76) completeness certificate — the semantic guarantee grep can't give: every result-bearing tool labels its
+// answer COMPLETE / PARTIAL / INCONCLUSIVE. The load-bearing distinction is PARTIAL (known, recoverable
+// remainder) vs INCONCLUSIVE (a bounded walk that may have missed — a 0 is not authoritative). Pure-fn modes +
+// a live search_text integration (a small, non-truncated scan certifies COMPLETE) + the VTS_CERT=0 toggle.
+const { completenessCert } = await import("../server/core.js");
+const certComplete = completenessCert({ shown: 3, total: 3, truncated: null, semantic: true }).includes("COMPLETE");
+const certPartial = (() => { const s = completenessCert({ shown: 60, total: 200, truncated: "cap", semantic: true }); return s.includes("PARTIAL") && s.includes("60 of 200"); })();
+const certTime = completenessCert({ shown: 0, truncated: "time", semantic: false }).includes("INCONCLUSIVE");
+const certIndex = completenessCert({ truncated: "index" }).includes("INCONCLUSIVE"); // partial-index 0 (ts/py) ≠ authoritative 0
+const certOff = (() => { const prev = process.env.VTS_CERT; process.env.VTS_CERT = "0"; const s = completenessCert({ shown: 1, total: 1 }); if (prev === undefined) delete process.env.VTS_CERT; else process.env.VTS_CERT = prev; return s === ""; })();
+const certDir = path.join(os.tmpdir(), `vts-eval-${process.pid}-cert`);
+fs.mkdirSync(certDir, { recursive: true });
+fs.writeFileSync(path.join(certDir, "c.js"), "const certToken123 = 1;\n");
+const certScan = await runTool("search_text", { q: "certToken123", projectPath: certDir }); // pure FS, no backend
+const certWired = /\[completeness: COMPLETE/.test(certScan.text || "");
+try { fs.rmSync(certDir, { recursive: true, force: true }); } catch { /* ignore */ }
+const certOk = certComplete && certPartial && certTime && certIndex && certOff && certWired;
+
+// 77) counterfactual shadow measurement — the quasi-controlled answer to "did vts reach the same answer as
+// grep?". relateSets classifies vts's answer set against grep's; maybeCounterfactual (opt-in
+// VTS_COUNTERFACTUAL=1) runs a local shadow grep, compares, and records — the grep output never reaches the
+// model. We assert the set algebra + the live wiring (a semantic hit that REFINES grep → "subset") + report.
+const { relateSets, readCounterfactual, counterfactualReport, counterfactualOn, recordCounterfactual } = await import("../server/counterfactual.js");
+const { maybeCounterfactual } = await import("../server/core.js");
+const relSubset = relateSets(["a:1"], ["a:1", "a:2"]) === "subset";       // vts ⊂ grep (refinement — the goal)
+const relSuperset = relateSets(["a:1", "a:2"], ["a:1"]) === "superset";   // vts ⊃ grep (found referents grep missed)
+const relEqual = relateSets(["a:1"], ["a:1"]) === "equal";
+const relEmptyGrep = relateSets(["a:1"], []) === "superset";              // grep found nothing literal; vts did
+const relDisjoint = relateSets(["a:1"], ["b:2"]) === "disjoint";
+const relSetsOk = relSubset && relSuperset && relEqual && relEmptyGrep && relDisjoint;
+const cfPrevOn = process.env.VTS_COUNTERFACTUAL, cfPrevFile = process.env.VTS_COUNTERFACTUAL_FILE;
+const cfFile = path.join(os.tmpdir(), `vts-eval-cf-${process.pid}.json`);
+process.env.VTS_COUNTERFACTUAL = "1"; process.env.VTS_COUNTERFACTUAL_FILE = cfFile;
+const cfToggleOk = counterfactualOn() === true;
+const cfDir = path.join(os.tmpdir(), `vts-eval-${process.pid}-cf`);
+fs.mkdirSync(cfDir, { recursive: true });
+const cfSrc = path.join(cfDir, "x.js");
+fs.writeFileSync(cfSrc, "const a = 1;\nfunction MyCounterSym() {}\nconst b = 2;\n// see MyCounterSym above\n"); // decl @ line 2, comment @ line 4
+const cfUri = cfSrc.replace(/\\/g, "/");
+maybeCounterfactual("search_symbol", "MyCounterSym", cfDir, [{ uri: cfUri, range: { start: { line: 1 } } }], "fake vts body"); // vts found ONLY the decl (line 2)
+const cfL = readCounterfactual();
+const cfRecorded = cfL.runs === 1 && cfL.tools && cfL.tools.search_symbol && cfL.tools.search_symbol.rel && cfL.tools.search_symbol.rel.subset === 1; // grep also hit the comment → vts ⊂ grep
+const cfReport = counterfactualReport(cfL);
+const cfReportOk = cfReport.includes("Counterfactual") && cfReport.includes("subset");
+// EDGE (UE-tree found): a truncated shadow-grep baseline must NOT yield a misleading subset/disjoint verdict
+// — it is recorded as "baseline-truncated" and the report flags the grep tokens as a lower bound.
+recordCounterfactual("search_symbol", { grepTok: 999, vtsTok: 10, relation: "baseline-truncated", truncatedBaseline: true });
+const cfTrunc = readCounterfactual();
+const cfTruncReport = counterfactualReport(cfTrunc);
+const cfTruncOk = cfTrunc.tools.search_symbol.truncatedBaseline === 1 &&
+  cfTrunc.tools.search_symbol.rel["baseline-truncated"] === 1 &&
+  cfTruncReport.includes("baseline-truncated") && cfTruncReport.includes("lower bound");
+if (cfPrevOn === undefined) delete process.env.VTS_COUNTERFACTUAL; else process.env.VTS_COUNTERFACTUAL = cfPrevOn;
+if (cfPrevFile === undefined) delete process.env.VTS_COUNTERFACTUAL_FILE; else process.env.VTS_COUNTERFACTUAL_FILE = cfPrevFile;
+try { fs.rmSync(cfDir, { recursive: true, force: true }); fs.rmSync(cfFile, { force: true }); } catch { /* ignore */ }
+const counterfactualEvalOk = relSetsOk && cfToggleOk && cfRecorded && cfReportOk && cfTruncOk;
+
+// 78) adaptive escalation controller — the closed loop over the edit-adoption ledger. decideEscalation picks
+// warn-vs-block from MEASURED per-modality conversion (self-correcting: stay soft when warns work; escalate
+// when warns fail and the block is untried/better; BACK OFF when the block was tried and isn't helping — the
+// documented "agent fights the wall" failure). We assert the policy across the regimes + the conversion
+// crediting (a symbol-edit credits the last-shown modality) + the report line.
+const ELc = await import("../server/edit-ledger.js");
+const mkEsc = (streak, w, b) => ({ streak, mod: { warn: { shown: w[0], converted: w[1] }, block: { shown: b[0], converted: b[1] } } });
+const escOff = ELc.decideEscalation(mkEsc(5, [0, 0], [0, 0]), 0) === false;                  // threshold 0 → off
+const escFloor = ELc.decideEscalation(mkEsc(1, [10, 0], [0, 0]), 3) === false;               // below patience floor
+const escWarnsWork = ELc.decideEscalation(mkEsc(3, [10, 8], [0, 0]), 3) === false;           // warns converting → stay soft
+const escTryBlock = ELc.decideEscalation(mkEsc(3, [10, 0], [0, 0]), 3) === true;             // warns fail, block untried → escalate
+const escBackOff = ELc.decideEscalation(mkEsc(3, [6, 2], [8, 0]), 3) === false;              // block tried & not converting → back off
+const escBothFail = ELc.decideEscalation(mkEsc(6, [3, 0], [3, 0]), 3) === false;             // BOTH failing, block tried ≥2 → absolute back-off (live-sim regression)
+const escBlockWins = ELc.decideEscalation(mkEsc(3, [8, 0], [4, 3]), 3) === true;             // block proven better → escalate
+const escPolicyOk = escOff && escFloor && escWarnsWork && escTryBlock && escBackOff && escBothFail && escBlockWins;
+const elPrev = process.env.VTS_EDIT_LEDGER;
+const elFresh = path.join(os.tmpdir(), `vts-eval-elctrl-${process.pid}.json`);
+try { fs.rmSync(elFresh, { force: true }); } catch { /* ignore */ }
+process.env.VTS_EDIT_LEDGER = elFresh;
+ELc.recordSteerShown("warn");
+const elAfterWarn = ELc.readEditLedger();
+ELc.recordEditEvent("symbol-edit"); // the agent switched → credit the pending "warn"
+const elAfterConv = ELc.readEditLedger();
+ELc.recordSteerShown("block");
+ELc.recordEditEvent("builtin-warn"); // a built-in edit instead → block shown but NOT converted
+const elAfterMiss = ELc.readEditLedger();
+const ctrlCreditOk =
+  elAfterWarn.mod.warn.shown === 1 && elAfterWarn.pending === "warn" &&
+  elAfterConv.symbol === 1 && elAfterConv.mod.warn.converted === 1 && elAfterConv.pending === null &&
+  elAfterMiss.mod.block.shown === 1 && elAfterMiss.mod.block.converted === 0 && elAfterMiss.builtin === 1;
+const ctrlReportOk = ELc.controllerReport(elAfterMiss).includes("warn 1/1") && ELc.controllerReport(elAfterMiss).includes("block 0/1");
+if (elPrev === undefined) delete process.env.VTS_EDIT_LEDGER; else process.env.VTS_EDIT_LEDGER = elPrev;
+try { fs.rmSync(elFresh, { force: true }); } catch { /* ignore */ }
+const adaptiveCtrlOk = escPolicyOk && ctrlCreditOk && ctrlReportOk;
+
 await disposeClients(); // guard 75's read_symbol spawned a backend AFTER the earlier teardown — dispose it so node exits
 
 const rows = [
@@ -1706,6 +1799,9 @@ const rows = [
   ["on-demand call graph + symbol autocomplete: buildCallGraph/listSymbols + /callgraph + /symbols routes", callGraphAllOk, "true", callGraphAllOk],
   ["result rerank (Semble-inspired, charter-pure): lexical+kind+history, stable, before the cap", rerankOk, "true", rerankOk],
   ["effective cuts: focus (exact→few) + concept (multi-term rank) + read-avoidance ledger", effectiveCutsOk, "true", effectiveCutsOk],
+  ["completeness certificate: COMPLETE/PARTIAL/INCONCLUSIVE label + wired into search_text + toggle", certOk, "true", certOk],
+  ["counterfactual shadow grep: relateSets algebra + maybeCounterfactual records (vts⊆grep) + report + toggle", counterfactualEvalOk, "true", counterfactualEvalOk],
+  ["adaptive escalation controller: warn/block policy (soft/escalate/back-off) + conversion crediting + report", adaptiveCtrlOk, "true", adaptiveCtrlOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -35,7 +35,7 @@ import { splitSegments } from "../server/shell-split.js";
 // Whole-declaration edit detector, shared with discover (core.js) so the set we STEER matches the set we
 // MEASURE; the adoption ledger is the live metric the steer is tuned against.
 import { classifyDeclEdit } from "../server/edit-detect.js";
-import { recordEditEvent, resetStreak } from "../server/edit-ledger.js";
+import { recordEditEvent, resetStreak, recordSteerShown, decideEscalation } from "../server/edit-ledger.js";
 
 const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(os.homedir(), ".vs-token-safer", "config.json");
 const readConfig = () => { try { return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8")) || {}; } catch { return {}; } };
@@ -565,11 +565,17 @@ process.stdin.on("end", () => {
         // not a wall. VTS_GREP_BLOCK=0 also holds it to warn (shares the master block switch).
         const after = Number(process.env.VTS_EDIT_BLOCK_AFTER);
         const threshold = Number.isFinite(after) && after >= 0 ? after : 0; // OFF by default (block traps the model)
-        if (grepBlockOn() && threshold > 0 && led.streak >= threshold && ce.insertDecl && !ce.replaceDecl) {
+        // ADAPTIVE controller (replaces the static `streak >= threshold`): escalate to the one-shot block only
+        // when warns aren't converting AND the block is untried-or-proven-better; back off to warn if the block
+        // has been tried and isn't helping (the "agent fights the wall" failure). Block stays on the SAFE
+        // subset (a pure insert — insert_symbol can't corrupt) and the master grep-block switch.
+        if (grepBlockOn() && ce.insertDecl && !ce.replaceDecl && decideEscalation(led, threshold)) {
+          recordSteerShown("block"); // mark block as shown so its conversion (next symbol-edit?) is measured
           resetStreak(); // fire ONCE then back off — no permanent wall
-          process.stderr.write(editNudgeFor(toolName, ti) + " (one-time block: the nudge was ignored " + led.streak + "× — use insert_symbol (position=after|before) for this insert. Set VTS_EDIT_BLOCK_AFTER=0 to disable entirely.)" + setup + "\n");
+          process.stderr.write(editNudgeFor(toolName, ti) + " (one-time block: warns weren't converting (streak " + led.streak + ", adaptive) — use insert_symbol (position=after|before) for this insert. Set VTS_EDIT_BLOCK_AFTER=0 to disable entirely.)" + setup + "\n");
           process.exit(2); // block — route the safe insert to a symbol-edit
         }
+        recordSteerShown("warn"); // mark warn as shown so its conversion is measured by the controller
         emitWarn(editNudgeFor(toolName, ti) + setup);
       }
     }

--- a/hooks/edit-report.js
+++ b/hooks/edit-report.js
@@ -4,15 +4,19 @@
 // + discover MEASURE, this RE-INJECTS the gap as a concrete goal, behavior shifts, and the next session
 // measures again (the SkillOpt textual-gradient cadence — a static skill rule can't self-improve, but a
 // re-injected live metric can). Stays quiet until there's enough data to be worth a line of context.
-import { readEditLedger, adoptionPct } from "../server/edit-ledger.js";
+import { readEditLedger, adoptionPct, controllerReport } from "../server/edit-ledger.js";
 
 try {
   const o = readEditLedger();
   const pct = adoptionPct(o);
   const total = (o.builtin || 0) + (o.symbol || 0);
   if (pct === null || total < 5) process.exit(0); // too little data — don't nag
+  // Surface the adaptive controller's per-modality conversions only once it has signal (a steer was shown),
+  // so the model sees WHICH lever is moving the number, not just the aggregate ratio.
+  const hasSteerData = ((o.mod && o.mod.warn && o.mod.warn.shown) || 0) + ((o.mod && o.mod.block && o.mod.block.shown) || 0) > 0;
+  const ctrl = hasSteerData ? ` [${controllerReport(o)}]` : "";
   const msg =
-    `[vs-token-safer] Symbol-edit adoption: ${pct}% (${o.symbol || 0} symbol-edit vs ${o.builtin || 0} built-in Edit on whole declarations). ` +
+    `[vs-token-safer] Symbol-edit adoption: ${pct}% (${o.symbol || 0} symbol-edit vs ${o.builtin || 0} built-in Edit on whole declarations).${ctrl} ` +
     `When you ADD or REPLACE a whole declaration this session, prefer replace_symbol_body / insert_symbol — ` +
     `they edit by NAME and skip reading the file into context. Aim to raise the ratio. (Built-in Edit stays right for sub-declaration tweaks.)`;
   process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: msg } }) + "\n");

--- a/server/core.js
+++ b/server/core.js
@@ -15,6 +15,7 @@ import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPers
 import { recordQueryResults, languageCensus, histRank } from "./warmset.js";
 import { splitSegments } from "./shell-split.js";
 import { classifyDeclEdit } from "./edit-detect.js";
+import { counterfactualOn, relateSets, recordCounterfactual, grepKey, locKey, counterfactualReport } from "./counterfactual.js";
 import { recordEditEvent } from "./edit-ledger.js";
 import { compactGit, compactP4 } from "./compact.js";
 
@@ -319,6 +320,7 @@ function savingsReport(a = {}) {
   if (want("history")) {
     body += `\n\nRecent runs:\n` + (s.history || []).slice().reverse().map((h) => `  ${h.t.replace("T", " ").slice(0, 19)}  ${h.raw.toLocaleString()} → ${h.out.toLocaleString()} tok`).join("\n");
   }
+  body += counterfactualReport(); // "" unless VTS_COUNTERFACTUAL=1 has recorded shadow-grep comparisons
   return body + starNudgeLine(totalSaved) + `\n\nLedger: ${SAVINGS_FILE}`;
 }
 
@@ -1031,6 +1033,33 @@ function factorCommonPrefix(lines) {
   if (!prefix) return lines.join("\n");
   return `under ${prefix}/\n` + lines.map((l) => "  " + l.slice(prefix.length + 1)).join("\n");
 }
+// ── Completeness certificate — the semantic guarantee grep cannot give ──────────────────────────────────
+// Every result-bearing tool states whether the answer set is COMPLETE (the engine/scan covered everything),
+// PARTIAL (capped — more exist and the remainder is KNOWN and recoverable via the cap/tee), or INCONCLUSIVE
+// (a bounded walk hit a time/scan limit before finishing, so the remainder is UNKNOWN — a real 0 and an
+// unreached-0 are indistinguishable). The crucial, paper-load-bearing distinction is PARTIAL vs INCONCLUSIVE:
+// grep returns a flat match list with no signal about either; a semantic index can certify COMPLETE, and a
+// bounded lexical walk can at least honestly flag INCONCLUSIVE instead of presenting a possibly-truncated 0 as
+// fact. The tag is additive (the human-facing notes elsewhere stay) and machine-readable. VTS_CERT=0 hides it.
+function certOn() { return !/^(0|false|off|no)$/i.test(String(process.env.VTS_CERT ?? "1")); }
+// truncated: falsy | "cap" | "time" | "scan". semantic=true → a language-server index answered (authoritative
+// 0); false → a bounded lexical scan. shown/total optional (total null = unknown upper bound).
+function completenessCert({ shown = 0, total = null, truncated = null, semantic = false } = {}) {
+  if (!certOn()) return "";
+  if (truncated === "time" || truncated === "scan") {
+    const how = truncated === "time" ? "time-boxed" : "scan-limited";
+    return `\n[completeness: INCONCLUSIVE — a bounded ${how} walk did not cover the whole tree, so this result (a 0 included) may be incomplete; narrow the scope or use a semantic tool (search_symbol/find_references) to certify.]`;
+  }
+  if (truncated === "index") {
+    return `\n[completeness: INCONCLUSIVE — this backend answers from open/indexed files only, so a symbol whose file isn't indexed yet can be missed; this is not an authoritative 0.]`;
+  }
+  if (truncated === "cap" || (total != null && shown < total)) {
+    const more = total != null ? `${shown} of ${total}` : `the top ${shown}`;
+    return `\n[completeness: PARTIAL — showing ${more}; the remainder is known and recoverable (raise the cap or read the tee file).]`;
+  }
+  return `\n[completeness: COMPLETE — ${semantic ? "the language-server index" : "the bounded scan"} returned every match (${shown}).]`;
+}
+export { completenessCert };
 function fmtLocations(locs, max, label) {
   const arr = Array.isArray(locs) ? locs : locs ? [locs] : [];
   const shown = arr.slice(0, max);
@@ -1439,6 +1468,30 @@ function scanTextUnder(root, q, max, accept) {
   else if (timedOut) out.truncated = "time";
   return out;
 }
+// Counterfactual shadow measurement (opt-in VTS_COUNTERFACTUAL=1): run a LOCAL literal grep for the same
+// symbol NAME, compare what grep WOULD have returned (tokens + match positions) against the vts answer, and
+// record the comparison. The grep output is DISCARDED — only the numbers reach the local ledger, never the
+// model (zero transmission, zero added model cost). Bounded by scanTextUnder's 4s time-box; any failure is
+// swallowed so a measurement never breaks a query. `locs` items each carry {uri, range}. See
+// server/counterfactual.js for the construct-validity rationale.
+export function maybeCounterfactual(tool, name, root, locs, vtsBody) {
+  if (!counterfactualOn() || !name) return;
+  try {
+    const grepHits = scanTextUnder(root, String(name), 5000);
+    const grepTok = rawTokensOf(grepHits.join("\n"));
+    const vtsTok = tok(vtsBody);
+    const vtsKeys = (locs || []).map((l) => locKey(l.uri, l.range)).filter(Boolean);
+    const grepKeys = grepHits.map(grepKey).filter(Boolean);
+    // EDGE CASE (UE-tree dogfood): on a giant tree the shadow grep itself hits its cap or 4s time-box, so the
+    // grep BASELINE is truncated. Comparing the vts set against a truncated baseline is unreliable — the two
+    // can look "disjoint" merely because grep only reached other directories. So when the baseline truncated,
+    // do NOT compute a set relation (record "baseline-truncated"); the token figure is then a LOWER bound on
+    // what a complete grep would have spent, flagged as such in the report.
+    const truncatedBaseline = !!grepHits.truncated;
+    const relation = truncatedBaseline ? "baseline-truncated" : relateSets(vtsKeys, grepKeys);
+    recordCounterfactual(tool, { grepTok, vtsTok, relation, truncatedBaseline });
+  } catch { /* best-effort — never break a query for a measurement */ }
+}
 // Filename glob (* ?) → a predicate over basenames, for a TARGETED text search (`search_text glob=*.md`).
 // Naming the glob IS the opt-in to whatever extension it covers — no separate docs flag needed.
 function globAccept(glob) {
@@ -1695,10 +1748,11 @@ export async function runTool(name, a = {}) {
       const root = resolveRoot(a);
       const max = Number(a.maxResults) || MAX_RESULTS;
       const files = findFilesUnder(root, String(a.q), max);
-      if (!files.length) return finishOut([], `No files matching "${a.q}" under ${root}.` + LOG_EMPTY_HINT);
+      if (!files.length) return finishOut([], `No files matching "${a.q}" under ${root}.` + LOG_EMPTY_HINT + completenessCert({ shown: 0, total: files.truncated ? null : 0, truncated: files.truncated || null, semantic: false }));
       let ft = files.truncated === "cap" ? ` — capped at ${max} (raise maxResults or narrow q; more exist)` : files.truncated === "scan" ? ` — scan limit hit (narrow projectPath; more exist)` : "";
       if (files.truncated) ft += teeNote("find_files", a.q, root, (n) => findFilesUnder(root, String(a.q), n));
-      return finishOut(files, `${files.length} file(s) matching "${a.q}"${ft}:\n` + factorCommonPrefix(files));
+      const filesCert = completenessCert({ shown: files.length, total: files.truncated ? null : files.length, truncated: files.truncated || null, semantic: false });
+      return finishOut(files, `${files.length} file(s) matching "${a.q}"${ft}:\n` + factorCommonPrefix(files) + filesCert);
     }
     if (name === "search_text") {
       if (!a.q) return err("search_text needs q (a string or regex to find in code).");
@@ -1741,14 +1795,16 @@ export async function runTool(name, a = {}) {
         // symbol hunt to find_references (semantic, walks no tree, complete).
         const toNote = hits.truncated === "time" ? " — but the 4s time-box hit before the scan finished, so this 0 is NOT conclusive (the walk didn't cover the whole tree; a real 0 and an unreached-in-time 0 are indistinguishable here)" : "";
         const emptySteer = (!docs && !a.path && hits.truncated) ? textSymbolSteer(a.q, true) : "";
-        return finishOut([], `No text matches for "${a.q}" (${scopeLabel}) under ${root}${toNote}.` + LOG_EMPTY_HINT + emptySteer);
+        const emptyTextCert = completenessCert({ shown: 0, total: hits.truncated ? null : 0, truncated: hits.truncated || null, semantic: false });
+        return finishOut([], `No text matches for "${a.q}" (${scopeLabel}) under ${root}${toNote}.` + LOG_EMPTY_HINT + emptySteer + emptyTextCert);
       }
       let tt = hits.truncated === "cap" ? ` — capped at ${max} (raise maxResults or narrow q; more exist)` : hits.truncated === "time" ? ` — 4s time-box hit (narrow projectPath/q; more matches likely exist)` : "";
       if (hits.truncated) tt += teeNote("search_text", a.q, root, runScan);
       // Steer a symbol/class usage hunt toward find_references/search_symbol (complete + far smaller than a
       // time-boxed text scan). Only on a CODE scan — a doc/single-file target is an intentional text lookup.
       const steer = (!docs && !a.path) ? textSymbolSteer(a.q, hits.truncated) : "";
-      return finishOut(hits, `${hits.length} match(es) for "${a.q}" (${scopeLabel})${tt}:\n` + factorCommonPrefix(hits) + steer);
+      const textCert = completenessCert({ shown: hits.length, total: hits.truncated ? null : hits.length, truncated: hits.truncated || null, semantic: false });
+      return finishOut(hits, `${hits.length} match(es) for "${a.q}" (${scopeLabel})${tt}:\n` + factorCommonPrefix(hits) + steer + textCert);
     }
     // vts_git / vts_p4 — run the real VCS command and COMPACT its output before it reaches the model. The
     // language-server index can't help here (status/log/diff/opened aren't source symbols), but the raw dump
@@ -1840,14 +1896,19 @@ export async function runTool(name, a = {}) {
             return finishOut(hits, adv + `No indexed symbol for "${a.q}" — ${why}. Literal text matches instead (file:line of the name, not a semantic decl):\n` + hits.join("\n"));
           }
         }
-        return finishOut([], adv + `No symbols matching "${a.q}" (backend: ${backendName}).` + EMPTY_HINT + clangdIndexAdvisory(backendName, root, null));
+        const partialIdx = backendName === "typescript" || backendName === "pyright" || (backendName === "clangd" && !hasCompileDb(root));
+        const emptyCert = completenessCert({ shown: 0, total: 0, truncated: partialIdx ? "index" : null, semantic: true });
+        return finishOut([], adv + `No symbols matching "${a.q}" (backend: ${backendName}).` + EMPTY_HINT + clangdIndexAdvisory(backendName, root, null) + emptyCert);
       }
       // confidence-adaptive focus: an exact-name match in a big set → show it + a few, not the whole tail.
       const focusN = focusCap(String(a.q), syms, max);
       const symTee = teeOverflow("search_symbol", a.q, syms.map((s) => `${s.name} @ ${locLine(s.location.uri, s.location.range)}`), focusN);
       const symEdit = editSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10) ? EDIT_STEER : ""; // focused lookup → likely an edit precursor
       const focusNote = focusN < max && focusN < syms.length ? ` — showing the ${focusN} best for an exact-name hit (raise maxResults or VTS_FOCUS=0 for all ${syms.length})` : "";
-      return finishOut(syms, adv + `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root})${focusNote}${symTee}:\n` + fmtSymbols(syms, focusN) + symEdit);
+      const symCert = completenessCert({ shown: Math.min(focusN, syms.length), total: syms.length, truncated: focusN < syms.length ? "cap" : null, semantic: true });
+      const symBody = adv + `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root})${focusNote}${symTee}:\n` + fmtSymbols(syms, focusN) + symEdit + symCert;
+      maybeCounterfactual("search_symbol", String(a.q), root, syms.map((s) => s.location), symBody);
+      return finishOut(syms, symBody);
     }
     if (name === "find_references") {
       const c = await getClient(root, backendName);
@@ -1924,7 +1985,10 @@ export async function runTool(name, a = {}) {
       // detail=file|dir → a blast-radius summary (dependents grouped + ranked) instead of the per-line list.
       const detail = String(a.detail || "").toLowerCase();
       const refBody = (detail === "file" || detail === "dir") ? fmtRefSummary(locList, detail, max) : fmtLocations(locs, max, "reference(s)");
-      return finishOut(locs, backendAdvisory(backendName, root) + `references of ${originLabel} (backend: ${backendName})${refTee}:\n` + refBody);
+      const refCert = completenessCert({ shown: Math.min(locList.length, max), total: locList.length, truncated: locList.length > max ? "cap" : null, semantic: true });
+      const refBodyFull = backendAdvisory(backendName, root) + `references of ${originLabel} (backend: ${backendName})${refTee}:\n` + refBody + refCert;
+      if (a.symbol) maybeCounterfactual("find_references", String(a.symbol), root, locList, refBodyFull); // by-name → a NAME to shadow-grep
+      return finishOut(locs, refBodyFull);
     }
     if (name === "goto_definition") {
       if (!a.path || a.line == null || a.character == null) return err("goto_definition needs path, line, character (0-based position).");

--- a/server/counterfactual.js
+++ b/server/counterfactual.js
@@ -1,0 +1,96 @@
+// Counterfactual shadow measurement — the quasi-controlled answer to the construct-validity question
+// "did the agent reach the SAME answer it would have reached from grep?". When VTS_COUNTERFACTUAL=1 (opt-in:
+// it doubles local CPU per semantic query, OFF by default), a semantic search (search_symbol /
+// find_references) ALSO runs a LOCAL shadow grep over the same scope. The shadow result NEVER reaches the
+// model — only the comparison is recorded: how many tokens grep WOULD have spent, how many vts spent, and how
+// the answer SETS relate. Semantic search is expected to REFINE grep — a SUBSET of grep's textual hits (it
+// drops comment / string-literal / substring look-alikes) while still covering the real referents — so a
+// "subset" verdict is the desired one, not a miss. This turns the observational token-saving telemetry into a
+// measured comparison against the baseline it claims to beat. Zero transmission: a local JSON ledger, no
+// network; local CPU only. Mirrors the savings-ledger conventions in core.js.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { canonFsPath } from "./lsp.js";
+
+const tok = (s) => Math.round(Buffer.byteLength(String(s), "utf8") / 4); // core.js:119 parity
+export const counterfactualOn = () => /^(1|true|on|yes)$/i.test(String(process.env.VTS_COUNTERFACTUAL ?? "0"));
+const LEDGER = () => process.env.VTS_COUNTERFACTUAL_FILE || path.join(os.homedir(), ".vs-token-safer", "counterfactual.json");
+
+export function readCounterfactual() {
+  try { return JSON.parse(fs.readFileSync(LEDGER(), "utf8")); } catch { return { runs: 0, tools: {} }; }
+}
+function write(o) {
+  try { const p = LEDGER(); fs.mkdirSync(path.dirname(p), { recursive: true }); fs.writeFileSync(p, JSON.stringify(o, null, 2)); } catch { /* best-effort */ }
+}
+
+// A scanTextUnder hit is `<abs-path>:<line>: <text>` (forward-slash path, 1-based line). Parse to the
+// canonical `<canonpath>:<line>` key so it compares against a vts location key on the same basis. The path
+// can itself contain a drive colon (`G:/…`), so match the LAST `:<digits>:` — `.*` is greedy.
+const HIT_RE = /^(.*):(\d+):/;
+export function grepKey(hit) {
+  const m = HIT_RE.exec(String(hit));
+  if (!m) return null;
+  return canonFsPath(m[1]) + ":" + m[2];
+}
+// A vts location → the same `<canonpath>:<line>` key (1-based line to match the grep hit).
+export function locKey(uri, range) {
+  const line = (((range || {}).start || {}).line ?? 0) + 1;
+  return canonFsPath(uri) + ":" + line;
+}
+
+// Relate two answer sets by (canonical-path, line). "equal" | "subset" (vts ⊆ grep — the REFINEMENT case) |
+// "superset" (vts ⊇ grep — vts found cross-file/semantic referents grep's literal scan missed) | "overlap" |
+// "disjoint". Empty grep set with a non-empty vts set → "superset" (vts found what a literal scan couldn't).
+export function relateSets(vtsKeys, grepKeys) {
+  const v = new Set(vtsKeys.filter(Boolean));
+  const g = new Set(grepKeys.filter(Boolean));
+  if (!v.size && !g.size) return "equal";
+  if (!g.size) return "superset";
+  if (!v.size) return "subset";
+  let inG = 0; for (const k of v) if (g.has(k)) inG++;
+  const vSubG = inG === v.size;
+  const gSubV = [...g].every((k) => v.has(k));
+  if (vSubG && gSubV) return "equal";
+  if (vSubG) return "subset";
+  if (gSubV) return "superset";
+  return inG ? "overlap" : "disjoint";
+}
+
+// Record one comparison into the per-tool ledger.
+export function recordCounterfactual(tool, { grepTok = 0, vtsTok = 0, relation = "n/a", truncatedBaseline = false } = {}) {
+  const o = readCounterfactual();
+  o.runs = (o.runs || 0) + 1;
+  o.tools = o.tools || {};
+  const t = (o.tools[tool] = o.tools[tool] || { runs: 0, grepTok: 0, vtsTok: 0, truncatedBaseline: 0, rel: {} });
+  t.runs++; t.grepTok += grepTok; t.vtsTok += vtsTok;
+  if (truncatedBaseline) t.truncatedBaseline = (t.truncatedBaseline || 0) + 1;
+  t.rel = t.rel || {};
+  t.rel[relation] = (t.rel[relation] || 0) + 1;
+  write(o);
+  return o;
+}
+export { tok as cfTok };
+
+// A `vts savings`-style section: tokens grep WOULD have spent vs vts, and the distribution of set relations.
+// Returns "" when no counterfactual data exists (the feature is opt-in, so this is the common case).
+export function counterfactualReport(o = readCounterfactual()) {
+  if (!o.runs) return "";
+  let grepTok = 0, vtsTok = 0, truncated = 0; const rel = {};
+  for (const t of Object.values(o.tools || {})) {
+    grepTok += t.grepTok || 0; vtsTok += t.vtsTok || 0; truncated += t.truncatedBaseline || 0;
+    for (const [k, n] of Object.entries(t.rel || {})) rel[k] = (rel[k] || 0) + n;
+  }
+  const ratio = vtsTok > 0 ? (grepTok / vtsTok).toFixed(1) : "∞";
+  const relStr = Object.entries(rel).sort((a, b) => b[1] - a[1]).map(([k, n]) => `${k} ${n}`).join(", ") || "—";
+  // On a giant tree the shadow grep truncates, so its token figure is a LOWER bound and its set relation is
+  // not comparable — say so rather than present a misleading "disjoint".
+  const caveat = truncated
+    ? `\n  note: ${truncated} comparison(s) had a TRUNCATED grep baseline (capped/time-boxed on a large tree) ` +
+      `— for those the grep tokens are a lower bound and the set relation is recorded as "baseline-truncated", not a verdict`
+    : "";
+  return `\n\nCounterfactual (shadow grep, ${o.runs} comparison(s) — opt-in VTS_COUNTERFACTUAL=1):` +
+    `\n  grep would have spent ~${grepTok.toLocaleString()} tok vs vts ~${vtsTok.toLocaleString()} tok (~${ratio}× smaller)` +
+    `\n  answer-set vs grep: ${relStr}  (subset = vts refined grep's textual hits; superset = vts found referents grep missed)` +
+    caveat;
+}

--- a/server/edit-ledger.js
+++ b/server/edit-ledger.js
@@ -1,27 +1,54 @@
-// Edit-adoption ledger — the live metric for the symbol-edit steering loop (the SkillOpt-style "score"):
-// how often a whole-declaration edit went through a vts symbol-edit tool (the behavior we want) vs the
-// built-in Edit (which we warned on). The hook records a builtin-warn; core.js records a symbol-edit. The
-// `streak` (consecutive builtin-warns since the last symbol-edit) drives the L2 auto-escalation, and the
+// Edit-adoption ledger + adaptive escalation controller — the live metric AND the closed loop for the
+// symbol-edit steering (the SkillOpt-style "score"): how often a whole-declaration edit went through a vts
+// symbol-edit tool (the behavior we want) vs the built-in Edit (which we warned on). The hook records a
+// builtin-warn; core.js records a symbol-edit. The `streak` (consecutive builtin-warns since the last
+// symbol-edit) is the patience floor; on top of it an ADAPTIVE CONTROLLER decides whether to escalate from a
+// warn to the one-shot block, using MEASURED per-modality conversion rather than a fixed threshold. The
 // SessionStart self-report reads the ratio back to the model as a goal. Local JSON, best-effort, never throws.
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 const LEDGER = () => process.env.VTS_EDIT_LEDGER || path.join(os.homedir(), ".vs-token-safer", "edit-adoption.json");
+const freshMod = () => ({ warn: { shown: 0, converted: 0 }, block: { shown: 0, converted: 0 } });
 
 export function readEditLedger() {
-  try { return JSON.parse(fs.readFileSync(LEDGER(), "utf8")); } catch { return { builtin: 0, symbol: 0, streak: 0 }; }
+  try {
+    const o = JSON.parse(fs.readFileSync(LEDGER(), "utf8"));
+    o.mod = o.mod || freshMod();
+    o.mod.warn = o.mod.warn || { shown: 0, converted: 0 };
+    o.mod.block = o.mod.block || { shown: 0, converted: 0 };
+    if (!("pending" in o)) o.pending = null;
+    return o;
+  } catch { return { builtin: 0, symbol: 0, streak: 0, mod: freshMod(), pending: null }; }
 }
 function write(o) {
   try { const p = LEDGER(); fs.mkdirSync(path.dirname(p), { recursive: true }); fs.writeFileSync(p, JSON.stringify(o)); } catch { /* best-effort */ }
 }
-// kind: "symbol-edit" (a vts symbol-edit tool was used → adoption up, ignore-streak reset) or anything else
-// (a whole-decl edit went through the built-in Edit and we warned → builtin up, streak up). Returns the
-// updated ledger so the caller (the hook) can read the fresh streak for an escalation decision.
+// kind: "symbol-edit" (a vts symbol-edit tool was used → adoption up, ignore-streak reset, and the steer
+// modality last shown is CREDITED as having converted) or anything else (a whole-decl edit went through the
+// built-in Edit and we warned → builtin up, streak up; the pending modality stays shown-not-converted).
+// Returns the updated ledger so the caller (the hook) can read the fresh streak/stats for an escalation call.
 export function recordEditEvent(kind) {
   const o = readEditLedger();
-  if (kind === "symbol-edit") { o.symbol = (o.symbol || 0) + 1; o.streak = 0; }
-  else { o.builtin = (o.builtin || 0) + 1; o.streak = (o.streak || 0) + 1; }
+  if (kind === "symbol-edit") {
+    o.symbol = (o.symbol || 0) + 1; o.streak = 0;
+    // The agent SWITCHED to a symbol-edit — credit whichever steer modality was last shown (the conversion).
+    if (o.pending && o.mod[o.pending]) o.mod[o.pending].converted = (o.mod[o.pending].converted || 0) + 1;
+    o.pending = null;
+  } else {
+    o.builtin = (o.builtin || 0) + 1; o.streak = (o.streak || 0) + 1;
+    // A whole-decl edit went to the built-in tool: the previously-shown modality (still pending) did NOT
+    // convert. Leave it shown-not-converted; recordSteerShown sets the next pending modality.
+  }
+  write(o);
+  return o;
+}
+// Record that a steer MODALITY was just shown ("warn" | "block") and mark it pending, so the next symbol-edit
+// (if any) credits it as a conversion. This is what gives the controller its per-modality conversion signal.
+export function recordSteerShown(modality) {
+  const o = readEditLedger();
+  if (o.mod[modality]) { o.mod[modality].shown = (o.mod[modality].shown || 0) + 1; o.pending = modality; }
   write(o);
   return o;
 }
@@ -37,4 +64,45 @@ export function resetStreak() {
   const o = readEditLedger();
   o.streak = 0;
   write(o);
+}
+
+// Laplace-smoothed conversion rate of a modality: (converted+1)/(shown+2). The +1/+2 prior reads an unproven
+// modality as ~0.5 (neither trusted nor distrusted), so the controller will EXPLORE it once before judging.
+function rate(m) { const s = (m && m.shown) || 0, c = (m && m.converted) || 0; return (c + 1) / (s + 2); }
+
+// Adaptive escalation controller — the closed loop. Given a warn-eligible whole-decl edit, decide whether to
+// ESCALATE to the one-shot block instead of merely warning, using MEASURED conversion rather than a fixed
+// streak threshold. Returns true (escalate → block) or false (warn only). Self-correcting:
+//   • warns ARE converting (warnRate ≥ VTS_WARN_OK) → stay soft (don't escalate).
+//   • warns failing AND the block is untried-or-PROVEN-better → escalate (explore/exploit the block).
+//   • warns failing AND the block was tried but is NOT out-converting the warn (the documented "agent fights
+//     the wall" failure) → BACK OFF to warn (escalating again would only re-trap it).
+// `threshold` is the patience floor (VTS_EDIT_BLOCK_AFTER); 0 keeps escalation OFF entirely (current default),
+// so this is a strict superset of the old static behavior — opt-in, and safer once on.
+export function decideEscalation(o = readEditLedger(), threshold = 0) {
+  if (!(threshold > 0)) return false;             // escalation is opt-in; OFF by default
+  // 0.6 (not 0.5): an UNPROVEN warn reads ~0.5 under the Laplace prior, which must NOT count as "working" —
+  // otherwise escalation could never start on fresh data. So a warn must demonstrably convert (rate > 0.6)
+  // before it holds off the block; until then, the patience-floor behavior matches the old static threshold.
+  const warnOk = parseFloat(process.env.VTS_WARN_OK || "0.6") || 0.6;
+  // The block must EARN its place by an ABSOLUTE bar, not a relative one. A relative test (blockRate <
+  // warnRate) is wrong when BOTH are failing: Laplace makes the LESS-tried modality look better, so a block
+  // fired repeatedly with zero conversions still "beat" a warn that failed more often and kept getting chosen
+  // (live-sim found: block 0/3 vs warn 0/4 → 0.2 > 0.167 → never backs off). Instead: once the block has been
+  // tried VTS_BLOCK_TRIES times and converts below VTS_BLOCK_OK, it is PROVEN not to work → back off to warn
+  // (the "agent fights the wall" failure). VTS_BLOCK_TRIES/VTS_BLOCK_OK tune the bar.
+  const blockTries = parseInt(process.env.VTS_BLOCK_TRIES || "2", 10) || 2;
+  const blockOk = parseFloat(process.env.VTS_BLOCK_OK || "0.4") || 0.4;
+  const warnRate = rate(o.mod.warn), blockRate = rate(o.mod.block);
+  if (warnRate >= warnOk) return false;                                          // warns are working — don't escalate
+  if ((o.mod.block.shown || 0) >= blockTries && blockRate < blockOk) return false; // block PROVEN not working → back off
+  if ((o.streak || 0) < threshold) return false;                                 // respect the patience floor
+  return true;                                                                   // warns failing, block not-yet-disproven → escalate
+}
+
+// One-line controller state for the SessionStart self-report — surfaces WHICH lever is moving the number.
+export function controllerReport(o = readEditLedger()) {
+  const pc = (m) => `${(m && m.converted) || 0}/${(m && m.shown) || 0}`;
+  const willEsc = decideEscalation(o, Number(process.env.VTS_EDIT_BLOCK_AFTER) || 0);
+  return `steer conversions — warn ${pc(o.mod.warn)}, block ${pc(o.mod.block)} (adaptive escalation: ${willEsc ? "→ block" : "warn-only"})`;
 }


### PR DESCRIPTION
## Release theme

Patch release folding the three research-grade features already merged to dev
via #127, plus the bugs their effectiveness testing caught.

Versioned as a PATCH at the maintainer's request (consolidating, not inflating
the minor line), overriding the default feat->minor.

## What ships
- **B** completeness certificate (COMPLETE / PARTIAL / INCONCLUSIVE) on every
  result-bearing tool; partial-index empty -> INCONCLUSIVE, not authoritative 0.
- **C** opt-in counterfactual shadow-grep measurement (VTS_COUNTERFACTUAL=1);
  records grep-vs-vts token delta + answer-set relation, baseline-truncated
  flagged honestly on huge trees.
- **A** adaptive closed-loop escalation controller (warn/block by measured
  conversion, backs off the block on an absolute bar); off by default.
- 3 bugfixes from live testing: cert shown-count, controller back-off,
  truncated shadow-grep baseline.

## Review points
- All additive + togglable; defaults preserve prior behavior.
- Eval 74 -> 78, all green on Ubuntu+Windows (node 18/20/22), lint + validate.
- Version files bumped in sync on main after merge (plugin.json /
  marketplace.json / server/package.json) -> validate parity holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
