### PR TITLE
feat(perf): clangd-indexer kill switch + --static/--docs bool flags

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1750,7 +1750,15 @@ const scStatsOk = scStats && scStats.total === 2 && scStats.kept === 1;
 const scNoScopeOk = scopedCdb(scDir, scDir, [], scOutBase) === scDir;          // empty scope → src unchanged
 const scNoMatchOk = scopedCdb(scDir, scDir, scopeDirs(scDir, "Nonexistent"), scOutBase) === scDir; // no match → fall back to full
 try { fs.rmSync(scDir, { recursive: true, force: true }); } catch { /* ignore */ }
-const scopeOk = scResolveOk && scInOk && scEmptyAllOk && scPruneOk && scStatsOk && scNoScopeOk && scNoMatchOk;
+// clangd-indexer kill switch: default on; VTS_CLANGD_INDEXER=off (or config clangdIndexer:"off") disables it.
+const { indexerEnabled } = await import("../server/backends/index.js");
+const idxTogPrev = process.env.VTS_CLANGD_INDEXER;
+const idxDefaultOn = indexerEnabled() === true;
+process.env.VTS_CLANGD_INDEXER = "off";
+const idxOff = indexerEnabled() === false;
+if (idxTogPrev === undefined) delete process.env.VTS_CLANGD_INDEXER; else process.env.VTS_CLANGD_INDEXER = idxTogPrev;
+const indexerToggleOk = idxDefaultOn && idxOff;
+const scopeOk = scResolveOk && scInOk && scEmptyAllOk && scPruneOk && scStatsOk && scNoScopeOk && scNoMatchOk && indexerToggleOk;
 
 // 80) unified tool-routing policy — vts COMPLEMENTS Claude Code's native tools. shouldSuppressSteer stays
 // silent on generated/build-output paths (CC-native is fine there); routingDigest is the single
