### PR TITLE
feat(perf): indexing scope + clangd-indexer static preindex + dead-code cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,20 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   `workspace/configuration`→array, `workspace/applyEdit`→`{applied:false}`, `window/showDocument`→
   `{success:false}`, void reqs→null, unknown→MethodNotFound -32601); a timed-out request sends
   `$/cancelRequest`; client declares `synchronization` + `workspace.configuration` capabilities.
+- `server/scope.js` — INDEXING SCOPE (cold-latency attack): index a SUBTREE not the whole monorepo. Config
+  `scope` / `VTS_SCOPE` (comma-list of dirs rel to root); `vts setup --scope "TSGame,Plugins"` persists it.
+  `scopeDirs`/`inScope`/`scopedCdb` (writes a FILTERED compile_commands.json of only in-scope TUs to the
+  out-of-tree dir → clangd `--compile-commands-dir` points there → it background-indexes far fewer TUs;
+  live UE5: `VTS_SCOPE=TSGame` = 3,377 of 26,488 TUs (13%), ~7.8× cut) / `scopeStats`. UNIVERSAL: every
+  backend's afterInit warm walk is scope-filtered too (no tsconfig/sln edit). `backends/index.js`
+  `effectiveCdbDir(root)` = scoped CDB when scope set, else `resolveCdbDir`; `scopeDirsFor(root)`. clangd
+  STATIC PREINDEX: `clangd-indexer` (full LLVM release bundles it; `VTS_CLANGD_INDEXER_CMD`/next-to-clangd/
+  PATH) builds a monolithic .idx over the scoped CDB → clangd loads it via `--index-file` (LOCAL file, no
+  remote server) for an instant project-wide index; `buildStaticIndex`/`hasClangdIndexer`/`staticIndexPath`,
+  absent → warm-pass fallback + advisory to install full LLVM. Ops `vts_scope` (show scope + TU stats +
+  top-level dirs) / `vts_preindex` (build ahead: static index if indexer present, else warm pass); CLI `vts
+  scope`/`vts preindex`, folded into `vts_admin`. Eval guard 79. Env: `VTS_SCOPE`, `VTS_CLANGD_INDEXER_CMD`,
+  `VTS_INDEXER_TIMEOUT_MS` (1800000).
 - `server/backends/index.js` — clangd/roslyn/typescript/pyright spawn configs + `pickBackend(root)`
   (detect order: compile_commands→clangd > .sln/.csproj→roslyn > tsconfig/package.json→typescript >
   pyproject/*.py→pyright; strongest build-artifact first). MIXED-REPO FIX: a query that TARGETS a file uses

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1720,6 +1720,34 @@ if (elPrev === undefined) delete process.env.VTS_EDIT_LEDGER; else process.env.V
 try { fs.rmSync(elFresh, { force: true }); } catch { /* ignore */ }
 const adaptiveCtrlOk = escPolicyOk && ctrlCreditOk && ctrlReportOk;
 
