### PR TITLE
release: vs-token-safer 0.33.3 (within-scope cert, policy, indexer kill switch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,20 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   absent → warm-pass fallback + advisory to install full LLVM. Ops `vts_scope` (show scope + TU stats +
   top-level dirs) / `vts_preindex` (build ahead: static index if indexer present, else warm pass); CLI `vts
   scope`/`vts preindex`, folded into `vts_admin`. Eval guard 79. Env: `VTS_SCOPE`, `VTS_CLANGD_INDEXER_CMD`,
-  `VTS_INDEXER_TIMEOUT_MS` (1800000).
+  `VTS_INDEXER_TIMEOUT_MS` (1800000). PREINDEX GATING: `vts preindex` DEFAULT = fast scoped background warm;
+  the clangd-indexer STATIC `--index-file` (parses every in-scope TU, tens of min on a big scope) is OPT-IN via
+  `static=true`/`--static` — never auto-run just because the indexer exists (an existing `vts-static.idx` is
+  still auto-loaded, cheap). within-scope cert: `completenessCert({scoped})` qualifies a semantic COMPLETE/0 as
+  "within the configured indexing scope" (search_symbol/find_references), and `clangdIndexAdvisory` counts
+  TUs/shards against the EFFECTIVE (scoped) CDB.
+- `server/policy.js` — UNIFIED TOOL-ROUTING POLICY (vts COMPLEMENTS Claude Code, not competes). `shouldSuppressSteer(file)`
+  stays SILENT where CC-native is clearly better — generated/build-output paths (`Intermediate|Binaries|Saved|
+  DerivedDataCache|node_modules|build|dist|out|obj|.git`, `*.generated.*`/`*.g.cs`/`*.min.js`); wired into the
+  edit-steer hook (a whole-decl edit there isn't nagged AND isn't counted against adoption). `VTS_SUPPRESS=0` off.
+  `routingDigest()` = the SINGLE SessionStart message: a when-to-use-what decision tree (semantic→vts, whole-decl→
+  symbol-edit, doc/just-edited/sub-decl→CC-native Read/Grep/Edit, big-tree→scope+preindex) + live adoption posture +
+  adaptive-controller state — replaces the adoption-only nudge in `hooks/edit-report.js` (one coherent policy, not
+  scattered nudges). Eval guard 80.
 - `server/backends/index.js` — clangd/roslyn/typescript/pyright spawn configs + `pickBackend(root)`
   (detect order: compile_commands→clangd > .sln/.csproj→roslyn > tsconfig/package.json→typescript >
   pyproject/*.py→pyright; strongest build-artifact first). MIXED-REPO FIX: a query that TARGETS a file uses

--- a/README.ko.md
+++ b/README.ko.md
@@ -220,6 +220,38 @@ clangd는 비동기로 인덱싱하므로 *첫* 검색은 일회성 워밍업을
 </details>
 
 <details>
+<summary><b>큰 트리: 스코프 &amp; 사전 인덱싱(콜드 스타트)</b></summary>
+
+거대 모노레포(예: 전체 Unreal Engine 소스 트리, 번역 단위 ~26k)에서는 콜드 인덱스가 유일한 실비용입니다.
+두 옵트인 지렛대로 줄입니다 — 둘 다 로컬, 전송 없음:
+
+**1. 스코프 — 전체가 아니라 서브트리만 인덱싱.** 무엇을 스코프할지 보고 설정:
+
+```bash
+vts scope --projectPath /path/to/UE        # 현재 스코프, 유지/전체 TU 수, 고를 수 있는 최상위 디렉터리 표시
+vts setup --scope "TSGame,Plugins"         # 영속화(또는 VTS_SCOPE="TSGame,Plugins"); 이후 reload/재시작
+```
+
+그러면 clangd가 스코프 내 번역 단위만 인덱싱하고(실측 UE5: `TSGame` → 26,488 중 3,377 TU, **13%**), 모든
+백엔드의 워밍도 함께 스코프됩니다. 스코프 미설정 = 기존 전체 트리 동작 그대로.
+
+**2. 사전 인덱싱 — 첫 질의 전에 인덱스를 빌드.**
+
+```bash
+vts preindex --projectPath /path/to/UE     # 위 스코프를 따름
+```
+
+**full LLVM 릴리스**가 설치돼 있으면(`clangd` 옆에 `clangd-indexer` 동봉) 단일 정적 인덱스를 오프라인으로
+빌드하고 clangd가 `--index-file`(원격 서버가 아닌 로컬 파일)로 로드 — 게으른 백그라운드 크롤을 기다리지 않고
+첫 질의가 즉시. `clangd-indexer`가 없으면 워밍 패스로 폴백(+ full LLVM 설치 안내). 바이너리는
+`VTS_CLANGD_INDEXER_CMD`로 지정.
+
+**기존 사용자는 setup을 다시 해야 하나요?** 기본(전체 트리) 동작은 **아니요** — 플러그인 업데이트 후
+`/reload-plugins`만 하면 됩니다. 스코핑을 *옵트인*하려는 경우에만 `vts setup --scope …`를 한 번 실행하면 되고,
+`clangd-indexer` 경로는 vts setup이 전혀 필요 없습니다(자동 감지 — full LLVM만 설치돼 있으면 됨).
+</details>
+
+<details>
 <summary><b>절감 &amp; discover (포착률)</b></summary>
 
 검색마다 원시 인덱스 응답을 그대로 보내는 것 대비 아낀 토큰을 기록합니다. `/vs-token-safer:savings`,
@@ -251,7 +283,7 @@ $ vts discover --since 1
 <summary><b>언어 서버 &amp; 컴파일 데이터베이스</b></summary>
 
 - **Node.js ≥ 18**이 PATH에.
-- **C/C++ → clangd ≥ 22** ([릴리스](https://github.com/clangd/clangd/releases)). Visual Studio에 번들된 clangd 19.1.x는 실제 Unreal TU를 서버 모드로 인덱싱할 때 **교착**합니다 — 오래된 게 감지되면 vts가 경고합니다. `compile_commands.json`이 필요합니다.
+- **C/C++ → clangd ≥ 22** ([릴리스](https://github.com/clangd/clangd/releases)). Visual Studio에 번들된 clangd 19.1.x는 실제 Unreal TU를 서버 모드로 인덱싱할 때 **교착**합니다 — 오래된 게 감지되면 vts가 경고합니다. `compile_commands.json`이 필요합니다. **full LLVM 릴리스**를 권장 — `clangd` 옆에 `clangd-indexer`가 동봉되어 `vts preindex`가 즉시 정적 인덱스를 만듭니다(*큰 트리: 스코프 &amp; 사전 인덱싱* 참고).
 - **C#/.NET → Roslyn LSP.** VS Code C# 확장(`ms-dotnettools.csharp`)을 설치하면 vts가 번들에서 `Microsoft.CodeAnalysis.LanguageServer`와 런타임을 자동 감지합니다. 대안: `dotnet tool install --global csharp-ls`. `.sln`/`.csproj`가 필요합니다.
 - **JS/TS → typescript-language-server, Python → pyright.** 플러그인 의존성으로 들어가 첫 세션에 자동 설치됩니다(최초 1회 ~50MB; JS/TS는 Node 20+를 원하고 18에서는 건너뜀).
 - **혼합 repo?** 파일을 대상으로 한 질의는 그 파일의 언어 백엔드를 씁니다 — C++/C#(clangd/roslyn 루트) 트리 안의 `.py`/`.ts`도 pyright/typescript로 자동 처리되므로, UE 트리에 Python 도구 디렉터리가 섞여 있어도 수동 `backend=` 없이 vts가 동작합니다. 이건 **고정된 `backend`/`VTS_BACKEND`보다도 우선**합니다(충돌 시): 전역 서버 하나가 건드리는 모든 repo를 처리하므로, C++ 프로젝트용으로 `backend:"clangd"`를 박아 둬도 다른 repo의 `.js`/`.cs`/`.py`를 clangd로 보내지 않습니다(보내면 clangd가 `-32001 invalid AST`로 응답). 파일 대상이 없는 질의(예: 이름으로 `search_symbol`)는 고정 백엔드를 유지합니다.

--- a/README.md
+++ b/README.md
@@ -223,6 +223,38 @@ The smaller the slice you can afford to warm, the bigger the win.
 </details>
 
 <details>
+<summary><b>Big trees: scope &amp; pre-index (cold-start)</b></summary>
+
+On a huge monorepo (e.g. a full Unreal Engine source tree, ~26k translation units) the cold index is the
+one real cost. Two opt-in levers cut it — both stay local, nothing is transmitted:
+
+**1. Scope — index a subtree, not the whole tree.** See what you'd scope, then set it:
+
+```bash
+vts scope --projectPath /path/to/UE        # shows current scope, kept/total TUs, and top-level dirs to pick
+vts setup --scope "TSGame,Plugins"         # persist it (or set VTS_SCOPE="TSGame,Plugins"); then reload/restart
+```
+
+clangd then indexes only the in-scope translation units (live UE5: `TSGame` → 3,377 of 26,488 TUs, **13%**),
+and every backend's warm-up is scoped with it. No scope set = whole-tree behavior, unchanged.
+
+**2. Pre-index — build the index ahead of the first query.**
+
+```bash
+vts preindex --projectPath /path/to/UE     # honors the scope above
+```
+
+With the **full LLVM release** installed (it bundles `clangd-indexer` next to `clangd`), this builds a
+monolithic static index offline and clangd loads it via `--index-file` — a local file, no server — so the
+first query is instant instead of waiting on the lazy background crawl. Without `clangd-indexer` it falls
+back to a warm pass (and tells you to install full LLVM). Override the binary with `VTS_CLANGD_INDEXER_CMD`.
+
+**Do existing users need to re-run setup?** For default (whole-tree) behavior, **no** — just update the
+plugin and `/reload-plugins`. You only run `vts setup --scope …` (once) if you want to *opt into* scoping;
+the `clangd-indexer` path needs no vts setup at all (it's auto-detected — you just need full LLVM installed).
+</details>
+
+<details>
 <summary><b>Savings &amp; discover (catch-rate)</b></summary>
 
 Each search records the tokens it saved vs forwarding the raw index response. Check it with
@@ -254,7 +286,7 @@ searches hit into the warm-up set, so each session leaves the index warmer.
 <summary><b>Language servers &amp; the compile database</b></summary>
 
 - **Node.js ≥ 18** on PATH.
-- **C/C++ → clangd ≥ 22** ([releases](https://github.com/clangd/clangd/releases)). The clangd 19.1.x bundled with Visual Studio **deadlocks** indexing real Unreal TUs in server mode; vts warns on an older one. Needs a `compile_commands.json`.
+- **C/C++ → clangd ≥ 22** ([releases](https://github.com/clangd/clangd/releases)). The clangd 19.1.x bundled with Visual Studio **deadlocks** indexing real Unreal TUs in server mode; vts warns on an older one. Needs a `compile_commands.json`. Prefer the **full LLVM release** — it bundles `clangd-indexer` alongside `clangd`, which `vts preindex` uses for an instant static index (see *Big trees: scope &amp; pre-index*).
 - **C#/.NET → a Roslyn LSP.** Install the VS Code C# extension (`ms-dotnettools.csharp`) — vts auto-detects `Microsoft.CodeAnalysis.LanguageServer` and its runtime from the bundle. Fallback: `dotnet tool install --global csharp-ls`. Needs a `.sln`/`.csproj`.
 - **JS/TS → typescript-language-server, Python → pyright.** Ship as plugin deps, install automatically on the first session (one-time ~50 MB; JS/TS wants Node 20+, skipped on 18).
 - **Mixed repo?** A query that targets a file uses that file's own language backend — a `.py`/`.ts` inside a C++/C# (clangd/roslyn-rooted) tree gets pyright/typescript automatically, so vts works in a UE tree with a Python tooling dir without a manual `backend=`. This even **overrides a pinned `backend` / `VTS_BACKEND`** when they conflict: one global server serves every repo you touch, so a `backend:"clangd"` set for a C++ project never sends another repo's `.js`/`.cs`/`.py` to clangd (which would answer `-32001 invalid AST`). A query with no file target (e.g. `search_symbol` by name) keeps the pinned backend.

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1750,7 +1750,15 @@ const scStatsOk = scStats && scStats.total === 2 && scStats.kept === 1;
 const scNoScopeOk = scopedCdb(scDir, scDir, [], scOutBase) === scDir;          // empty scope → src unchanged
 const scNoMatchOk = scopedCdb(scDir, scDir, scopeDirs(scDir, "Nonexistent"), scOutBase) === scDir; // no match → fall back to full
 try { fs.rmSync(scDir, { recursive: true, force: true }); } catch { /* ignore */ }
-const scopeOk = scResolveOk && scInOk && scEmptyAllOk && scPruneOk && scStatsOk && scNoScopeOk && scNoMatchOk;
+// clangd-indexer kill switch: default on; VTS_CLANGD_INDEXER=off (or config clangdIndexer:"off") disables it.
+const { indexerEnabled } = await import("../server/backends/index.js");
+const idxTogPrev = process.env.VTS_CLANGD_INDEXER;
+const idxDefaultOn = indexerEnabled() === true;
+process.env.VTS_CLANGD_INDEXER = "off";
+const idxOff = indexerEnabled() === false;
+if (idxTogPrev === undefined) delete process.env.VTS_CLANGD_INDEXER; else process.env.VTS_CLANGD_INDEXER = idxTogPrev;
+const indexerToggleOk = idxDefaultOn && idxOff;
+const scopeOk = scResolveOk && scInOk && scEmptyAllOk && scPruneOk && scStatsOk && scNoScopeOk && scNoMatchOk && indexerToggleOk;
 
 // 80) unified tool-routing policy — vts COMPLEMENTS Claude Code's native tools. shouldSuppressSteer stays
 // silent on generated/build-output paths (CC-native is fine there); routingDigest is the single
@@ -1850,7 +1858,7 @@ const rows = [
   ["completeness certificate: COMPLETE/PARTIAL/INCONCLUSIVE label + wired into search_text + toggle", certOk, "true", certOk],
   ["counterfactual shadow grep: relateSets algebra + maybeCounterfactual records (vts⊆grep) + report + toggle", counterfactualEvalOk, "true", counterfactualEvalOk],
   ["adaptive escalation controller: warn/block policy (soft/escalate/back-off) + conversion crediting + report", adaptiveCtrlOk, "true", adaptiveCtrlOk],
-  ["indexing scope: scopeDirs/inScope + scopedCdb prune (in-scope TUs only) + stats + no-scope/no-match fallback", scopeOk, "true", scopeOk],
+  ["indexing scope: scopeDirs/inScope + scopedCdb prune + stats + fallbacks + clangd-indexer kill switch", scopeOk, "true", scopeOk],
   ["tool-routing policy: suppress steer on generated/build paths (CC-native) + routing digest + toggle", policyOk, "true", policyOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1643,8 +1643,12 @@ fs.mkdirSync(certDir, { recursive: true });
 fs.writeFileSync(path.join(certDir, "c.js"), "const certToken123 = 1;\n");
 const certScan = await runTool("search_text", { q: "certToken123", projectPath: certDir }); // pure FS, no backend
 const certWired = /\[completeness: COMPLETE/.test(certScan.text || "");
+// scoped: a semantic COMPLETE under an active indexing scope must say it's complete WITHIN the scope, not
+// project-wide (so the agent doesn't over-trust a scoped 0/N).
+const certScopedOk = completenessCert({ shown: 3, total: 3, semantic: true, scoped: true }).includes("within the configured indexing scope")
+  && !completenessCert({ shown: 3, total: 3, semantic: true, scoped: false }).includes("within the configured");
 try { fs.rmSync(certDir, { recursive: true, force: true }); } catch { /* ignore */ }
-const certOk = certComplete && certPartial && certTime && certIndex && certOff && certWired;
+const certOk = certComplete && certPartial && certTime && certIndex && certOff && certWired && certScopedOk;
 
 // 77) counterfactual shadow measurement — the quasi-controlled answer to "did vts reach the same answer as
 // grep?". relateSets classifies vts's answer set against grep's; maybeCounterfactual (opt-in
@@ -1748,6 +1752,22 @@ const scNoMatchOk = scopedCdb(scDir, scDir, scopeDirs(scDir, "Nonexistent"), scO
 try { fs.rmSync(scDir, { recursive: true, force: true }); } catch { /* ignore */ }
 const scopeOk = scResolveOk && scInOk && scEmptyAllOk && scPruneOk && scStatsOk && scNoScopeOk && scNoMatchOk;
 
+// 80) unified tool-routing policy — vts COMPLEMENTS Claude Code's native tools. shouldSuppressSteer stays
+// silent on generated/build-output paths (CC-native is fine there); routingDigest is the single
+// when-to-use-what decision tree + live adoption posture re-injected at SessionStart.
+const { shouldSuppressSteer, routingDigest, suppressOn } = await import("../server/policy.js");
+const supGen = shouldSuppressSteer("/p/Intermediate/Build/Foo.gen.cpp") === true;   // build output → suppress
+const supDotGen = shouldSuppressSteer("/p/Source/Foo.generated.h") === true;        // generated header → suppress
+const supNodeMod = shouldSuppressSteer("/p/node_modules/x/y.js") === true;          // vendored dep → suppress
+const supReal = shouldSuppressSteer("/p/Source/TSGame/Weapon.cpp") === false;       // real source → steer as usual
+const supTogglePrev = process.env.VTS_SUPPRESS;
+process.env.VTS_SUPPRESS = "0";
+const supOff = shouldSuppressSteer("/p/Intermediate/Build/Foo.gen.cpp") === false && suppressOn() === false; // toggle off
+if (supTogglePrev === undefined) delete process.env.VTS_SUPPRESS; else process.env.VTS_SUPPRESS = supTogglePrev;
+const dig = routingDigest({ builtin: 8, symbol: 2, mod: { warn: { shown: 0, converted: 0 }, block: { shown: 0, converted: 0 } } });
+const digOk = /Tool routing/.test(dig) && /COMPLEMENTARY/.test(dig) && /--scope/.test(dig) && /adoption 20% \(2\/10\)/.test(dig); // tree + posture
+const policyOk = supGen && supDotGen && supNodeMod && supReal && supOff && digOk;
+
 await disposeClients(); // guard 75's read_symbol spawned a backend AFTER the earlier teardown — dispose it so node exits
 
 const rows = [
@@ -1831,6 +1851,7 @@ const rows = [
   ["counterfactual shadow grep: relateSets algebra + maybeCounterfactual records (vts⊆grep) + report + toggle", counterfactualEvalOk, "true", counterfactualEvalOk],
   ["adaptive escalation controller: warn/block policy (soft/escalate/back-off) + conversion crediting + report", adaptiveCtrlOk, "true", adaptiveCtrlOk],
   ["indexing scope: scopeDirs/inScope + scopedCdb prune (in-scope TUs only) + stats + no-scope/no-match fallback", scopeOk, "true", scopeOk],
+  ["tool-routing policy: suppress steer on generated/build paths (CC-native) + routing digest + toggle", policyOk, "true", policyOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -36,6 +36,7 @@ import { splitSegments } from "../server/shell-split.js";
 // MEASURE; the adoption ledger is the live metric the steer is tuned against.
 import { classifyDeclEdit } from "../server/edit-detect.js";
 import { recordEditEvent, resetStreak, recordSteerShown, decideEscalation } from "../server/edit-ledger.js";
+import { shouldSuppressSteer } from "../server/policy.js";
 
 const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(os.homedir(), ".vs-token-safer", "config.json");
 const readConfig = () => { try { return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8")) || {}; } catch { return {}; } };
@@ -556,6 +557,10 @@ process.stdin.on("end", () => {
     if (editWarnOn()) {
       const ce = classifyDeclEdit(toolName, ti, editMinLines());
       if (ce.file && (ce.replaceDecl || ce.insertDecl)) {
+        // CC-complement: a whole-decl edit in a GENERATED / build-output path (Intermediate, Binaries,
+        // *.generated.*, node_modules…) is fine with the native Edit — a symbol-edit there buys nothing.
+        // Stay silent AND don't count it against adoption (it isn't a case we'd steer).
+        if (shouldSuppressSteer(ce.file)) process.exit(0);
         const led = recordEditEvent("builtin-warn");
         // L2: an OPT-IN escalation. After VTS_EDIT_BLOCK_AFTER consecutive ignored nudges, BLOCK once on the
         // SAFE subset (a pure insert of a new declaration). DEFAULT OFF (0) — a persistent block TRAPPED the

--- a/hooks/edit-report.js
+++ b/hooks/edit-report.js
@@ -1,24 +1,19 @@
 #!/usr/bin/env node
-// SessionStart self-report — read the edit-adoption ledger and re-inject the symbol-edit adoption ratio as
-// a goal the model sees at the top of the session. This is the "learning" half of the steer loop: the hook
-// + discover MEASURE, this RE-INJECTS the gap as a concrete goal, behavior shifts, and the next session
-// measures again (the SkillOpt textual-gradient cadence — a static skill rule can't self-improve, but a
-// re-injected live metric can). Stays quiet until there's enough data to be worth a line of context.
-import { readEditLedger, adoptionPct, controllerReport } from "../server/edit-ledger.js";
+// SessionStart self-report — re-inject ONE coherent tool-routing policy (the decision tree + the live
+// adoption posture) so the model reads a single integrative guide instead of N scattered reflexive nudges.
+// This is the "learning" half of the steer loop: the hook + discover MEASURE, this RE-INJECTS the gap + the
+// when-to-use-what policy, behavior shifts, the next session measures again (the SkillOpt textual-gradient
+// cadence — a static rule can't self-improve, a re-injected live metric + policy can). Quiet until there's
+// enough activity to be worth a line of context.
+import { readEditLedger, adoptionPct } from "../server/edit-ledger.js";
+import { routingDigest } from "../server/policy.js";
 
 try {
   const o = readEditLedger();
   const pct = adoptionPct(o);
   const total = (o.builtin || 0) + (o.symbol || 0);
-  if (pct === null || total < 5) process.exit(0); // too little data — don't nag
-  // Surface the adaptive controller's per-modality conversions only once it has signal (a steer was shown),
-  // so the model sees WHICH lever is moving the number, not just the aggregate ratio.
-  const hasSteerData = ((o.mod && o.mod.warn && o.mod.warn.shown) || 0) + ((o.mod && o.mod.block && o.mod.block.shown) || 0) > 0;
-  const ctrl = hasSteerData ? ` [${controllerReport(o)}]` : "";
-  const msg =
-    `[vs-token-safer] Symbol-edit adoption: ${pct}% (${o.symbol || 0} symbol-edit vs ${o.builtin || 0} built-in Edit on whole declarations).${ctrl} ` +
-    `When you ADD or REPLACE a whole declaration this session, prefer replace_symbol_body / insert_symbol — ` +
-    `they edit by NAME and skip reading the file into context. Aim to raise the ratio. (Built-in Edit stays right for sub-declaration tweaks.)`;
+  if (pct === null || total < 3) process.exit(0); // too little data — don't nag on a fresh/idle session
+  const msg = routingDigest(o);
   process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: msg } }) + "\n");
 } catch { /* best-effort — never break session start */ }
 process.exit(0);

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -167,9 +167,18 @@ export function clangdIndexerCmd() {
   }
   return "clangd-indexer";
 }
+// Kill switch — disable the clangd-indexer static-index path entirely on a machine where it's unwanted
+// (e.g. the build is too slow, or you don't want a static --index-file). VTS_CLANGD_INDEXER=off (env) or
+// config `clangdIndexer:"off"`. Default on. When off: hasClangdIndexer() is false (preindex --static refuses)
+// AND clangd does NOT load a prebuilt vts-static.idx via --index-file (so a stale .idx is ignored too).
+export function indexerEnabled() {
+  const v = env("VTS_CLANGD_INDEXER") || (_fileCfg.clangdIndexer != null ? String(_fileCfg.clangdIndexer) : "");
+  return !/^(0|false|off|no)$/i.test(v);
+}
 // Is clangd-indexer actually runnable? (full LLVM installs have it; the VS-bundled LLVM ships only clangd.)
 let _indexerOk;
 export function hasClangdIndexer() {
+  if (!indexerEnabled()) return false; // explicit kill switch — don't even probe
   if (_indexerOk !== undefined) return _indexerOk;
   try { execFileSync(clangdIndexerCmd(), ["--help"], { encoding: "utf8", timeout: 8000, stdio: ["ignore", "ignore", "ignore"] }); _indexerOk = true; }
   catch { _indexerOk = false; }
@@ -256,7 +265,7 @@ export const BACKENDS = {
       // server. Gives an instant project-wide index instead of the lazy background crawl. Built by
       // `vts preindex`; scope-specific (next to the scoped compile DB). Background index stays on so edits
       // made after the static build are still picked up.
-      try { const idx = staticIndexPath(root); if (fs.existsSync(idx)) a.push(`--index-file=${idx}`); } catch { /* none */ }
+      try { if (indexerEnabled()) { const idx = staticIndexPath(root); if (fs.existsSync(idx)) a.push(`--index-file=${idx}`); } } catch { /* none */ }
       // Prebuilt/remote index (zero per-dev warmup): point clangd at a shared clangd-index-server.
       const remote = env("VTS_CLANGD_REMOTE");
       if (remote) a.push(`--remote-index-address=${remote}`, `--project-root=${root}`);

--- a/server/cli.js
+++ b/server/cli.js
@@ -80,7 +80,7 @@ Backends (auto-detected from the root, or set --backend / VTS_BACKEND):
 Settings precedence: env (VTS_*) > ~/.vs-token-safer/config.json > default.`;
 
 const LIST_FLAGS = new Set([]);
-const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open"]);
+const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open", "static", "docs"]);
 
 function parseArgs(argv) {
   const a = {};

--- a/server/core.js
+++ b/server/core.js
@@ -772,7 +772,9 @@ function clangdShardCount(cdbDir) {
 export function clangdIndexAdvisory(backendName, root, targetPath) {
   if (backendName !== "clangd") return "";
   if (/^(0|false|off|no)$/i.test(String(process.env.VTS_INDEX_ADVISORY ?? "1"))) return "";
-  let cdbDir; try { cdbDir = resolveCdbDir(root); } catch { cdbDir = null; }
+  // Use the EFFECTIVE (scoped) CDB so the TU count + shard % reflect the scope — else a scoped project still
+  // reports the full ~26k TUs and tells the user to scope when they already have.
+  let cdbDir; try { cdbDir = effectiveCdbDir(root); } catch { cdbDir = null; }
   if (!cdbDir) return ""; // the no-DB case is already covered by compileDbAdvisory
   const db = loadCdb(cdbDir);
   if (!db) return "";
@@ -1045,8 +1047,11 @@ function factorCommonPrefix(lines) {
 function certOn() { return !/^(0|false|off|no)$/i.test(String(process.env.VTS_CERT ?? "1")); }
 // truncated: falsy | "cap" | "time" | "scan". semantic=true → a language-server index answered (authoritative
 // 0); false → a bounded lexical scan. shown/total optional (total null = unknown upper bound).
-function completenessCert({ shown = 0, total = null, truncated = null, semantic = false } = {}) {
+function completenessCert({ shown = 0, total = null, truncated = null, semantic = false, scoped = false } = {}) {
   if (!certOn()) return "";
+  // When an indexing scope is active, a semantic COMPLETE (or authoritative 0) is complete WITHIN THE SCOPE,
+  // not across the whole project — qualify it so the agent doesn't read it as project-wide coverage.
+  const within = scoped ? " within the configured indexing scope (not the whole project — widen or unset the scope for full coverage)" : "";
   if (truncated === "time" || truncated === "scan") {
     const how = truncated === "time" ? "time-boxed" : "scan-limited";
     return `\n[completeness: INCONCLUSIVE — a bounded ${how} walk did not cover the whole tree, so this result (a 0 included) may be incomplete; narrow the scope or use a semantic tool (search_symbol/find_references) to certify.]`;
@@ -1058,7 +1063,7 @@ function completenessCert({ shown = 0, total = null, truncated = null, semantic 
     const more = total != null ? `${shown} of ${total}` : `the top ${shown}`;
     return `\n[completeness: PARTIAL — showing ${more}; the remainder is known and recoverable (raise the cap or read the tee file).]`;
   }
-  return `\n[completeness: COMPLETE — ${semantic ? "the language-server index" : "the bounded scan"} returned every match (${shown}).]`;
+  return `\n[completeness: COMPLETE — ${semantic ? "the language-server index" : "the bounded scan"} returned every match${within} (${shown}).]`;
 }
 export { completenessCert };
 function fmtLocations(locs, max, label) {
@@ -1710,27 +1715,34 @@ export async function runTool(name, a = {}) {
       return out(lines.join("\n"));
     }
     if (name === "vts_preindex") {
-      // Pre-build the index so the first real query is instant. clangd + clangd-indexer → an offline static
-      // index loaded via --index-file (no lazy crawl); otherwise a full warm pass that persists the background
-      // index. Honors the configured scope, so on a huge tree only the chosen subset is indexed.
+      // Pre-build the index so the first real query is instant. DEFAULT = a scoped background-index warm pass
+      // (no extra build step; works with the clangd everyone has). The clangd-indexer STATIC index is the
+      // heavy, OPT-IN path (`static=true`): it parses every in-scope TU offline and can take TENS OF MINUTES on
+      // a large scope, so it is never triggered just because the binary exists. Either way the scope is
+      // honored, and clangd auto-loads an EXISTING vts-static.idx via --index-file (cheap) regardless.
       const root = resolveRoot(a);
       const backendName = a.backend || BACKEND || pickBackend(root);
       if (!backendName) return err(`No backend to pre-index. Pass backend=clangd|roslyn|typescript|pyright or ensure ${root} has a build artifact.`);
       const dirs = scopeDirsFor(root);
       const scopeNote = dirs.length ? ` (scope: ${dirs.length} dir(s))` : " (whole tree — set a scope via vts setup --scope to index a subset faster)";
-      if (backendName === "clangd" && hasClangdIndexer()) {
+      const wantStatic = a.static === true || a.static === "true";
+      if (backendName === "clangd" && wantStatic) {
+        if (!hasClangdIndexer()) return err(`preindex static: clangd-indexer not found. Install the full LLVM toolchain (scoop install llvm | winget install LLVM.LLVM) or set VTS_CLANGD_INDEXER_CMD. Or omit static=true for the background-index warm pass.`);
         const r = buildStaticIndex(root);
         if (r.error) return err(`preindex: ${r.error}`);
         const t0 = Date.now();
         try { await getClient(root, backendName); } catch { /* warm best-effort */ }
-        return out(`Built static clangd index${scopeNote}: ${r.tus} TU(s) → ${r.path} in ${(r.ms / 1000).toFixed(1)}s, loaded via --index-file (no background crawl wait). Warm in ${((Date.now() - t0) / 1000).toFixed(1)}s.`);
+        return out(`Built STATIC clangd index${scopeNote}: ${r.tus} TU(s) → ${r.path} in ${(r.ms / 1000).toFixed(1)}s, loaded via --index-file (no background crawl wait). Warm in ${((Date.now() - t0) / 1000).toFixed(1)}s.`);
       }
       const t0 = Date.now();
       await getClient(root, backendName);
-      const adv = backendName === "clangd" && !hasClangdIndexer()
-        ? `\n(For INSTANT pre-indexing install the full LLVM release — it bundles clangd-indexer — then re-run vts preindex; it builds a static --index-file instead of the slower background crawl.)`
-        : "";
-      return out(backendAdvisory(backendName, root) + `Pre-warmed ${backendName} for ${root}${scopeNote} in ${((Date.now() - t0) / 1000).toFixed(1)}s (background index persisted to .cache).` + adv);
+      // After a default warm pass, point at the heavier static option ONLY as a hint (with the time caveat) —
+      // never auto-run it. Install advice when clangd has no indexer at all.
+      const staticHint = backendName !== "clangd" ? ""
+        : hasClangdIndexer()
+          ? `\n(Want instant COLD starts across sessions? \`vts preindex --static\` builds a one-time monolithic --index-file via clangd-indexer — but it parses every in-scope TU and can take tens of minutes on a large scope, so run it in the background / CI. The scoped background index above is usually enough.)`
+          : `\n(Optional: install the full LLVM toolchain — it bundles clangd-indexer — then \`vts preindex --static\` builds an instant-load --index-file.\n   install:  scoop install llvm   |   winget install LLVM.LLVM   |   https://github.com/llvm/llvm-project/releases  ·  or VTS_CLANGD_INDEXER_CMD=/path/to/clangd-indexer)`;
+      return out(backendAdvisory(backendName, root) + `Pre-warmed ${backendName} for ${root}${scopeNote} in ${((Date.now() - t0) / 1000).toFixed(1)}s (background index persisted to .cache).` + staticHint);
     }
     if (name === "vts_gen_compile_db") {
       // The user's choice: run UBT GenerateClangDatabase for full semantic clangd, OR don't and stay in
@@ -1941,7 +1953,7 @@ export async function runTool(name, a = {}) {
           }
         }
         const partialIdx = backendName === "typescript" || backendName === "pyright" || (backendName === "clangd" && !hasCompileDb(root));
-        const emptyCert = completenessCert({ shown: 0, total: 0, truncated: partialIdx ? "index" : null, semantic: true });
+        const emptyCert = completenessCert({ shown: 0, total: 0, truncated: partialIdx ? "index" : null, semantic: true, scoped: scopeDirsFor(root).length > 0 });
         return finishOut([], adv + `No symbols matching "${a.q}" (backend: ${backendName}).` + EMPTY_HINT + clangdIndexAdvisory(backendName, root, null) + emptyCert);
       }
       // confidence-adaptive focus: an exact-name match in a big set → show it + a few, not the whole tail.
@@ -1949,7 +1961,7 @@ export async function runTool(name, a = {}) {
       const symTee = teeOverflow("search_symbol", a.q, syms.map((s) => `${s.name} @ ${locLine(s.location.uri, s.location.range)}`), focusN);
       const symEdit = editSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10) ? EDIT_STEER : ""; // focused lookup → likely an edit precursor
       const focusNote = focusN < max && focusN < syms.length ? ` — showing the ${focusN} best for an exact-name hit (raise maxResults or VTS_FOCUS=0 for all ${syms.length})` : "";
-      const symCert = completenessCert({ shown: Math.min(focusN, syms.length), total: syms.length, truncated: focusN < syms.length ? "cap" : null, semantic: true });
+      const symCert = completenessCert({ shown: Math.min(focusN, syms.length), total: syms.length, truncated: focusN < syms.length ? "cap" : null, semantic: true, scoped: scopeDirsFor(root).length > 0 });
       const symBody = adv + `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root})${focusNote}${symTee}:\n` + fmtSymbols(syms, focusN) + symEdit + symCert;
       maybeCounterfactual("search_symbol", String(a.q), root, syms.map((s) => s.location), symBody);
       return finishOut(syms, symBody);
@@ -2029,7 +2041,7 @@ export async function runTool(name, a = {}) {
       // detail=file|dir → a blast-radius summary (dependents grouped + ranked) instead of the per-line list.
       const detail = String(a.detail || "").toLowerCase();
       const refBody = (detail === "file" || detail === "dir") ? fmtRefSummary(locList, detail, max) : fmtLocations(locs, max, "reference(s)");
-      const refCert = completenessCert({ shown: Math.min(locList.length, max), total: locList.length, truncated: locList.length > max ? "cap" : null, semantic: true });
+      const refCert = completenessCert({ shown: Math.min(locList.length, max), total: locList.length, truncated: locList.length > max ? "cap" : null, semantic: true, scoped: scopeDirsFor(root).length > 0 });
       const refBodyFull = backendAdvisory(backendName, root) + `references of ${originLabel} (backend: ${backendName})${refTee}:\n` + refBody + refCert;
       if (a.symbol) maybeCounterfactual("find_references", String(a.symbol), root, locList, refBodyFull); // by-name → a NAME to shadow-grep
       return finishOut(locs, refBodyFull);

--- a/server/core.js
+++ b/server/core.js
@@ -11,7 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync, execSync } from "node:child_process";
 import { LspClient, fromUri, langIdForPath, envInt, canonFsPath } from "./lsp.js";
-import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot, effectiveCdbDir, scopeDirsFor, buildStaticIndex, hasClangdIndexer } from "./backends/index.js";
+import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot, effectiveCdbDir, scopeDirsFor, buildStaticIndex, hasClangdIndexer, indexerEnabled } from "./backends/index.js";
 import { scopeStats } from "./scope.js";
 import { recordQueryResults, languageCensus, histRank } from "./warmset.js";
 import { splitSegments } from "./shell-split.js";
@@ -35,7 +35,7 @@ export const PROJECT_PATH = cfg("VTS_PROJECT_PATH", "projectPath", "");
 export const BACKEND = cfg("VTS_BACKEND", "backend", ""); // "clangd" | "roslyn" | "" (auto)
 export const MAX_RESULTS = parseInt(cfg("VTS_MAX_RESULTS", "maxResults", "60"), 10) || 60;
 export const PREWARM_BACKENDS = cfg("VTS_PREWARM_BACKENDS", "prewarmBackends", ""); // "" | auto | all | comma-list
-const CONFIG_KEYS = ["projectPath", "backend", "maxResults", "prewarmBackends", "tee", "excludeCommands", "usdPerMtok", "clangdCmd", "scope"];
+const CONFIG_KEYS = ["projectPath", "backend", "maxResults", "prewarmBackends", "tee", "excludeCommands", "usdPerMtok", "clangdCmd", "scope", "clangdIndexer"];
 
 // ---- per-call project root resolution ----
 // The MCP server is ONE long-lived process serving every repo a session touches, so a single configured
@@ -1727,7 +1727,9 @@ export async function runTool(name, a = {}) {
       const scopeNote = dirs.length ? ` (scope: ${dirs.length} dir(s))` : " (whole tree — set a scope via vts setup --scope to index a subset faster)";
       const wantStatic = a.static === true || a.static === "true";
       if (backendName === "clangd" && wantStatic) {
-        if (!hasClangdIndexer()) return err(`preindex static: clangd-indexer not found. Install the full LLVM toolchain (scoop install llvm | winget install LLVM.LLVM) or set VTS_CLANGD_INDEXER_CMD. Or omit static=true for the background-index warm pass.`);
+        if (!hasClangdIndexer()) return err(!indexerEnabled()
+          ? `preindex static: clangd-indexer is DISABLED on this machine (clangdIndexer="off" / VTS_CLANGD_INDEXER=off). Re-enable with \`vts setup --clangdIndexer on\`, or omit static for the background-index warm pass.`
+          : `preindex static: clangd-indexer not found. Install the full LLVM toolchain (scoop install llvm | winget install LLVM.LLVM) or set VTS_CLANGD_INDEXER_CMD. Or omit static for the background-index warm pass.`);
         const r = buildStaticIndex(root);
         if (r.error) return err(`preindex: ${r.error}`);
         const t0 = Date.now();

--- a/server/policy.js
+++ b/server/policy.js
@@ -1,0 +1,44 @@
+// Unified tool-routing policy — the "integratively wise" layer that makes vts COMPLEMENT Claude Code's native
+// tools (Read / Grep / Glob / Edit / native LSP) instead of competing with them. Two jobs:
+//
+//   1. shouldSuppressSteer(file) — stay SILENT where a CC-native tool is clearly the better choice, so vts
+//      never nags on a case it can't improve. The clear wins (aggressive default: only obvious cases): a
+//      GENERATED or BUILD-OUTPUT path (Intermediate / Binaries / Saved / *.generated.* / node_modules / build
+//      …) where a semantic index is noise. (The doc/log carve-out, sub-declaration ignore, and freeform-grep
+//      warn already live in the hook — this fills the generated/build-output gap.)
+//
+//   2. routingDigest() — ONE coherent SessionStart message: a when-to-use-what decision tree PLUS the live
+//      adoption posture (edit-adoption % + the adaptive controller state), so the model reads a single policy
+//      instead of N scattered reflexive nudges. This is the "integrative" half — vts and CC-native each named
+//      for what they're best at.
+import { readEditLedger, adoptionPct, controllerReport } from "./edit-ledger.js";
+
+// Generated code / build output / vendored deps — a semantic index adds nothing here; CC-native is fine.
+const SUPPRESS_DIR = /(^|[/\\])(Intermediate|Binaries|Saved|DerivedDataCache|node_modules|build|dist|out|obj|\.git)([/\\]|$)/i;
+const GENERATED = /\.(generated\.[a-z0-9]+|g\.cs|designer\.cs|pb\.(go|cc|h)|min\.js)$/i;
+export function shouldSuppressSteer(file) {
+  if (!suppressOn() || !file) return false;
+  const f = String(file).replace(/\\/g, "/");
+  return SUPPRESS_DIR.test(f) || GENERATED.test(f);
+}
+const onOff = (v, d) => !/^(0|false|off|no)$/i.test(String(v ?? d));
+export function suppressOn() { return onOff(process.env.VTS_SUPPRESS, "1"); }
+
+// The single routing digest. Always emits the decision tree (the integrative guidance); appends the live
+// adoption posture + adaptive-controller state when there is enough data.
+export function routingDigest(o = readEditLedger()) {
+  const pct = adoptionPct(o);
+  const total = (o.builtin || 0) + (o.symbol || 0);
+  const lines = [
+    "[vs-token-safer] Tool routing — vts and Claude Code's native tools are COMPLEMENTARY; use the cheapest tool that fits:",
+    "  • a symbol / its references / a rename, on INDEXED code → vts search_symbol / find_references / rename (semantic, token-capped) — not grep",
+    "  • ADD or REPLACE a whole declaration → vts replace_symbol_body / insert_symbol (edits by name, skips reading the file)",
+    "  • a doc or log, a quick literal peek, a JUST-edited or unindexed file, a sub-declaration tweak → CC-native Read / Grep / Edit is right; vts stays out of the way",
+    "  • a big tree with a slow first query → vts setup --scope <module> then vts preindex (index a subtree, not the whole monorepo)",
+  ];
+  if (pct !== null && total >= 3) {
+    const hasSteer = (((o.mod || {}).warn || {}).shown || 0) + (((o.mod || {}).block || {}).shown || 0) > 0;
+    lines.push(`  posture: symbol-edit adoption ${pct}% (${o.symbol || 0}/${total})${hasSteer ? " · " + controllerReport(o) : ""}`);
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Release theme

Patch release of the post-0.33.2 refinements merged to dev (#132, #133). Versioned PATCH at maintainer's request.

## What ships
- **within-scope completeness cert** — a scoped semantic COMPLETE/0 is qualified "within the configured indexing scope".
- **Preindex gating** — clangd-indexer STATIC `--index-file` is OPT-IN (`--static`), never auto-run; default = fast scoped warm. Scope-aware index advisory. Install hints surfaced.
- **Unified tool-routing policy** (`server/policy.js`) — vts COMPLEMENTS Claude Code: suppress steer on generated/build paths; one SessionStart routing digest (decision tree + adoption posture) instead of scattered nudges.
- **clangd-indexer kill switch** — `VTS_CLANGD_INDEXER=off` / config `clangdIndexer` disables the static path (no probe, no `--index-file`, `--static` refuses with a clear message). `--static`/`--docs` are now real bool flags.

## Review points
- Additive + togglable; defaults preserve behavior. Charter held (official engine, local, nothing transmitted).
- Eval 78 → 80, green Ubuntu+Windows (node 18/20/22) + lint + validate.
- Version bumped in sync on main after merge (plugin.json / marketplace.json / server/package.json).
- Live-verified on a real UE5 tree (scope 13% of TUs; static build works; kill switch refuses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