@@ -1850,7 +1858,7 @@ const rows = [
   ["completeness certificate: COMPLETE/PARTIAL/INCONCLUSIVE label + wired into search_text + toggle", certOk, "true", certOk],
   ["counterfactual shadow grep: relateSets algebra + maybeCounterfactual records (vts⊆grep) + report + toggle", counterfactualEvalOk, "true", counterfactualEvalOk],
   ["adaptive escalation controller: warn/block policy (soft/escalate/back-off) + conversion crediting + report", adaptiveCtrlOk, "true", adaptiveCtrlOk],
-  ["indexing scope: scopeDirs/inScope + scopedCdb prune (in-scope TUs only) + stats + no-scope/no-match fallback", scopeOk, "true", scopeOk],
+  ["indexing scope: scopeDirs/inScope + scopedCdb prune + stats + fallbacks + clangd-indexer kill switch", scopeOk, "true", scopeOk],
   ["tool-routing policy: suppress steer on generated/build paths (CC-native) + routing digest + toggle", policyOk, "true", policyOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -167,9 +167,18 @@ export function clangdIndexerCmd() {
   }
   return "clangd-indexer";
 }
+// Kill switch — disable the clangd-indexer static-index path entirely on a machine where it's unwanted
+// (e.g. the build is too slow, or you don't want a static --index-file). VTS_CLANGD_INDEXER=off (env) or
+// config `clangdIndexer:"off"`. Default on. When off: hasClangdIndexer() is false (preindex --static refuses)
+// AND clangd does NOT load a prebuilt vts-static.idx via --index-file (so a stale .idx is ignored too).
+export function indexerEnabled() {
+  const v = env("VTS_CLANGD_INDEXER") || (_fileCfg.clangdIndexer != null ? String(_fileCfg.clangdIndexer) : "");
+  return !/^(0|false|off|no)$/i.test(v);
+}
 // Is clangd-indexer actually runnable? (full LLVM installs have it; the VS-bundled LLVM ships only clangd.)
 let _indexerOk;
 export function hasClangdIndexer() {
+  if (!indexerEnabled()) return false; // explicit kill switch — don't even probe
   if (_indexerOk !== undefined) return _indexerOk;
   try { execFileSync(clangdIndexerCmd(), ["--help"], { encoding: "utf8", timeout: 8000, stdio: ["ignore", "ignore", "ignore"] }); _indexerOk = true; }
   catch { _indexerOk = false; }
@@ -256,7 +265,7 @@ export const BACKENDS = {
       // server. Gives an instant project-wide index instead of the lazy background crawl. Built by
       // `vts preindex`; scope-specific (next to the scoped compile DB). Background index stays on so edits
       // made after the static build are still picked up.
-      try { const idx = staticIndexPath(root); if (fs.existsSync(idx)) a.push(`--index-file=${idx}`); } catch { /* none */ }
+      try { if (indexerEnabled()) { const idx = staticIndexPath(root); if (fs.existsSync(idx)) a.push(`--index-file=${idx}`); } } catch { /* none */ }
       // Prebuilt/remote index (zero per-dev warmup): point clangd at a shared clangd-index-server.
       const remote = env("VTS_CLANGD_REMOTE");
       if (remote) a.push(`--remote-index-address=${remote}`, `--project-root=${root}`);

--- a/server/cli.js
+++ b/server/cli.js
@@ -80,7 +80,7 @@ Backends (auto-detected from the root, or set --backend / VTS_BACKEND):
 Settings precedence: env (VTS_*) > ~/.vs-token-safer/config.json > default.`;
 
 const LIST_FLAGS = new Set([]);
-const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open"]);
+const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open", "static", "docs"]);
 
 function parseArgs(argv) {
   const a = {};

--- a/server/core.js
+++ b/server/core.js
@@ -11,7 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync, execSync } from "node:child_process";
 import { LspClient, fromUri, langIdForPath, envInt, canonFsPath } from "./lsp.js";
-import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot, effectiveCdbDir, scopeDirsFor, buildStaticIndex, hasClangdIndexer } from "./backends/index.js";
+import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot, effectiveCdbDir, scopeDirsFor, buildStaticIndex, hasClangdIndexer, indexerEnabled } from "./backends/index.js";
 import { scopeStats } from "./scope.js";
 import { recordQueryResults, languageCensus, histRank } from "./warmset.js";
 import { splitSegments } from "./shell-split.js";
@@ -35,7 +35,7 @@ export const PROJECT_PATH = cfg("VTS_PROJECT_PATH", "projectPath", "");
 export const BACKEND = cfg("VTS_BACKEND", "backend", ""); // "clangd" | "roslyn" | "" (auto)
 export const MAX_RESULTS = parseInt(cfg("VTS_MAX_RESULTS", "maxResults", "60"), 10) || 60;
 export const PREWARM_BACKENDS = cfg("VTS_PREWARM_BACKENDS", "prewarmBackends", ""); // "" | auto | all | comma-list
-const CONFIG_KEYS = ["projectPath", "backend", "maxResults", "prewarmBackends", "tee", "excludeCommands", "usdPerMtok", "clangdCmd", "scope"];
+const CONFIG_KEYS = ["projectPath", "backend", "maxResults", "prewarmBackends", "tee", "excludeCommands", "usdPerMtok", "clangdCmd", "scope", "clangdIndexer"];
 
 // ---- per-call project root resolution ----
 // The MCP server is ONE long-lived process serving every repo a session touches, so a single configured
@@ -1727,7 +1727,9 @@ export async function runTool(name, a = {}) {
       const scopeNote = dirs.length ? ` (scope: ${dirs.length} dir(s))` : " (whole tree — set a scope via vts setup --scope to index a subset faster)";
       const wantStatic = a.static === true || a.static === "true";
       if (backendName === "clangd" && wantStatic) {
-        if (!hasClangdIndexer()) return err(`preindex static: clangd-indexer not found. Install the full LLVM toolchain (scoop install llvm | winget install LLVM.LLVM) or set VTS_CLANGD_INDEXER_CMD. Or omit static=true for the background-index warm pass.`);
+        if (!hasClangdIndexer()) return err(!indexerEnabled()
+          ? `preindex static: clangd-indexer is DISABLED on this machine (clangdIndexer="off" / VTS_CLANGD_INDEXER=off). Re-enable with \`vts setup --clangdIndexer on\`, or omit static for the background-index warm pass.`
+          : `preindex static: clangd-indexer not found. Install the full LLVM toolchain (scoop install llvm | winget install LLVM.LLVM) or set VTS_CLANGD_INDEXER_CMD. Or omit static for the background-index warm pass.`);
         const r = buildStaticIndex(root);
         if (r.error) return err(`preindex: ${r.error}`);
         const t0 = Date.now();


### PR DESCRIPTION
## Summary

Lets a machine disable the clangd-indexer static-index path entirely — for boxes where the offline build is too slow to be worth it (the static build parses every in-scope TU).

- `VTS_CLANGD_INDEXER=off` (env) or config `clangdIndexer:"off"` (`vts setup --clangdIndexer off`). When off: `hasClangdIndexer()` → false (no probe), clangd does NOT load a prebuilt `vts-static.idx` via `--index-file` (stale .idx ignored), and `vts preindex --static` refuses with a clear DISABLED message (→ `vts setup --clangdIndexer on`).
- Bug fix: `--static` / `--docs` are now real boolean CLI flags — a bare `--static` was parsed as `""` and silently ignored. New CONFIG_KEY `clangdIndexer`.

## Review points
- Default on (no behavior change unless disabled). Eval 80/80 (guard 79 extended: default-on / off toggle). Lint clean.
- Verified live: with `clangdIndexer=off` persisted, `vts preindex --static` refuses with the DISABLED message; default preindex warm-passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