+// 79) indexing SCOPE — the cold-index accelerator: index a subtree, not the whole monorepo. scopeDirs
+// resolves the config/env scope; inScope tests membership; scopedCdb writes a filtered compile_commands.json
+// (only in-scope TUs) for clangd to index; scopeStats reports kept/total. Pure-fn + a tmp compile DB.
+const { scopeDirs, inScope, scopedCdb, scopeStats } = await import("../server/scope.js");
+const scDir = path.join(os.tmpdir(), `vts-eval-${process.pid}-scope`);
+const scA = path.join(scDir, "GameMod"), scB = path.join(scDir, "Engine");
+fs.mkdirSync(scA, { recursive: true }); fs.mkdirSync(scB, { recursive: true });
+const scAf = path.join(scA, "a.cpp").replace(/\\/g, "/"), scBf = path.join(scB, "b.cpp").replace(/\\/g, "/");
+fs.writeFileSync(scAf, "int a;\n"); fs.writeFileSync(scBf, "int b;\n");
+fs.writeFileSync(path.join(scDir, "compile_commands.json"), JSON.stringify([
+  { directory: scDir, file: scAf, command: "clang++ a.cpp" },
+  { directory: scDir, file: scBf, command: "clang++ b.cpp" },
+]));
+const scDirs = scopeDirs(scDir, "GameMod");                          // config scope → [scDir/GameMod]
+const scResolveOk = scDirs.length === 1 && scDirs[0].replace(/\\/g, "/").toLowerCase().endsWith("gamemod");
+const scInOk = inScope(scAf, scDirs) === true && inScope(scBf, scDirs) === false; // a in scope, b out
+const scEmptyAllOk = inScope(scBf, []) === true;                     // no scope → everything in scope
+const scOutBase = path.join(scDir, "out");
+const scopedDir = scopedCdb(scDir, scDir, scDirs, scOutBase);        // write filtered DB
+let scopedEntries = []; try { scopedEntries = JSON.parse(fs.readFileSync(path.join(scopedDir, "compile_commands.json"), "utf8")); } catch { /* ignore */ }
+const scPruneOk = scopedDir !== scDir && scopedEntries.length === 1 && scopedEntries[0].file === scAf; // only the in-scope TU
+const scStats = scopeStats(scDir, scDirs);
+const scStatsOk = scStats && scStats.total === 2 && scStats.kept === 1;
+const scNoScopeOk = scopedCdb(scDir, scDir, [], scOutBase) === scDir;          // empty scope → src unchanged
+const scNoMatchOk = scopedCdb(scDir, scDir, scopeDirs(scDir, "Nonexistent"), scOutBase) === scDir; // no match → fall back to full
+try { fs.rmSync(scDir, { recursive: true, force: true }); } catch { /* ignore */ }
+const scopeOk = scResolveOk && scInOk && scEmptyAllOk && scPruneOk && scStatsOk && scNoScopeOk && scNoMatchOk;
+
 await disposeClients(); // guard 75's read_symbol spawned a backend AFTER the earlier teardown — dispose it so node exits
 
 const rows = [
@@ -1802,6 +1830,7 @@ const rows = [
   ["completeness certificate: COMPLETE/PARTIAL/INCONCLUSIVE label + wired into search_text + toggle", certOk, "true", certOk],
   ["counterfactual shadow grep: relateSets algebra + maybeCounterfactual records (vts⊆grep) + report + toggle", counterfactualEvalOk, "true", counterfactualEvalOk],
   ["adaptive escalation controller: warn/block policy (soft/escalate/back-off) + conversion crediting + report", adaptiveCtrlOk, "true", adaptiveCtrlOk],
+  ["indexing scope: scopeDirs/inScope + scopedCdb prune (in-scope TUs only) + stats + no-scope/no-match fallback", scopeOk, "true", scopeOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -12,6 +12,7 @@ import path from "node:path";
 import { toUri, envInt, langIdForPath } from "../lsp.js";
 import { orderForWarm, warmCap } from "../warmset.js";
 import { resolveBinJs } from "../resolve-bin.js";
+import { scopeDirs, scopedCdb, inScope } from "../scope.js";
 
 const env = (name, def) => { const v = process.env[name]; return v && v !== "" ? v : def; };
 const splitArgs = (s) => (s ? s.split(/\s+/).filter(Boolean) : null);
@@ -45,7 +46,7 @@ export function clangdMajor(cmd) {
 export function clangdAdvisory(cmd) {
   const major = clangdMajor(cmd);
   if (major != null && major < MIN_CLANGD)
-    return `⚠ clangd ${major}.x detected — clangd ≥ ${MIN_CLANGD} is recommended for large Unreal/C++ projects. Older clangd (e.g. the 19.1.x bundled with Visual Studio) can hang indexing UE translation units. Point VTS_CLANGD_CMD at a newer clangd (https://github.com/clangd/clangd/releases).`;
+    return `⚠ clangd ${major}.x detected — clangd ≥ ${MIN_CLANGD} is recommended for large Unreal/C++ projects. Older clangd (e.g. the 19.1.x bundled with Visual Studio) can hang indexing UE translation units. Install the full LLVM release (https://github.com/llvm/llvm-project/releases — it bundles clangd-indexer too, which vts uses for instant pre-indexing) and point VTS_CLANGD_CMD at its clangd.`;
   return "";
 }
 
@@ -126,7 +127,7 @@ export function dbDirFor(root) {
 // was the bulk of the cold-start latency vs a warm IDE like Rider) — a tiny nudge-open + shard load is
 // enough. Returns true if any .idx shard is present under the root's (or the CDB dir's) clangd cache.
 export function hasPersistedIndex(root) {
-  for (const base of [root, resolveCdbDir(root)].filter(Boolean)) {
+  for (const base of [root, effectiveCdbDir(root)].filter(Boolean)) {
     const idxDir = path.join(base, ".cache", "clangd", "index");
     try { if (fs.readdirSync(idxDir).some((f) => /\.idx$/i.test(f))) return true; } catch { /* none */ }
   }
@@ -140,6 +141,64 @@ export function resolveCdbDir(root) {
   const out = dbDirFor(root);
   try { if (fs.existsSync(path.join(out, "compile_commands.json"))) return out; } catch { /* ignore */ }
   return null;
+}
+// The scope (config `scope`, env VTS_SCOPE) as absolute dirs for this root — [] = whole tree.
+export const scopeDirsFor = (root) => scopeDirs(root, _fileCfg.scope || "");
+// The compile-DB dir clangd should actually use: the SCOPED DB (filtered to the in-scope TUs, out-of-tree)
+// when a scope is set, else the full resolveCdbDir. This is where the deep clangd acceleration comes from —
+// the engine background-indexes only the scoped translation units.
+export function effectiveCdbDir(root) {
+  const src = resolveCdbDir(root);
+  const dirs = scopeDirsFor(root);
+  return dirs.length ? scopedCdb(root, src, dirs, dbDirFor(root)) : src;
+}
+// clangd-indexer — the offline batch indexer shipped in the SAME full LLVM/clang-tools-extra release as
+// clangd. It builds a monolithic static index from a compile_commands.json in one parallel pass, and clangd
+// loads it directly with `--index-file=<idx>` (a LOCAL file — no remote index server), giving an instant
+// project-wide index instead of waiting on the lazy background crawl. Resolution: VTS_CLANGD_INDEXER_CMD >
+// the binary sitting next to the resolved clangd (clangd → clangd-indexer) > a PATH `clangd-indexer`.
+export function clangdIndexerCmd() {
+  const ov = env("VTS_CLANGD_INDEXER_CMD");
+  if (ov) return ov;
+  const cd = cfgCmd("VTS_CLANGD_CMD", "clangdCmd", "clangd");
+  if (cd.includes("/") || cd.includes("\\")) {
+    const sib = cd.replace(/clangd(\.exe)?$/i, (_m, exe) => "clangd-indexer" + (exe || ""));
+    if (sib !== cd && fs.existsSync(sib)) return sib;
+  }
+  return "clangd-indexer";
+}
+// Is clangd-indexer actually runnable? (full LLVM installs have it; the VS-bundled LLVM ships only clangd.)
+let _indexerOk;
+export function hasClangdIndexer() {
+  if (_indexerOk !== undefined) return _indexerOk;
+  try { execFileSync(clangdIndexerCmd(), ["--help"], { encoding: "utf8", timeout: 8000, stdio: ["ignore", "ignore", "ignore"] }); _indexerOk = true; }
+  catch { _indexerOk = false; }
+  return _indexerOk;
+}
+// Where the prebuilt static index lives — next to the (scoped) compile DB, so it is scope-specific and stays
+// out-of-tree. clangd reads it via --index-file when present.
+export function staticIndexPath(root) {
+  const dir = effectiveCdbDir(root) || dbDirFor(root);
+  return path.join(dir, "vts-static.idx");
+}
+// Build the static index with clangd-indexer over the effective (scoped) compile DB, writing it to
+// staticIndexPath(root). Returns { ok, path, tus, ms } or { error }. Heavy (one full parse pass) but offline
+// and parallel — far faster than clangd's lazy background crawl, and it runs once.
+export function buildStaticIndex(root) {
+  if (!hasClangdIndexer()) return { error: "clangd-indexer not found — install the full LLVM release (it bundles clangd-indexer alongside clangd), or set VTS_CLANGD_INDEXER_CMD." };
+  const cdbDir = effectiveCdbDir(root);
+  const cc = cdbDir ? path.join(cdbDir, "compile_commands.json") : null;
+  if (!cc || !fs.existsSync(cc)) return { error: `no compile_commands.json for ${root} (generate it via vts_gen_compile_db).` };
+  let tus = 0; try { tus = JSON.parse(fs.readFileSync(cc, "utf8")).length; } catch { /* count best-effort */ }
+  const out = staticIndexPath(root);
+  const t0 = Date.now();
+  try {
+    fs.mkdirSync(path.dirname(out), { recursive: true });
+    // clangd-indexer writes the index to stdout; capture it to the file. all-TUs = index every entry in the DB.
+    const buf = execFileSync(clangdIndexerCmd(), [`--executor=all-TUs`, cc], { maxBuffer: 1 << 30, timeout: envInt("VTS_INDEXER_TIMEOUT_MS", 1800000) });
+    fs.writeFileSync(out, buf);
+  } catch (e) { return { error: `clangd-indexer failed: ${e.message}` }; }
+  return { ok: true, path: out, tus, ms: Date.now() - t0 };
 }
 // shallow scan for a file matching a predicate (1 level) — for .sln/.csproj/compile_commands in subdirs
 function findShallow(root, re, depth = 2) {
@@ -183,7 +242,7 @@ export const BACKENDS = {
         // --compile-commands-dir only tells clangd where to FIND compile_commands.json (out-of-tree home
         // or in-tree); it does NOT relocate the index. clangd has no index-dir flag — it persists its
         // background index in `<project>/.cache/clangd` (in-tree), reused across spawns for warm speed.
-        `--compile-commands-dir=${resolveCdbDir(root) || root}`,
+        `--compile-commands-dir=${effectiveCdbDir(root) || root}`,
         "--background-index",
         // Default priority is `background` = MINIMUM, idle-CPU-only — so a fresh index crawls (a big reason
         // the first query felt far slower than a warm IDE like Rider). We want it built NOW; `normal` lets
@@ -193,6 +252,11 @@ export const BACKENDS = {
         `-j=${Math.max(2, parseInt(env("VTS_CLANGD_JOBS", String(Math.max(2, (os.cpus()?.length || 4) - 1))), 10) || 4)}`,
         "--header-insertion=never",
       ];
+      // Prebuilt STATIC index (clangd-indexer output): load it directly via --index-file — a local file, no
+      // server. Gives an instant project-wide index instead of the lazy background crawl. Built by
+      // `vts preindex`; scope-specific (next to the scoped compile DB). Background index stays on so edits
+      // made after the static build are still picked up.
+      try { const idx = staticIndexPath(root); if (fs.existsSync(idx)) a.push(`--index-file=${idx}`); } catch { /* none */ }
       // Prebuilt/remote index (zero per-dev warmup): point clangd at a shared clangd-index-server.
       const remote = env("VTS_CLANGD_REMOTE");
       if (remote) a.push(`--remote-index-address=${remote}`, `--project-root=${root}`);
@@ -204,13 +268,16 @@ export const BACKENDS = {
     // enter clangd's dynamic index, then wait until at least one file is parsed (publishDiagnostics)
     // before the first query. Long-lived MCP use also benefits: the warm-up primes the index.
     afterInit: async (client, root) => {
-      const cdbDir = resolveCdbDir(root);
+      const cdbDir = effectiveCdbDir(root);
       const cc = cdbDir ? path.join(cdbDir, "compile_commands.json") : null;
       let files = [];
       if (cc) {
         try { files = JSON.parse(fs.readFileSync(cc, "utf8")).map((e) => e.file).filter(Boolean); } catch { /* ignore */ }
       }
-      const extra = findAllShallow(root, /\.(c|cc|cxx|cpp|h|hpp|hh|inl)$/i, 2);
+      // Scope the nearby-header walk too, so a scoped index doesn't get dragged back to whole-tree by the
+      // header sweep. The scoped CDB already filters `files`; this filters `extra`.
+      const dirs = scopeDirsFor(root);
+      const extra = findAllShallow(root, /\.(c|cc|cxx|cpp|h|hpp|hh|inl)$/i, 2).filter((f) => inScope(f, dirs));
       // When a persisted index already exists, clangd answers workspace/symbol from the loaded shards —
       // re-opening 100 TUs only triggers a costly re-parse (~seconds EACH on UE) for no symbol-search gain.
       // Open just a small nudge set so clangd starts loading; the full project is already in the index.
@@ -283,7 +350,8 @@ export const BACKENDS = {
   typescript: nodeLspBackend(TS_BIN, env("VTS_TS_CMD"), "typescript-language-server", "VTS_TS_ARGS", {
     detect: (root) => exists(root, "tsconfig.json", "jsconfig.json", "package.json") || !!findShallow(root, /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/, 1),
     afterInit: async (client, root) => {
-      const files = findAllShallow(root, /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/i, 3);
+      const dirs = scopeDirsFor(root);
+      const files = findAllShallow(root, /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/i, 3).filter((f) => inScope(f, dirs));
       const open = orderForWarm(root, files, warmCap(root, "typescript", "VTS_TS_OPEN_CAP", 60));
       for (const f of open) client.didOpen(f, langIdForPath(f, "typescript"));
     },
@@ -294,7 +362,8 @@ export const BACKENDS = {
   pyright: nodeLspBackend(PY_BIN, env("VTS_PY_CMD"), "pyright-langserver", "VTS_PY_ARGS", {
     detect: (root) => exists(root, "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile") || !!findShallow(root, /\.py$/, 1),
     afterInit: async (client, root) => {
-      const files = findAllShallow(root, /\.pyi?$/i, 3);
+      const dirs = scopeDirsFor(root);
+      const files = findAllShallow(root, /\.pyi?$/i, 3).filter((f) => inScope(f, dirs));
       const open = orderForWarm(root, files, warmCap(root, "pyright", "VTS_PY_OPEN_CAP", 60));
       for (const f of open) client.didOpen(f, "python");
     },

--- a/server/cli.js
+++ b/server/cli.js
@@ -96,7 +96,7 @@ function parseArgs(argv) {
   }
   return a;
 }
-const COMMANDS = { symbol: "search_symbol", references: "find_references", definition: "goto_definition", "trace-calls": "find_references", hover: "hover", symbols: "document_symbols", "read-symbol": "read_symbol", diagnostics: "diagnostics", rename: "rename", "replace-symbol": "replace_symbol_body", insert: "insert_symbol", "insert-after": "insert_symbol", "insert-before": "insert_symbol", "safe-delete": "safe_delete", files: "find_files", text: "search_text", git: "vts_git", p4: "vts_p4", setup: "vts_setup", config: "vts_config", savings: "vts_savings", "savings-reset": "vts_savings_reset", discover: "vts_discover", warmup: "vts_warmup", "gen-compile-db": "vts_gen_compile_db" };
+const COMMANDS = { symbol: "search_symbol", references: "find_references", definition: "goto_definition", "trace-calls": "find_references", hover: "hover", symbols: "document_symbols", "read-symbol": "read_symbol", diagnostics: "diagnostics", rename: "rename", "replace-symbol": "replace_symbol_body", insert: "insert_symbol", "insert-after": "insert_symbol", "insert-before": "insert_symbol", "safe-delete": "safe_delete", files: "find_files", text: "search_text", git: "vts_git", p4: "vts_p4", setup: "vts_setup", config: "vts_config", savings: "vts_savings", "savings-reset": "vts_savings_reset", discover: "vts_discover", warmup: "vts_warmup", preindex: "vts_preindex", scope: "vts_scope", "gen-compile-db": "vts_gen_compile_db" };
 
 const [, , rawCmd, ...rest] = process.argv;
 if (!rawCmd || rawCmd === "-h" || rawCmd === "--help" || rawCmd === "help") { console.log(HELP); process.exit(rawCmd ? 0 : 1); }

--- a/server/compact.js
+++ b/server/compact.js
@@ -173,6 +173,3 @@ export function compactP4(sub, raw, max = 60) {
   if (!lines.length) return "(no output).";
   return lines.join("\n") + (total > lines.length ? `\n… +${total - lines.length} more unique line(s).` : "");
 }
-
-// Exposed for the eval (deterministic unit coverage of the grouping helpers).
-export const _internals = { dedupCap, topDir, compactGitStatus, compactGitLog, compactGitDiff, compactP4Opened, compactP4Changes };

--- a/server/core.js
+++ b/server/core.js
@@ -11,7 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync, execSync } from "node:child_process";
 import { LspClient, fromUri, langIdForPath, envInt, canonFsPath } from "./lsp.js";
-import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot, effectiveCdbDir, scopeDirsFor, buildStaticIndex, hasClangdIndexer, staticIndexPath } from "./backends/index.js";
+import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot, effectiveCdbDir, scopeDirsFor, buildStaticIndex, hasClangdIndexer } from "./backends/index.js";
 import { scopeStats } from "./scope.js";
 import { recordQueryResults, languageCensus, histRank } from "./warmset.js";
 import { splitSegments } from "./shell-split.js";

--- a/server/core.js
+++ b/server/core.js
@@ -11,7 +11,8 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync, execSync } from "node:child_process";
 import { LspClient, fromUri, langIdForPath, envInt, canonFsPath } from "./lsp.js";
-import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot } from "./backends/index.js";
+import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot, effectiveCdbDir, scopeDirsFor, buildStaticIndex, hasClangdIndexer, staticIndexPath } from "./backends/index.js";
+import { scopeStats } from "./scope.js";
 import { recordQueryResults, languageCensus, histRank } from "./warmset.js";
 import { splitSegments } from "./shell-split.js";
 import { classifyDeclEdit } from "./edit-detect.js";
@@ -34,7 +35,7 @@ export const PROJECT_PATH = cfg("VTS_PROJECT_PATH", "projectPath", "");
 export const BACKEND = cfg("VTS_BACKEND", "backend", ""); // "clangd" | "roslyn" | "" (auto)
 export const MAX_RESULTS = parseInt(cfg("VTS_MAX_RESULTS", "maxResults", "60"), 10) || 60;
 export const PREWARM_BACKENDS = cfg("VTS_PREWARM_BACKENDS", "prewarmBackends", ""); // "" | auto | all | comma-list
-const CONFIG_KEYS = ["projectPath", "backend", "maxResults", "prewarmBackends", "tee", "excludeCommands", "usdPerMtok", "clangdCmd"];
+const CONFIG_KEYS = ["projectPath", "backend", "maxResults", "prewarmBackends", "tee", "excludeCommands", "usdPerMtok", "clangdCmd", "scope"];
 
 // ---- per-call project root resolution ----
 // The MCP server is ONE long-lived process serving every repo a session touches, so a single configured
@@ -1687,6 +1688,49 @@ export async function runTool(name, a = {}) {
       const t0 = Date.now();
       await getClient(root, backendName); // spawn + afterInit (index-ready wait) → primes the on-disk + in-process index
       return out(backendAdvisory(backendName, root) + `Warmed ${backendName} for ${root} in ${((Date.now() - t0) / 1000).toFixed(1)}s. Queries in this process are now warm; clangd's on-disk index (.cache/clangd) also persists for faster cold starts.`);
+    }
+    if (name === "vts_scope") {
+      // Show / inspect the indexing scope: the biggest cold-index accelerator on a huge tree (index a subset,
+      // not the whole monorepo). Read-only; set it via `vts setup --scope` (persists) or the VTS_SCOPE env.
+      const root = resolveRoot(a);
+      const dirs = scopeDirsFor(root);
+      const lines = [`Scope for ${root}:`, `  current: ${dirs.length ? dirs.join(", ") : "(none — whole tree indexed)"}`];
+      const src = resolveCdbDir(root);
+      if (src && dirs.length) {
+        const st = scopeStats(src, dirs);
+        if (st) lines.push(`  clangd TUs: ${st.kept} of ${st.total} kept (${Math.round((100 * st.kept) / Math.max(st.total, 1))}%) → scoped compile DB at ${effectiveCdbDir(root)}`);
+      } else if (src) {
+        let total = 0; try { total = JSON.parse(fs.readFileSync(path.join(src, "compile_commands.json"), "utf8")).length; } catch { /* ignore */ }
+        if (total) lines.push(`  clangd TUs: ${total} (whole tree — set a scope to index a subset)`);
+      }
+      let tops = [];
+      try { tops = fs.readdirSync(root, { withFileTypes: true }).filter((e) => e.isDirectory() && !e.name.startsWith(".") && e.name !== "node_modules").map((e) => e.name).sort(); } catch { /* ignore */ }
+      if (tops.length) lines.push(`  top-level dirs (pick a subset): ${tops.slice(0, 40).join(", ")}`);
+      lines.push(`  set with: vts setup --scope "Sub1,Sub2"  (or VTS_SCOPE env), then run vts preindex.`);
+      return out(lines.join("\n"));
+    }
+    if (name === "vts_preindex") {
+      // Pre-build the index so the first real query is instant. clangd + clangd-indexer → an offline static
+      // index loaded via --index-file (no lazy crawl); otherwise a full warm pass that persists the background
+      // index. Honors the configured scope, so on a huge tree only the chosen subset is indexed.
+      const root = resolveRoot(a);
+      const backendName = a.backend || BACKEND || pickBackend(root);
+      if (!backendName) return err(`No backend to pre-index. Pass backend=clangd|roslyn|typescript|pyright or ensure ${root} has a build artifact.`);
+      const dirs = scopeDirsFor(root);
+      const scopeNote = dirs.length ? ` (scope: ${dirs.length} dir(s))` : " (whole tree — set a scope via vts setup --scope to index a subset faster)";
+      if (backendName === "clangd" && hasClangdIndexer()) {
+        const r = buildStaticIndex(root);
+        if (r.error) return err(`preindex: ${r.error}`);
+        const t0 = Date.now();
+        try { await getClient(root, backendName); } catch { /* warm best-effort */ }
+        return out(`Built static clangd index${scopeNote}: ${r.tus} TU(s) → ${r.path} in ${(r.ms / 1000).toFixed(1)}s, loaded via --index-file (no background crawl wait). Warm in ${((Date.now() - t0) / 1000).toFixed(1)}s.`);
+      }
+      const t0 = Date.now();
+      await getClient(root, backendName);
+      const adv = backendName === "clangd" && !hasClangdIndexer()
+        ? `\n(For INSTANT pre-indexing install the full LLVM release — it bundles clangd-indexer — then re-run vts preindex; it builds a static --index-file instead of the slower background crawl.)`
+        : "";
+      return out(backendAdvisory(backendName, root) + `Pre-warmed ${backendName} for ${root}${scopeNote} in ${((Date.now() - t0) / 1000).toFixed(1)}s (background index persisted to .cache).` + adv);
     }
     if (name === "vts_gen_compile_db") {
       // The user's choice: run UBT GenerateClangDatabase for full semantic clangd, OR don't and stay in

--- a/server/counterfactual.js
+++ b/server/counterfactual.js
@@ -13,7 +13,6 @@ import os from "node:os";
 import path from "node:path";
 import { canonFsPath } from "./lsp.js";
 
-const tok = (s) => Math.round(Buffer.byteLength(String(s), "utf8") / 4); // core.js:119 parity
 export const counterfactualOn = () => /^(1|true|on|yes)$/i.test(String(process.env.VTS_COUNTERFACTUAL ?? "0"));
 const LEDGER = () => process.env.VTS_COUNTERFACTUAL_FILE || path.join(os.homedir(), ".vs-token-safer", "counterfactual.json");
 
@@ -70,7 +69,6 @@ export function recordCounterfactual(tool, { grepTok = 0, vtsTok = 0, relation =
   write(o);
   return o;
 }
-export { tok as cfTok };
 
 // A `vts savings`-style section: tokens grep WOULD have spent vs vts, and the distribution of set relations.
 // Returns "" when no counterfactual data exists (the feature is opt-in, so this is the common case).

--- a/server/lsp.js
+++ b/server/lsp.js
@@ -272,7 +272,6 @@ export class LspClient {
       context: { includeDeclaration },
     });
   }
-  definition(uriOrPath, line, character) { return this.gotoByKind("definition", uriOrPath, line, character); }
   // Definition / type-definition / implementation / declaration share one position-request shape; the kind
   // just picks the LSP method (textDocument/definition|typeDefinition|implementation|declaration). Folded so
   // goto_definition can expose all four without four separate MCP tools.

--- a/server/scope.js
+++ b/server/scope.js
@@ -1,0 +1,73 @@
+// Indexing SCOPE — index/warm a SUBSET of a project instead of the whole tree. This is the single biggest
+// cold-index accelerator on a huge monorepo: on a full Unreal Engine source tree (~26k translation units)
+// where a developer only touches the game module, scoping clangd to that subtree means it background-indexes
+// a few hundred TUs, not all of them — the first-index time drops by the TU ratio. Scope is a comma-list of
+// paths relative to the project root (or absolute), set via VTS_SCOPE or the config `scope` key (persisted by
+// `vts setup --scope`). Empty scope = the whole tree (unchanged behavior).
+//
+// The mechanism is twofold and backend-aware:
+//   • clangd — DEEP prune: write a filtered compile_commands.json (only in-scope entries) to an out-of-tree
+//     dir and point clangd's --compile-commands-dir at it, so the engine itself indexes less (scopedCdb).
+//   • every backend (clangd/roslyn/tsserver/pyright) — UNIVERSAL: restrict vts's own file walks (warm-set,
+//     find_files, search_text) to the scope subtree via inScope, without touching the user's tsconfig/sln.
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+
+const norm = (p) => path.resolve(String(p)).replace(/\\/g, "/").toLowerCase();
+
+// Resolve the scope to a list of absolute, existing directories. `cfgScope` is the config-file `scope` value
+// (env VTS_SCOPE wins). Returns [] when no scope is set or none of the paths exist (→ whole-tree behavior).
+export function scopeDirs(root, cfgScope) {
+  const raw = process.env.VTS_SCOPE || cfgScope || "";
+  if (!raw) return [];
+  return String(raw)
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => path.resolve(path.isAbsolute(s) ? s : path.join(root, s)))
+    .filter((p) => { try { return fs.existsSync(p); } catch { return false; } });
+}
+
+// Is `absPath` under any scope dir? Empty scope → everything is in scope (so callers can apply it
+// unconditionally: `inScope(f, scopeDirs(...))` is a no-op when no scope is configured).
+export function inScope(absPath, dirs) {
+  if (!dirs || !dirs.length) return true;
+  const f = norm(absPath);
+  return dirs.some((d) => { const dd = norm(d); return f === dd || f.startsWith(dd + "/"); });
+}
+
+// Write a SCOPED compile_commands.json — only the entries whose source `file` is in scope — to an out-of-tree
+// dir and return that dir (clangd then indexes just those TUs). Idempotent: rewrites only when the filtered
+// content changes (keyed by the scope set), so repeated spawns don't churn the file or clangd's index. Falls
+// back to `srcCdbDir` unchanged when there is no scope, no source DB, or the scope matched zero TUs (never
+// strand clangd with an empty DB). `outBase` is dbDirFor(root) — the per-root out-of-tree home.
+export function scopedCdb(root, srcCdbDir, dirs, outBase) {
+  if (!dirs || !dirs.length || !srcCdbDir) return srcCdbDir;
+  let entries;
+  try { entries = JSON.parse(fs.readFileSync(path.join(srcCdbDir, "compile_commands.json"), "utf8")); } catch { return srcCdbDir; }
+  if (!Array.isArray(entries)) return srcCdbDir;
+  const abs = (e) => (path.isAbsolute(e.file) ? e.file : path.join(e.directory || srcCdbDir, e.file));
+  const kept = entries.filter((e) => e && e.file && inScope(abs(e), dirs));
+  if (!kept.length) return srcCdbDir; // scope matched nothing in the DB → don't hand clangd an empty DB
+  const json = JSON.stringify(kept);
+  const hash = crypto.createHash("sha1").update(dirs.map(norm).sort().join("|")).digest("hex").slice(0, 10);
+  const outDir = path.join(outBase, "scoped-" + hash);
+  const outFile = path.join(outDir, "compile_commands.json");
+  let prev = ""; try { prev = fs.readFileSync(outFile, "utf8"); } catch { /* none */ }
+  if (prev !== json) {
+    try { fs.mkdirSync(outDir, { recursive: true }); fs.writeFileSync(outFile, json); } catch { return srcCdbDir; }
+  }
+  return outDir;
+}
+
+// Stats for reporting (vts scope / setup): how many of the DB's TUs the scope keeps.
+export function scopeStats(srcCdbDir, dirs) {
+  try {
+    const entries = JSON.parse(fs.readFileSync(path.join(srcCdbDir, "compile_commands.json"), "utf8"));
+    if (!Array.isArray(entries)) return null;
+    const abs = (e) => (path.isAbsolute(e.file) ? e.file : path.join(e.directory || srcCdbDir, e.file));
+    const kept = entries.filter((e) => e && e.file && inScope(abs(e), dirs)).length;
+    return { total: entries.length, kept };
+  } catch { return null; }
+}

--- a/server/tools.js
+++ b/server/tools.js
@@ -248,12 +248,14 @@ export const TOOLS = [
       "  • config {} — show effective settings · savings {graph,daily,history} — tokens saved (local) · savings_reset {} — clear it\n" +
       "  • discover {since,all,learn,projectPath} — find code searches that BYPASSED vts (missed savings)\n" +
       "  • warmup {projectPath,backend} — pre-build the index so later searches are fast\n" +
+      "  • preindex {projectPath,backend} — build the index ahead of time (clangd: a static --index-file via clangd-indexer if present, honoring scope)\n" +
+      "  • scope {projectPath} — show the indexing scope + TU stats + top-level dirs to pick from (set via setup --scope)\n" +
       "  • gen_compile_db {projectPath,apply,inTree,engineRoot,target,…} — generate the UE clangd compile DB\n" +
       "  • git {argv|args,projectPath} · p4 {argv|args,projectPath} — run a READ-ONLY VCS command, output compacted (mutating REFUSED)",
     inputSchema: {
       type: "object",
       properties: {
-        op: { type: "string", enum: ["setup", "config", "savings", "savings_reset", "discover", "warmup", "gen_compile_db", "git", "p4"], description: "Which admin operation (see the description)." },
+        op: { type: "string", enum: ["setup", "config", "savings", "savings_reset", "discover", "warmup", "preindex", "scope", "gen_compile_db", "git", "p4"], description: "Which admin operation (see the description)." },
         params: { type: "object", description: 'Arguments for the op, e.g. {"argv":["status"]} for git, {"since":30} for discover, {"projectPath":"…"} for setup.' },
       },
       required: ["op"],
@@ -261,5 +263,5 @@ export const TOOLS = [
   },
 ];
 
-// vts_admin folds these 9 cold ops; index.js maps vts_admin{op} -> runTool("vts_"+op).
-export const ADMIN_OPS = new Set(["setup", "config", "savings", "savings_reset", "discover", "warmup", "gen_compile_db", "git", "p4"]);
+// vts_admin folds these cold ops; index.js maps vts_admin{op} -> runTool("vts_"+op).
+export const ADMIN_OPS = new Set(["setup", "config", "savings", "savings_reset", "discover", "warmup", "preindex", "scope", "gen_compile_db", "git", "p4"]);


### PR DESCRIPTION
## Summary

Attacks the paper's one honest weakness — cold-index latency on huge trees — with two charter-pure accelerators, plus a dead-code sweep.

**Indexing scope** (`server/scope.js`): index a SUBTREE, not the whole monorepo. Config `scope` / `VTS_SCOPE`; `vts setup --scope "TSGame,Plugins"` persists it.
- clangd deep prune: a filtered `compile_commands.json` (in-scope TUs only) written out-of-tree, `--compile-commands-dir` points there. Live UE5: `TSGame` scope = 3,377 of 26,488 TUs (13%, ~7.8x cut).
- Universal: every backend's warm-set walk is scope-filtered (no tsconfig/sln edit).

**Static preindex** (clangd-indexer): clangd loads a monolithic offline index via `--index-file` (local file, no remote server). Built over the scoped DB; detected (`VTS_CLANGD_INDEXER_CMD`/next-to-clangd/PATH), absent -> warm-pass fallback + advisory to install the full LLVM release (which bundles clangd-indexer). New ops `vts_scope` / `vts_preindex` (CLI + vts_admin).

**Dead-code cleanup**: removed 4 genuinely-dead items (cfTok export + its orphaned helper, compact.js `_internals` test surface, lsp.js `definition()` wrapper). Verified against runTool dispatch / COMMANDS / ADMIN_OPS / eval.

## Review points
- All additive; no scope set = prior whole-tree behavior unchanged.
- Eval 78 -> 79 (new guard 79: scope resolve/prune/stats/fallbacks); lint clean.
- Charter held: index stays the official engine's, built+read locally, nothing transmitted.
- Paper's "Cold latency" section updated in the separate paper repo to reflect these mitigations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
