### PR TITLE
feat: within-scope cert + indexer gating + unified tool-routing policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,20 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   absent → warm-pass fallback + advisory to install full LLVM. Ops `vts_scope` (show scope + TU stats +
   top-level dirs) / `vts_preindex` (build ahead: static index if indexer present, else warm pass); CLI `vts
   scope`/`vts preindex`, folded into `vts_admin`. Eval guard 79. Env: `VTS_SCOPE`, `VTS_CLANGD_INDEXER_CMD`,
-  `VTS_INDEXER_TIMEOUT_MS` (1800000).
+  `VTS_INDEXER_TIMEOUT_MS` (1800000). PREINDEX GATING: `vts preindex` DEFAULT = fast scoped background warm;
+  the clangd-indexer STATIC `--index-file` (parses every in-scope TU, tens of min on a big scope) is OPT-IN via
+  `static=true`/`--static` — never auto-run just because the indexer exists (an existing `vts-static.idx` is
+  still auto-loaded, cheap). within-scope cert: `completenessCert({scoped})` qualifies a semantic COMPLETE/0 as
+  "within the configured indexing scope" (search_symbol/find_references), and `clangdIndexAdvisory` counts
+  TUs/shards against the EFFECTIVE (scoped) CDB.
+- `server/policy.js` — UNIFIED TOOL-ROUTING POLICY (vts COMPLEMENTS Claude Code, not competes). `shouldSuppressSteer(file)`
+  stays SILENT where CC-native is clearly better — generated/build-output paths (`Intermediate|Binaries|Saved|
+  DerivedDataCache|node_modules|build|dist|out|obj|.git`, `*.generated.*`/`*.g.cs`/`*.min.js`); wired into the
+  edit-steer hook (a whole-decl edit there isn't nagged AND isn't counted against adoption). `VTS_SUPPRESS=0` off.
+  `routingDigest()` = the SINGLE SessionStart message: a when-to-use-what decision tree (semantic→vts, whole-decl→
+  symbol-edit, doc/just-edited/sub-decl→CC-native Read/Grep/Edit, big-tree→scope+preindex) + live adoption posture +
+  adaptive-controller state — replaces the adoption-only nudge in `hooks/edit-report.js` (one coherent policy, not
+  scattered nudges). Eval guard 80.
 - `server/backends/index.js` — clangd/roslyn/typescript/pyright spawn configs + `pickBackend(root)`
   (detect order: compile_commands→clangd > .sln/.csproj→roslyn > tsconfig/package.json→typescript >
   pyproject/*.py→pyright; strongest build-artifact first). MIXED-REPO FIX: a query that TARGETS a file uses

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1752,6 +1752,22 @@ const scNoMatchOk = scopedCdb(scDir, scDir, scopeDirs(scDir, "Nonexistent"), scO
 try { fs.rmSync(scDir, { recursive: true, force: true }); } catch { /* ignore */ }
 const scopeOk = scResolveOk && scInOk && scEmptyAllOk && scPruneOk && scStatsOk && scNoScopeOk && scNoMatchOk;
 
+// 80) unified tool-routing policy — vts COMPLEMENTS Claude Code's native tools. shouldSuppressSteer stays
+// silent on generated/build-output paths (CC-native is fine there); routingDigest is the single
+// when-to-use-what decision tree + live adoption posture re-injected at SessionStart.
+const { shouldSuppressSteer, routingDigest, suppressOn } = await import("../server/policy.js");
+const supGen = shouldSuppressSteer("/p/Intermediate/Build/Foo.gen.cpp") === true;   // build output → suppress
+const supDotGen = shouldSuppressSteer("/p/Source/Foo.generated.h") === true;        // generated header → suppress
+const supNodeMod = shouldSuppressSteer("/p/node_modules/x/y.js") === true;          // vendored dep → suppress
+const supReal = shouldSuppressSteer("/p/Source/TSGame/Weapon.cpp") === false;       // real source → steer as usual
+const supTogglePrev = process.env.VTS_SUPPRESS;
+process.env.VTS_SUPPRESS = "0";
+const supOff = shouldSuppressSteer("/p/Intermediate/Build/Foo.gen.cpp") === false && suppressOn() === false; // toggle off
+if (supTogglePrev === undefined) delete process.env.VTS_SUPPRESS; else process.env.VTS_SUPPRESS = supTogglePrev;
+const dig = routingDigest({ builtin: 8, symbol: 2, mod: { warn: { shown: 0, converted: 0 }, block: { shown: 0, converted: 0 } } });
+const digOk = /Tool routing/.test(dig) && /COMPLEMENTARY/.test(dig) && /--scope/.test(dig) && /adoption 20% \(2\/10\)/.test(dig); // tree + posture
+const policyOk = supGen && supDotGen && supNodeMod && supReal && supOff && digOk;
+
 await disposeClients(); // guard 75's read_symbol spawned a backend AFTER the earlier teardown — dispose it so node exits
 
 const rows = [
@@ -1835,6 +1851,7 @@ const rows = [
   ["counterfactual shadow grep: relateSets algebra + maybeCounterfactual records (vts⊆grep) + report + toggle", counterfactualEvalOk, "true", counterfactualEvalOk],
   ["adaptive escalation controller: warn/block policy (soft/escalate/back-off) + conversion crediting + report", adaptiveCtrlOk, "true", adaptiveCtrlOk],
   ["indexing scope: scopeDirs/inScope + scopedCdb prune (in-scope TUs only) + stats + no-scope/no-match fallback", scopeOk, "true", scopeOk],
+  ["tool-routing policy: suppress steer on generated/build paths (CC-native) + routing digest + toggle", policyOk, "true", policyOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1643,8 +1643,12 @@ fs.mkdirSync(certDir, { recursive: true });
 fs.writeFileSync(path.join(certDir, "c.js"), "const certToken123 = 1;\n");
 const certScan = await runTool("search_text", { q: "certToken123", projectPath: certDir }); // pure FS, no backend
 const certWired = /\[completeness: COMPLETE/.test(certScan.text || "");
+// scoped: a semantic COMPLETE under an active indexing scope must say it's complete WITHIN the scope, not
+// project-wide (so the agent doesn't over-trust a scoped 0/N).
+const certScopedOk = completenessCert({ shown: 3, total: 3, semantic: true, scoped: true }).includes("within the configured indexing scope")
+  && !completenessCert({ shown: 3, total: 3, semantic: true, scoped: false }).includes("within the configured");
 try { fs.rmSync(certDir, { recursive: true, force: true }); } catch { /* ignore */ }
-const certOk = certComplete && certPartial && certTime && certIndex && certOff && certWired;
+const certOk = certComplete && certPartial && certTime && certIndex && certOff && certWired && certScopedOk;
 
 // 77) counterfactual shadow measurement — the quasi-controlled answer to "did vts reach the same answer as
 // grep?". relateSets classifies vts's answer set against grep's; maybeCounterfactual (opt-in

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -36,6 +36,7 @@ import { splitSegments } from "../server/shell-split.js";
 // MEASURE; the adoption ledger is the live metric the steer is tuned against.
 import { classifyDeclEdit } from "../server/edit-detect.js";
 import { recordEditEvent, resetStreak, recordSteerShown, decideEscalation } from "../server/edit-ledger.js";
+import { shouldSuppressSteer } from "../server/policy.js";
 
 const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(os.homedir(), ".vs-token-safer", "config.json");
 const readConfig = () => { try { return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8")) || {}; } catch { return {}; } };
@@ -556,6 +557,10 @@ process.stdin.on("end", () => {
     if (editWarnOn()) {
       const ce = classifyDeclEdit(toolName, ti, editMinLines());
       if (ce.file && (ce.replaceDecl || ce.insertDecl)) {
+        // CC-complement: a whole-decl edit in a GENERATED / build-output path (Intermediate, Binaries,
+        // *.generated.*, node_modules…) is fine with the native Edit — a symbol-edit there buys nothing.
+        // Stay silent AND don't count it against adoption (it isn't a case we'd steer).
+        if (shouldSuppressSteer(ce.file)) process.exit(0);
         const led = recordEditEvent("builtin-warn");
         // L2: an OPT-IN escalation. After VTS_EDIT_BLOCK_AFTER consecutive ignored nudges, BLOCK once on the
         // SAFE subset (a pure insert of a new declaration). DEFAULT OFF (0) — a persistent block TRAPPED the

--- a/hooks/edit-report.js
+++ b/hooks/edit-report.js
@@ -1,24 +1,19 @@
 #!/usr/bin/env node
-// SessionStart self-report — read the edit-adoption ledger and re-inject the symbol-edit adoption ratio as
-// a goal the model sees at the top of the session. This is the "learning" half of the steer loop: the hook
-// + discover MEASURE, this RE-INJECTS the gap as a concrete goal, behavior shifts, and the next session
-// measures again (the SkillOpt textual-gradient cadence — a static skill rule can't self-improve, but a
-// re-injected live metric can). Stays quiet until there's enough data to be worth a line of context.
-import { readEditLedger, adoptionPct, controllerReport } from "../server/edit-ledger.js";
+// SessionStart self-report — re-inject ONE coherent tool-routing policy (the decision tree + the live
+// adoption posture) so the model reads a single integrative guide instead of N scattered reflexive nudges.
+// This is the "learning" half of the steer loop: the hook + discover MEASURE, this RE-INJECTS the gap + the
+// when-to-use-what policy, behavior shifts, the next session measures again (the SkillOpt textual-gradient
+// cadence — a static rule can't self-improve, a re-injected live metric + policy can). Quiet until there's
+// enough activity to be worth a line of context.
+import { readEditLedger, adoptionPct } from "../server/edit-ledger.js";
+import { routingDigest } from "../server/policy.js";
 
 try {
   const o = readEditLedger();
   const pct = adoptionPct(o);
   const total = (o.builtin || 0) + (o.symbol || 0);
-  if (pct === null || total < 5) process.exit(0); // too little data — don't nag
-  // Surface the adaptive controller's per-modality conversions only once it has signal (a steer was shown),
-  // so the model sees WHICH lever is moving the number, not just the aggregate ratio.
-  const hasSteerData = ((o.mod && o.mod.warn && o.mod.warn.shown) || 0) + ((o.mod && o.mod.block && o.mod.block.shown) || 0) > 0;
-  const ctrl = hasSteerData ? ` [${controllerReport(o)}]` : "";
-  const msg =
-    `[vs-token-safer] Symbol-edit adoption: ${pct}% (${o.symbol || 0} symbol-edit vs ${o.builtin || 0} built-in Edit on whole declarations).${ctrl} ` +
-    `When you ADD or REPLACE a whole declaration this session, prefer replace_symbol_body / insert_symbol — ` +
-    `they edit by NAME and skip reading the file into context. Aim to raise the ratio. (Built-in Edit stays right for sub-declaration tweaks.)`;
+  if (pct === null || total < 3) process.exit(0); // too little data — don't nag on a fresh/idle session
+  const msg = routingDigest(o);
   process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: msg } }) + "\n");
 } catch { /* best-effort — never break session start */ }
 process.exit(0);

--- a/server/core.js
+++ b/server/core.js
@@ -1045,8 +1045,11 @@ function factorCommonPrefix(lines) {
 function certOn() { return !/^(0|false|off|no)$/i.test(String(process.env.VTS_CERT ?? "1")); }
 // truncated: falsy | "cap" | "time" | "scan". semantic=true → a language-server index answered (authoritative
 // 0); false → a bounded lexical scan. shown/total optional (total null = unknown upper bound).
-function completenessCert({ shown = 0, total = null, truncated = null, semantic = false } = {}) {
+function completenessCert({ shown = 0, total = null, truncated = null, semantic = false, scoped = false } = {}) {
   if (!certOn()) return "";
+  // When an indexing scope is active, a semantic COMPLETE (or authoritative 0) is complete WITHIN THE SCOPE,
+  // not across the whole project — qualify it so the agent doesn't read it as project-wide coverage.
+  const within = scoped ? " within the configured indexing scope (not the whole project — widen or unset the scope for full coverage)" : "";
   if (truncated === "time" || truncated === "scan") {
     const how = truncated === "time" ? "time-boxed" : "scan-limited";
     return `\n[completeness: INCONCLUSIVE — a bounded ${how} walk did not cover the whole tree, so this result (a 0 included) may be incomplete; narrow the scope or use a semantic tool (search_symbol/find_references) to certify.]`;
@@ -1058,7 +1061,7 @@ function completenessCert({ shown = 0, total = null, truncated = null, semantic 
     const more = total != null ? `${shown} of ${total}` : `the top ${shown}`;
     return `\n[completeness: PARTIAL — showing ${more}; the remainder is known and recoverable (raise the cap or read the tee file).]`;
   }
-  return `\n[completeness: COMPLETE — ${semantic ? "the language-server index" : "the bounded scan"} returned every match (${shown}).]`;
+  return `\n[completeness: COMPLETE — ${semantic ? "the language-server index" : "the bounded scan"} returned every match${within} (${shown}).]`;
 }
 export { completenessCert };
 function fmtLocations(locs, max, label) {
@@ -1728,7 +1731,7 @@ export async function runTool(name, a = {}) {
       const t0 = Date.now();
       await getClient(root, backendName);
       const adv = backendName === "clangd" && !hasClangdIndexer()
-        ? `\n(For INSTANT pre-indexing install the full LLVM release — it bundles clangd-indexer — then re-run vts preindex; it builds a static --index-file instead of the slower background crawl.)`
+        ? `\n(For INSTANT pre-indexing install the full LLVM toolchain — it bundles clangd-indexer — then re-run vts preindex; it builds a static --index-file instead of the slower background crawl.\n   install:  scoop install llvm   |   winget install LLVM.LLVM   |   https://github.com/llvm/llvm-project/releases\n   already have it elsewhere? point vts at it: VTS_CLANGD_INDEXER_CMD=/path/to/clangd-indexer)`
         : "";
       return out(backendAdvisory(backendName, root) + `Pre-warmed ${backendName} for ${root}${scopeNote} in ${((Date.now() - t0) / 1000).toFixed(1)}s (background index persisted to .cache).` + adv);
     }
@@ -1941,7 +1944,7 @@ export async function runTool(name, a = {}) {
           }
         }
         const partialIdx = backendName === "typescript" || backendName === "pyright" || (backendName === "clangd" && !hasCompileDb(root));
-        const emptyCert = completenessCert({ shown: 0, total: 0, truncated: partialIdx ? "index" : null, semantic: true });
+        const emptyCert = completenessCert({ shown: 0, total: 0, truncated: partialIdx ? "index" : null, semantic: true, scoped: scopeDirsFor(root).length > 0 });
         return finishOut([], adv + `No symbols matching "${a.q}" (backend: ${backendName}).` + EMPTY_HINT + clangdIndexAdvisory(backendName, root, null) + emptyCert);
       }
       // confidence-adaptive focus: an exact-name match in a big set → show it + a few, not the whole tail.
@@ -1949,7 +1952,7 @@ export async function runTool(name, a = {}) {
       const symTee = teeOverflow("search_symbol", a.q, syms.map((s) => `${s.name} @ ${locLine(s.location.uri, s.location.range)}`), focusN);
       const symEdit = editSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10) ? EDIT_STEER : ""; // focused lookup → likely an edit precursor
       const focusNote = focusN < max && focusN < syms.length ? ` — showing the ${focusN} best for an exact-name hit (raise maxResults or VTS_FOCUS=0 for all ${syms.length})` : "";
-      const symCert = completenessCert({ shown: Math.min(focusN, syms.length), total: syms.length, truncated: focusN < syms.length ? "cap" : null, semantic: true });
+      const symCert = completenessCert({ shown: Math.min(focusN, syms.length), total: syms.length, truncated: focusN < syms.length ? "cap" : null, semantic: true, scoped: scopeDirsFor(root).length > 0 });
       const symBody = adv + `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root})${focusNote}${symTee}:\n` + fmtSymbols(syms, focusN) + symEdit + symCert;
       maybeCounterfactual("search_symbol", String(a.q), root, syms.map((s) => s.location), symBody);
       return finishOut(syms, symBody);
@@ -2029,7 +2032,7 @@ export async function runTool(name, a = {}) {
       // detail=file|dir → a blast-radius summary (dependents grouped + ranked) instead of the per-line list.
       const detail = String(a.detail || "").toLowerCase();
       const refBody = (detail === "file" || detail === "dir") ? fmtRefSummary(locList, detail, max) : fmtLocations(locs, max, "reference(s)");
-      const refCert = completenessCert({ shown: Math.min(locList.length, max), total: locList.length, truncated: locList.length > max ? "cap" : null, semantic: true });
+      const refCert = completenessCert({ shown: Math.min(locList.length, max), total: locList.length, truncated: locList.length > max ? "cap" : null, semantic: true, scoped: scopeDirsFor(root).length > 0 });
       const refBodyFull = backendAdvisory(backendName, root) + `references of ${originLabel} (backend: ${backendName})${refTee}:\n` + refBody + refCert;
       if (a.symbol) maybeCounterfactual("find_references", String(a.symbol), root, locList, refBodyFull); // by-name → a NAME to shadow-grep
       return finishOut(locs, refBodyFull);

--- a/server/core.js
+++ b/server/core.js
@@ -772,7 +772,9 @@ function clangdShardCount(cdbDir) {
 export function clangdIndexAdvisory(backendName, root, targetPath) {
   if (backendName !== "clangd") return "";
   if (/^(0|false|off|no)$/i.test(String(process.env.VTS_INDEX_ADVISORY ?? "1"))) return "";
-  let cdbDir; try { cdbDir = resolveCdbDir(root); } catch { cdbDir = null; }
+  // Use the EFFECTIVE (scoped) CDB so the TU count + shard % reflect the scope — else a scoped project still
+  // reports the full ~26k TUs and tells the user to scope when they already have.
+  let cdbDir; try { cdbDir = effectiveCdbDir(root); } catch { cdbDir = null; }
   if (!cdbDir) return ""; // the no-DB case is already covered by compileDbAdvisory
   const db = loadCdb(cdbDir);
   if (!db) return "";
@@ -1713,27 +1715,34 @@ export async function runTool(name, a = {}) {
       return out(lines.join("\n"));
     }
     if (name === "vts_preindex") {
-      // Pre-build the index so the first real query is instant. clangd + clangd-indexer → an offline static
-      // index loaded via --index-file (no lazy crawl); otherwise a full warm pass that persists the background
-      // index. Honors the configured scope, so on a huge tree only the chosen subset is indexed.
+      // Pre-build the index so the first real query is instant. DEFAULT = a scoped background-index warm pass
+      // (no extra build step; works with the clangd everyone has). The clangd-indexer STATIC index is the
+      // heavy, OPT-IN path (`static=true`): it parses every in-scope TU offline and can take TENS OF MINUTES on
+      // a large scope, so it is never triggered just because the binary exists. Either way the scope is
+      // honored, and clangd auto-loads an EXISTING vts-static.idx via --index-file (cheap) regardless.
       const root = resolveRoot(a);
       const backendName = a.backend || BACKEND || pickBackend(root);
       if (!backendName) return err(`No backend to pre-index. Pass backend=clangd|roslyn|typescript|pyright or ensure ${root} has a build artifact.`);
       const dirs = scopeDirsFor(root);
       const scopeNote = dirs.length ? ` (scope: ${dirs.length} dir(s))` : " (whole tree — set a scope via vts setup --scope to index a subset faster)";
-      if (backendName === "clangd" && hasClangdIndexer()) {
+      const wantStatic = a.static === true || a.static === "true";
+      if (backendName === "clangd" && wantStatic) {
+        if (!hasClangdIndexer()) return err(`preindex static: clangd-indexer not found. Install the full LLVM toolchain (scoop install llvm | winget install LLVM.LLVM) or set VTS_CLANGD_INDEXER_CMD. Or omit static=true for the background-index warm pass.`);
         const r = buildStaticIndex(root);
         if (r.error) return err(`preindex: ${r.error}`);
         const t0 = Date.now();
         try { await getClient(root, backendName); } catch { /* warm best-effort */ }
-        return out(`Built static clangd index${scopeNote}: ${r.tus} TU(s) → ${r.path} in ${(r.ms / 1000).toFixed(1)}s, loaded via --index-file (no background crawl wait). Warm in ${((Date.now() - t0) / 1000).toFixed(1)}s.`);
+        return out(`Built STATIC clangd index${scopeNote}: ${r.tus} TU(s) → ${r.path} in ${(r.ms / 1000).toFixed(1)}s, loaded via --index-file (no background crawl wait). Warm in ${((Date.now() - t0) / 1000).toFixed(1)}s.`);
       }
       const t0 = Date.now();
       await getClient(root, backendName);
-      const adv = backendName === "clangd" && !hasClangdIndexer()
-        ? `\n(For INSTANT pre-indexing install the full LLVM toolchain — it bundles clangd-indexer — then re-run vts preindex; it builds a static --index-file instead of the slower background crawl.\n   install:  scoop install llvm   |   winget install LLVM.LLVM   |   https://github.com/llvm/llvm-project/releases\n   already have it elsewhere? point vts at it: VTS_CLANGD_INDEXER_CMD=/path/to/clangd-indexer)`
-        : "";
-      return out(backendAdvisory(backendName, root) + `Pre-warmed ${backendName} for ${root}${scopeNote} in ${((Date.now() - t0) / 1000).toFixed(1)}s (background index persisted to .cache).` + adv);
+      // After a default warm pass, point at the heavier static option ONLY as a hint (with the time caveat) —
+      // never auto-run it. Install advice when clangd has no indexer at all.
+      const staticHint = backendName !== "clangd" ? ""
+        : hasClangdIndexer()
+          ? `\n(Want instant COLD starts across sessions? \`vts preindex --static\` builds a one-time monolithic --index-file via clangd-indexer — but it parses every in-scope TU and can take tens of minutes on a large scope, so run it in the background / CI. The scoped background index above is usually enough.)`
+          : `\n(Optional: install the full LLVM toolchain — it bundles clangd-indexer — then \`vts preindex --static\` builds an instant-load --index-file.\n   install:  scoop install llvm   |   winget install LLVM.LLVM   |   https://github.com/llvm/llvm-project/releases  ·  or VTS_CLANGD_INDEXER_CMD=/path/to/clangd-indexer)`;
+      return out(backendAdvisory(backendName, root) + `Pre-warmed ${backendName} for ${root}${scopeNote} in ${((Date.now() - t0) / 1000).toFixed(1)}s (background index persisted to .cache).` + staticHint);
     }
     if (name === "vts_gen_compile_db") {
       // The user's choice: run UBT GenerateClangDatabase for full semantic clangd, OR don't and stay in

--- a/server/policy.js
+++ b/server/policy.js
@@ -1,0 +1,44 @@
+// Unified tool-routing policy — the "integratively wise" layer that makes vts COMPLEMENT Claude Code's native
+// tools (Read / Grep / Glob / Edit / native LSP) instead of competing with them. Two jobs:
+//
+//   1. shouldSuppressSteer(file) — stay SILENT where a CC-native tool is clearly the better choice, so vts
+//      never nags on a case it can't improve. The clear wins (aggressive default: only obvious cases): a
+//      GENERATED or BUILD-OUTPUT path (Intermediate / Binaries / Saved / *.generated.* / node_modules / build
+//      …) where a semantic index is noise. (The doc/log carve-out, sub-declaration ignore, and freeform-grep
+//      warn already live in the hook — this fills the generated/build-output gap.)
+//
+//   2. routingDigest() — ONE coherent SessionStart message: a when-to-use-what decision tree PLUS the live
+//      adoption posture (edit-adoption % + the adaptive controller state), so the model reads a single policy
+//      instead of N scattered reflexive nudges. This is the "integrative" half — vts and CC-native each named
+//      for what they're best at.
+import { readEditLedger, adoptionPct, controllerReport } from "./edit-ledger.js";
+
+// Generated code / build output / vendored deps — a semantic index adds nothing here; CC-native is fine.
+const SUPPRESS_DIR = /(^|[/\\])(Intermediate|Binaries|Saved|DerivedDataCache|node_modules|build|dist|out|obj|\.git)([/\\]|$)/i;
+const GENERATED = /\.(generated\.[a-z0-9]+|g\.cs|designer\.cs|pb\.(go|cc|h)|min\.js)$/i;
+export function shouldSuppressSteer(file) {
+  if (!suppressOn() || !file) return false;
+  const f = String(file).replace(/\\/g, "/");
+  return SUPPRESS_DIR.test(f) || GENERATED.test(f);
+}
+const onOff = (v, d) => !/^(0|false|off|no)$/i.test(String(v ?? d));
+export function suppressOn() { return onOff(process.env.VTS_SUPPRESS, "1"); }
+
+// The single routing digest. Always emits the decision tree (the integrative guidance); appends the live
+// adoption posture + adaptive-controller state when there is enough data.
+export function routingDigest(o = readEditLedger()) {
+  const pct = adoptionPct(o);
+  const total = (o.builtin || 0) + (o.symbol || 0);
+  const lines = [
+    "[vs-token-safer] Tool routing — vts and Claude Code's native tools are COMPLEMENTARY; use the cheapest tool that fits:",
+    "  • a symbol / its references / a rename, on INDEXED code → vts search_symbol / find_references / rename (semantic, token-capped) — not grep",
+    "  • ADD or REPLACE a whole declaration → vts replace_symbol_body / insert_symbol (edits by name, skips reading the file)",
+    "  • a doc or log, a quick literal peek, a JUST-edited or unindexed file, a sub-declaration tweak → CC-native Read / Grep / Edit is right; vts stays out of the way",
+    "  • a big tree with a slow first query → vts setup --scope <module> then vts preindex (index a subtree, not the whole monorepo)",
+  ];
+  if (pct !== null && total >= 3) {
+    const hasSteer = (((o.mod || {}).warn || {}).shown || 0) + (((o.mod || {}).block || {}).shown || 0) > 0;
+    lines.push(`  posture: symbol-edit adoption ${pct}% (${o.symbol || 0}/${total})${hasSteer ? " · " + controllerReport(o) : ""}`);
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

Follow-on to the scope/preindex release (v0.33.2), addressing live-test findings + the integrative tool-use ask.

**within-scope completeness cert** — when an indexing scope is active, a semantic COMPLETE / authoritative-0 is qualified "within the configured indexing scope (not the whole project)", so a scoped result isn't read as project-wide. Wired into search_symbol / find_references.

**Preindex gating (the "tens of minutes" footgun)** — `vts preindex` DEFAULT is now a fast scoped background warm; the clangd-indexer STATIC `--index-file` build (parses every in-scope TU) is OPT-IN via `--static` / `static=true`, never auto-run just because the binary exists. An existing `vts-static.idx` is still auto-loaded (cheap). `clangdIndexAdvisory` now counts against the EFFECTIVE (scoped) CDB. Concrete install hints surfaced (scoop/winget/LLVM). **Verified live on a real UE5 tree** (clangd-indexer 22.1.0, 2-TU scope → static .idx build works; default correctly skips it).

**Unified tool-routing policy** (`server/policy.js`) — vts now COMPLEMENTS Claude Code's native tools:
- `shouldSuppressSteer` stays silent on generated/build-output paths (Intermediate, Binaries, *.generated.*, node_modules…) — a whole-decl edit there isn't nagged or counted against adoption (verified through the actual hook). `VTS_SUPPRESS=0` off.
- `routingDigest` = ONE SessionStart message (when-to-use-what decision tree + live adoption posture + adaptive-controller state) replacing the adoption-only nudge — one coherent policy, not scattered nudges.

## Review points
- Additive + togglable; defaults preserve behavior. Charter held.
- Eval 79 → 80 (guards 79 scope, 80 policy; 76 extended for within-scope). Lint clean.
- Grep-side adaptivity reuses `vts discover` rather than a 2nd live loop — a deliberate scope choice, noted for a future extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
