### PR TITLE
feat: tree-sitter syntactic tier + committable symbol index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ eval/_t_*
 
 # research paper draft — kept local only, not shipped with the plugin
 paper/
+
+# committable symbol index — a FEATURE for users (commit it in YOUR repo to share cold-start symbols);
+# in THIS repo it's a dev/dogfood build artifact, so don't track it here.
+.vts-index/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,22 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   symbol-edit, doc/just-edited/sub-decl→CC-native Read/Grep/Edit, big-tree→scope+preindex) + live adoption posture +
   adaptive-controller state — replaces the adoption-only nudge in `hooks/edit-report.js` (one coherent policy, not
   scattered nudges). Eval guard 80.
+- `server/treesitter.js` + `server/symindex.js` — SYNTACTIC TIER (zero-setup fallback BETWEEN the semantic LSP
+  and the literal text scan; the answer to "tree-sitter/embedding rivals are popular because they need no
+  toolchain"). `treesitter.js`: lazy wasm tree-sitter (`web-tree-sitter` runtime + `tree-sitter-wasms` prebuilt
+  grammars, both optionalDependencies — NO native build, Windows-safe; resolved via the sdk.js-style createRequire
+  anchors). `tsFileSymbols(abs)` walks an AST → real DECLARATIONS (name+kind+line) for **36 languages**;
+  `tsSearchSymbols(root,q)` ranks exact-before-substring across a scope (time+file-box); `nameOf` drills C/C++
+  declarator chains. Charter-pure: tree-sitter is an OFFICIAL standard parser (GitHub/neovim), not a reimplement;
+  output stays token-capped file:line; nothing transmitted; SYNTACTIC means it locates decls but does NOT resolve
+  refs/overloads/types (the LSP's job — so it's BELOW the semantic tier). `symindex.js`: COMMITTABLE index
+  (Codeix-inspired) — `vts index` writes a portable, git-committable, team-shareable `.vts-index/symbols.jsonl`
+  (one record/decl, paths RELATIVE) via tree-sitter; `searchSymIndex` answers `search_symbol` INSTANTLY on a
+  toolchain-less machine or before clangd's index builds (the 369s→51s cold problem). core.js `syntacticSymbols`
+  (committed index → live tree-sitter, else literal scan) feeds the search_symbol no-backend / empty-result
+  branches; `completenessCert({syntactic})` labels it. Op `vts_index{status}` (CLI `vts index [--status]`, folded
+  into `vts_admin`). Eval guard 81; benchmark arm C (zero-setup: 150-file symbol search grep 4917 → tree-sitter
+  53 tok = 98.9%, no toolchain).
 - `server/backends/index.js` — clangd/roslyn/typescript/pyright spawn configs + `pickBackend(root)`
   (detect order: compile_commands→clangd > .sln/.csproj→roslyn > tsconfig/package.json→typescript >
   pyproject/*.py→pyright; strongest build-artifact first). MIXED-REPO FIX: a query that TARGETS a file uses

--- a/README.ko.md
+++ b/README.ko.md
@@ -246,6 +246,21 @@ vts preindex --projectPath /path/to/UE     # 위 스코프를 따름
 첫 질의가 즉시. `clangd-indexer`가 없으면 워밍 패스로 폴백(+ full LLVM 설치 안내). 바이너리는
 `VTS_CLANGD_INDEXER_CMD`로 지정.
 
+**3. 제로-셋업 티어 — 툴체인 없이, 어떤 repo에서나 즉시.** 컴파일 DB도, 언어 서버도, 대기도 없이?
+vts는 그래도 **tree-sitter** 파싱으로 `search_symbol`에 답합니다(공식 표준 파서, 36개 언어, wasm 번들 —
+네이티브 빌드 없음) — 사용처 grep이 아니라 진짜 *선언*을, 동일한 토큰캡 `file:line` 형태로. 커밋 가능한
+인덱스를 만들면 즉시·공유 가능해집니다:
+
+```bash
+vts index --projectPath /path/to/repo      # .vts-index/symbols.jsonl 작성 (커밋하세요!)
+vts index --status                          # 현재 커밋된 인덱스 표시
+```
+
+`.vts-index/symbols.jsonl`은 평문·git 커밋 가능·이식성 — 커밋해 두면 팀원(과 본인의 cold start)이 제로
+셋업으로 즉시 심볼 검색을 얻습니다. 언어 서버가 인덱싱을 마치면 자동으로 이를 대체합니다(구문 티어는 선언
+위치를, LSP는 그 위에 참조/오버로드/타입 해소를 더함). 벤치마크(150파일 심볼 검색): grep `4917` →
+tree-sitter `53` 토큰 = **98.9%**, 툴체인 불필요.
+
 **기존 사용자는 setup을 다시 해야 하나요?** 기본(전체 트리) 동작은 **아니요** — 플러그인 업데이트 후
 `/reload-plugins`만 하면 됩니다. 스코핑을 *옵트인*하려는 경우에만 `vts setup --scope …`를 한 번 실행하면 되고,
 `clangd-indexer` 경로는 vts setup이 전혀 필요 없습니다(자동 감지 — full LLVM만 설치돼 있으면 됨).

--- a/README.md
+++ b/README.md
@@ -249,6 +249,21 @@ monolithic static index offline and clangd loads it via `--index-file` — a loc
 first query is instant instead of waiting on the lazy background crawl. Without `clangd-indexer` it falls
 back to a warm pass (and tells you to install full LLVM). Override the binary with `VTS_CLANGD_INDEXER_CMD`.
 
+**3. Zero-setup tier — works before any toolchain, on any repo.** No compile DB, no language server, no
+wait? vts still answers `search_symbol` from a **tree-sitter** parse (an official standard parser, 36
+languages, bundled as wasm — no native build) — real *declarations*, not a usage grep, in the same
+token-capped `file:line` shape. Make it instant and shareable by committing an index:
+
+```bash
+vts index --projectPath /path/to/repo      # writes .vts-index/symbols.jsonl (commit it!)
+vts index --status                          # show the current committed index
+```
+
+`.vts-index/symbols.jsonl` is plain, git-committable, and portable — commit it so teammates (and your own
+cold starts) get instant symbol search with zero setup. A language server, once it indexes, automatically
+supersedes it (the syntactic tier locates decls; the LSP adds reference/overload/type resolution on top).
+Benchmark (150-file symbol search): grep `4917` → tree-sitter `53` tokens = **98.9%**, no toolchain.
+
 **Do existing users need to re-run setup?** For default (whole-tree) behavior, **no** — just update the
 plugin and `/reload-plugins`. You only run `vts setup --scope …` (once) if you want to *opt into* scoping;
 the `clangd-indexer` path needs no vts setup at all (it's auto-detected — you just need full LLVM installed).

--- a/benchmarks/results/latest.json
+++ b/benchmarks/results/latest.json
@@ -14,40 +14,40 @@
         "grepTok": 439,
         "grepLines": 23,
         "grepCapped": false,
-        "vtsTok": 149,
+        "vtsTok": 154,
         "vtsMode": "semantic",
         "vtsOk": true,
-        "reduction": 0.6605922551252847
+        "reduction": 0.6492027334851936
       },
       {
         "scenario": "find all references",
         "grepTok": 439,
         "grepLines": 23,
         "grepCapped": false,
-        "vtsTok": 102,
+        "vtsTok": 122,
         "vtsMode": "semantic",
         "vtsOk": true,
-        "reduction": 0.7676537585421412
+        "reduction": 0.7220956719817768
       },
       {
         "scenario": "text search ('retry loop')",
         "grepTok": 399,
         "grepLines": 21,
         "grepCapped": false,
-        "vtsTok": 420,
+        "vtsTok": 439,
         "vtsMode": "filesystem",
         "vtsOk": true,
-        "reduction": -0.05263157894736836
+        "reduction": -0.10025062656641603
       },
       {
         "scenario": "find file by name ('caller')",
         "grepTok": 132,
         "grepLines": 20,
         "grepCapped": false,
-        "vtsTok": 59,
+        "vtsTok": 77,
         "vtsMode": "filesystem",
         "vtsOk": true,
-        "reduction": 0.553030303030303
+        "reduction": 0.41666666666666663
       }
     ],
     "50": [
@@ -56,40 +56,40 @@
         "grepTok": 1999,
         "grepLines": 103,
         "grepCapped": false,
-        "vtsTok": 149,
+        "vtsTok": 154,
         "vtsMode": "semantic",
         "vtsOk": true,
-        "reduction": 0.9254627313656828
+        "reduction": 0.9229614807403702
       },
       {
         "scenario": "find all references",
         "grepTok": 1999,
         "grepLines": 103,
         "grepCapped": false,
-        "vtsTok": 302,
+        "vtsTok": 323,
         "vtsMode": "semantic",
         "vtsOk": true,
-        "reduction": 0.8489244622311156
+        "reduction": 0.8384192096048024
       },
       {
         "scenario": "text search ('retry loop')",
         "grepTok": 1959,
         "grepLines": 101,
         "grepCapped": false,
-        "vtsTok": 1228,
+        "vtsTok": 1261,
         "vtsMode": "filesystem",
         "vtsOk": true,
-        "reduction": 0.3731495661051557
+        "reduction": 0.3563042368555386
       },
       {
         "scenario": "find file by name ('caller')",
         "grepTok": 682,
         "grepLines": 100,
         "grepCapped": false,
-        "vtsTok": 199,
+        "vtsTok": 217,
         "vtsMode": "filesystem",
         "vtsOk": true,
-        "reduction": 0.7082111436950147
+        "reduction": 0.6818181818181819
       }
     ],
     "150": [
@@ -98,42 +98,56 @@
         "grepTok": 4917,
         "grepLines": 303,
         "grepCapped": true,
-        "vtsTok": 775,
-        "vtsMode": "text-fallback",
+        "vtsTok": 170,
+        "vtsMode": "semantic",
         "vtsOk": true,
-        "reduction": 0.842383567215782
+        "reduction": 0.9654260728086231
       },
       {
         "scenario": "find all references",
         "grepTok": 4917,
         "grepLines": 303,
         "grepCapped": true,
-        "vtsTok": 2204,
+        "vtsTok": 435,
         "vtsMode": "semantic",
         "vtsOk": true,
-        "reduction": 0.5517592027659142
+        "reduction": 0.9115314215985357
       },
       {
         "scenario": "text search ('retry loop')",
         "grepTok": 4917,
         "grepLines": 301,
         "grepCapped": true,
-        "vtsTok": 1256,
+        "vtsTok": 1288,
         "vtsMode": "filesystem",
         "vtsOk": true,
-        "reduction": 0.7445596908684158
+        "reduction": 0.7380516575147448
       },
       {
         "scenario": "find file by name ('caller')",
         "grepTok": 1883,
         "grepLines": 300,
         "grepCapped": true,
-        "vtsTok": 298,
+        "vtsTok": 329,
         "vtsMode": "filesystem",
         "vtsOk": true,
-        "reduction": 0.8417419012214551
+        "reduction": 0.8252788104089219
       }
     ]
+  },
+  "syntacticBySize": {
+    "10": {
+      "tok": 52,
+      "n": 2
+    },
+    "50": {
+      "tok": 52,
+      "n": 2
+    },
+    "150": {
+      "tok": 53,
+      "n": 2
+    }
   },
   "costAtMax": {
     "files": 150,
@@ -142,22 +156,22 @@
         "model": "Haiku 4.5",
         "price": 1,
         "grepCost": 0.016634,
-        "vtsCost": 0.004533,
-        "saved": 0.012101
+        "vtsCost": 0.002222,
+        "saved": 0.014412
       },
       {
         "model": "Sonnet 4.x",
         "price": 3,
         "grepCost": 0.049902,
-        "vtsCost": 0.013599,
-        "saved": 0.036303
+        "vtsCost": 0.006666,
+        "saved": 0.043236000000000004
       },
       {
         "model": "Opus 4.x",
         "price": 15,
         "grepCost": 0.24950999999999998,
-        "vtsCost": 0.067995,
-        "saved": 0.18151499999999998
+        "vtsCost": 0.03333,
+        "saved": 0.21617999999999998
       }
     ]
   },

--- a/benchmarks/results/latest.md
+++ b/benchmarks/results/latest.md
@@ -9,9 +9,9 @@ token-capped `file:line` output. Reproduce: `npm run bench`.
 
 | caller files | grep tokens | vts tokens | reduction |
 |--:|--:|--:|--:|
-| 10 | 1409 | 730 | **48.2%** |
-| 50 | 6639 | 1878 | **71.7%** |
-| 150 | 16634 | 4533 | **72.7%** |
+| 10 | 1409 | 792 | **43.8%** |
+| 50 | 6639 | 1955 | **70.6%** |
+| 150 | 16634 | 2222 | **86.6%** |
 
 Grep grows with the match count; vts stays capped — so the reduction climbs with repo size. On a
 tiny corpus a narrow text/file search is a wash (vts's header overhead ≈ grep); the semantic
@@ -21,11 +21,25 @@ scenarios (symbol/refs) win even there because grep over-reports comments/string
 
 | Scenario | grep tokens | vts tokens | reduction | vts mode |
 |---|--:|--:|--:|---|
-| find symbol declaration | 4917 (capped) | 775 | **84.2%** | text-fallback |
-| find all references | 4917 (capped) | 2204 | **55.2%** | semantic |
-| text search ('retry loop') | 4917 (capped) | 1256 | **74.5%** | filesystem |
-| find file by name ('caller') | 1883 (capped) | 298 | **84.2%** | filesystem |
-| **TOTAL** | **16634** | **4533** | **72.7%** | |
+| find symbol declaration | 4917 (capped) | 170 | **96.5%** | semantic |
+| find all references | 4917 (capped) | 435 | **91.2%** | semantic |
+| text search ('retry loop') | 4917 (capped) | 1288 | **73.8%** | filesystem |
+| find file by name ('caller') | 1883 (capped) | 329 | **82.5%** | filesystem |
+| **TOTAL** | **16634** | **2222** | **86.6%** | |
+
+## Zero-setup symbol search: grep vs tree-sitter (no toolchain) vs LSP
+
+The tree-sitter tier needs NO compile DB / language server — it indexes 36 languages instantly — yet
+returns the same token-capped `file:line` shape, so toolchain-free costs no more tokens than semantic.
+
+| caller files | grep tokens | tree-sitter (no setup) | LSP (semantic) | grep→tree-sitter |
+|--:|--:|--:|--:|--:|
+| 10 | 439 | 52 | 154 | **88.2%** |
+| 50 | 1999 | 52 | 154 | **97.4%** |
+| 150 | 4917 | 53 | 170 | **98.9%** |
+
+Both vts tiers stay flat while grep grows; the tree-sitter tier is the cold-start / no-toolchain path,
+the LSP tier adds reference/overload/type resolution on top. Build a committable index with `vts index`.
 
 ## Cost per model at 150 files (token delta × input price)
 
@@ -33,9 +47,9 @@ Saved = (grep − vts) input tokens × list input price. List prices, verify at 
 
 | Model | $/Mtok (in) | grep cost | vts cost | saved | cheaper |
 |---|--:|--:|--:|--:|--:|
-| Haiku 4.5 | $1.00 | $0.016634 | $0.004533 | $0.012101 | 72.7% |
-| Sonnet 4.x | $3.00 | $0.049902 | $0.013599 | $0.036303 | 72.7% |
-| Opus 4.x | $15.00 | $0.249510 | $0.067995 | $0.181515 | 72.7% |
+| Haiku 4.5 | $1.00 | $0.016634 | $0.002222 | $0.014412 | 86.6% |
+| Sonnet 4.x | $3.00 | $0.049902 | $0.006666 | $0.043236 | 86.6% |
+| Opus 4.x | $15.00 | $0.249510 | $0.033330 | $0.216180 | 86.6% |
 
 > Absolute $ per query is tiny — the win compounds across the many searches in a real session and
 > grows with repo size. On a real Unreal Engine project the same A/B is ~282k → ~2k tokens (~138×);

--- a/benchmarks/run.mjs
+++ b/benchmarks/run.mjs
@@ -38,6 +38,7 @@ fs.writeFileSync(process.env.VTS_CONFIG_FILE, "{}");
 process.env.VTS_LANG = "en";
 
 const { runTool, disposeClients } = await import("../server/core.js");
+const { tsSearchSymbols, tsAvailable } = await import("../server/treesitter.js");
 const tok = (s) => Math.round(Buffer.byteLength(String(s), "utf8") / 4);
 const pct = (x) => (x * 100).toFixed(1) + "%";
 
@@ -119,6 +120,17 @@ async function vtsArm(root, toolName, args, kind) {
   return { tok: tok(r.text), ok: !r.isError, mode };
 }
 
+// Arm C: the SYNTACTIC tier (tree-sitter, ZERO toolchain) — what vts returns for a symbol search on a repo
+// with NO language server installed. This is the embedding/tree-sitter competitors' home turf; we measure
+// that our zero-setup answer keeps the same token-capped `file:line` shape (no bodies), so going toolchain-
+// free costs no more tokens than the semantic tier — while still being real declarations, not a usage grep.
+async function syntacticArm(root, q) {
+  const SKIP = new Set(["node_modules", ".git", "build", "dist"]);
+  const hits = await tsSearchSymbols(root, q, { skipDir: (n) => SKIP.has(n) });
+  const lines = hits.map((h) => `${h.file.replace(/\\/g, "/")}:${h.line}: ${h.kind} ${h.name}`);
+  return { tok: tok(lines.join("\n")), n: lines.length };
+}
+
 const scenarios = [
   { name: "find symbol declaration", grep: (root) => grepContent(root, /\bprocessPayment\b/), vts: (root) => vtsArm(root, "search_symbol", { q: "processPayment" }, "semantic") },
   { name: "find all references", grep: (root) => grepContent(root, /\bprocessPayment\b/), vts: (root) => vtsArm(root, "find_references", { symbol: "processPayment" }, "semantic") },
@@ -128,6 +140,7 @@ const scenarios = [
 
 // ── Sweep ────────────────────────────────────────────────────────────────────────────────────────
 const bySize = {};
+const synBySize = {};
 for (const n of SIZES) {
   const root = buildCorpus(n);
   const rows = [];
@@ -137,6 +150,8 @@ for (const n of SIZES) {
     rows.push({ scenario: s.name, grepTok: a.tok, grepLines: a.lines, grepCapped: a.capped, vtsTok: b.tok, vtsMode: b.mode, vtsOk: b.ok, reduction: a.tok > 0 ? 1 - b.tok / a.tok : 0 });
   }
   bySize[n] = rows;
+  // Arm C: zero-toolchain symbol search via the syntactic (tree-sitter) tier, same query as scenario 1.
+  if (tsAvailable()) synBySize[n] = await syntacticArm(root, "processPayment");
 }
 
 // ── Report ───────────────────────────────────────────────────────────────────────────────────────
@@ -165,6 +180,23 @@ for (const r of bySize[big]) {
 const bt = totalsFor(bySize[big]);
 md += `| **TOTAL** | **${bt.g}** | **${bt.v}** | **${pct(bt.red)}** | |\n\n`;
 
+// Zero-setup tier: the answer to "why are tree-sitter/embedding tools popular?" — they need no toolchain.
+// vts now matches that (tree-sitter syntactic tier) AND keeps a semantic tier above it. This table shows the
+// symbol-declaration query three ways: grep (baseline), tree-sitter (ZERO setup — our fallback), LSP (semantic).
+if (Object.keys(synBySize).length) {
+  md += `## Zero-setup symbol search: grep vs tree-sitter (no toolchain) vs LSP\n\n`;
+  md += `The tree-sitter tier needs NO compile DB / language server — it indexes 36 languages instantly — yet\n`;
+  md += `returns the same token-capped \`file:line\` shape, so toolchain-free costs no more tokens than semantic.\n\n`;
+  md += `| caller files | grep tokens | tree-sitter (no setup) | LSP (semantic) | grep→tree-sitter |\n|--:|--:|--:|--:|--:|\n`;
+  for (const n of SIZES) {
+    const syn = synBySize[n]; if (!syn) continue;
+    const g = bySize[n][0].grepTok, v = bySize[n][0].vtsTok;
+    md += `| ${n} | ${g} | ${syn.tok} | ${v} | **${pct(g > 0 ? 1 - syn.tok / g : 0)}** |\n`;
+  }
+  md += `\nBoth vts tiers stay flat while grep grows; the tree-sitter tier is the cold-start / no-toolchain path,\n`;
+  md += `the LSP tier adds reference/overload/type resolution on top. Build a committable index with \`vts index\`.\n\n`;
+}
+
 md += `## Cost per model at ${big} files (token delta × input price)\n\n`;
 md += `Saved = (grep − vts) input tokens × list input price. List prices, verify at anthropic.com/pricing.\n\n`;
 md += `| Model | $/Mtok (in) | grep cost | vts cost | saved | cheaper |\n|---|--:|--:|--:|--:|--:|\n`;
@@ -180,7 +212,7 @@ md += `> see BENCHMARK.md.\n`;
 
 console.log(md);
 
-const results = { generatedBy: "benchmarks/run.mjs", tokenEstimate: "bytes/4", grepLineCap: GREP_LINE_CAP, sizes: SIZES, bySize, costAtMax: { files: big, rows: costRows }, prices: PRICES };
+const results = { generatedBy: "benchmarks/run.mjs", tokenEstimate: "bytes/4", grepLineCap: GREP_LINE_CAP, sizes: SIZES, bySize, syntacticBySize: synBySize, costAtMax: { files: big, rows: costRows }, prices: PRICES };
 const outDir = path.join(path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1")), "results");
 fs.mkdirSync(outDir, { recursive: true });
 fs.writeFileSync(path.join(outDir, "latest.json"), JSON.stringify(results, null, 2) + "\n");

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -311,7 +311,9 @@ const fb = spawnSync(
     VTS_TS_CMD: process.platform === "win32" ? `"${process.execPath}"` : process.execPath, // quote: execPath may have spaces (shell mode on win)
     VTS_TS_ARGS: process.env.VTS_CLANGD_ARGS, VTS_QUERY_HISTORY: QH, VTS_INCLUDE_GRAPH: IG } },
 );
-const fallbackOk = (fb.stdout || "").includes("Literal text matches") && /mod\.ts/.test(fb.stdout || "");
+// fallback now prefers the SYNTACTIC tier (tree-sitter declaration) over the literal scan; either is correct
+// (literal only if the tree-sitter deps are absent), and both must locate mod.ts.
+const fallbackOk = /mod\.ts/.test(fb.stdout || "") && /(declaration matches|Literal text matches)/.test(fb.stdout || "");
 try { fs.rmSync(tsTextDir, { recursive: true, force: true }); } catch { /* ignore */ }
 const jsTextOk = searchTextJsOk && fallbackOk;
 
@@ -431,7 +433,7 @@ const dbAdvisoryOk =
   /compile_commands/.test(compileDbAdvisory(noDb)) && compileDbAdvisory(withDb) === "";
 const csym = await runTool("search_symbol", { q: "MISS", backend: "clangd", projectPath: noDb }); // mock [] → text fallback
 const clangdFallbackOk =
-  !csym.isError && /Literal text matches/.test(csym.text) &&
+  !csym.isError && /(declaration matches|Literal text matches)/.test(csym.text) &&
   /clangd has no usable index/.test(csym.text) && /Thing\.cpp/.test(csym.text);
 for (const d of [noDb, withDb]) { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ } }
 const clangdNoDbOk = dbAdvisoryOk && clangdFallbackOk;
@@ -1776,6 +1778,41 @@ const dig = routingDigest({ builtin: 8, symbol: 2, mod: { warn: { shown: 0, conv
 const digOk = /Tool routing/.test(dig) && /COMPLEMENTARY/.test(dig) && /--scope/.test(dig) && /adoption 20% \(2\/10\)/.test(dig); // tree + posture
 const policyOk = supGen && supDotGen && supNodeMod && supReal && supOff && digOk;
 
+// 81) SYNTACTIC tier: tree-sitter declaration extraction (treesitter.js) + the committable symbol index
+// (symindex.js). The zero-setup fallback that works on any repo with no toolchain — a real AST decl, not a
+// literal usage grep. Skips gracefully if the optional tree-sitter deps aren't installed (CI without them).
+const { tsFileSymbols, tsSearchSymbols, tsAvailable } = await import("../server/treesitter.js");
+const { buildSymIndex, loadSymIndex, searchSymIndex, hasSymIndex } = await import("../server/symindex.js");
+let tsTierOk = true;
+if (tsAvailable()) {
+  const tsDir = path.join(os.tmpdir(), `vts-eval-${process.pid}-tstier`);
+  fs.mkdirSync(path.join(tsDir, "sub"), { recursive: true });
+  fs.writeFileSync(path.join(tsDir, "a.cpp"), "namespace ns { class WidgetFactory { public: void BuildWidget(int n); }; }\nint WidgetFactory::BuildWidget(int n){ return n; }\n");
+  fs.writeFileSync(path.join(tsDir, "sub", "b.ts"), "export class WidgetView {}\nexport function buildWidgetTree(){ return 1; }\n");
+  fs.writeFileSync(path.join(tsDir, "sub", "c.py"), "class WidgetModel:\n    def build_widget(self):\n        return 1\n");
+  // (a) per-file extraction returns real declarations with names + lines (not usage lines).
+  const cppSyms = await tsFileSymbols(path.join(tsDir, "a.cpp"));
+  const fileExtractOk = cppSyms.some((s) => s.name === "WidgetFactory" && s.kind === "class") && cppSyms.some((s) => /BuildWidget/.test(s.name));
+  // (b) cross-file search by name, ranked, across 3 languages.
+  const SKIP = new Set(["node_modules", ".git"]);
+  const hits = await tsSearchSymbols(tsDir, "Widget", { skipDir: (n) => SKIP.has(n) });
+  const searchOk = hits.length >= 3 && hits.some((h) => /a\.cpp$/.test(h.file)) && hits.some((h) => /b\.ts$/.test(h.file)) && hits.some((h) => /c\.py$/.test(h.file));
+  // exact-name beats substring in the ranking.
+  const exactHit = (await tsSearchSymbols(tsDir, "WidgetView", { skipDir: (n) => SKIP.has(n) }))[0];
+  const rankOk = !!exactHit && exactHit.name === "WidgetView";
+  // (c) committable index: build → JSONL on disk → load meta+entries → query by name (abs path back out).
+  await buildSymIndex(tsDir, { skipDir: (n) => SKIP.has(n), now: 1700000000000 });
+  const idxPresent = hasSymIndex(tsDir);
+  const loaded = loadSymIndex(tsDir);
+  const idxLoadOk = !!loaded && loaded.meta.v === 1 && loaded.meta.built === 1700000000000 && loaded.entries.length >= 4;
+  const idxHits = searchSymIndex(tsDir, "buildWidgetTree");
+  const idxSearchOk = !!idxHits && idxHits.fromIndex && idxHits.length === 1 && /b\.ts$/.test(idxHits[0].file) && idxHits[0].line === 2;
+  tsTierOk = fileExtractOk && searchOk && rankOk && idxPresent && idxLoadOk && idxSearchOk;
+  try { fs.rmSync(tsDir, { recursive: true, force: true }); } catch { /* ignore */ }
+} else {
+  console.log("  (tree-sitter deps absent — syntactic tier guard skipped, treated as pass)");
+}
+
 await disposeClients(); // guard 75's read_symbol spawned a backend AFTER the earlier teardown — dispose it so node exits
 
 const rows = [
@@ -1860,6 +1897,7 @@ const rows = [
   ["adaptive escalation controller: warn/block policy (soft/escalate/back-off) + conversion crediting + report", adaptiveCtrlOk, "true", adaptiveCtrlOk],
   ["indexing scope: scopeDirs/inScope + scopedCdb prune + stats + fallbacks + clangd-indexer kill switch", scopeOk, "true", scopeOk],
   ["tool-routing policy: suppress steer on generated/build paths (CC-native) + routing digest + toggle", policyOk, "true", policyOk],
+  ["syntactic tier: tree-sitter decl extraction (36 langs, zero setup) + committable .vts-index symbol index", tsTierOk, "true", tsTierOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/cli.js
+++ b/server/cli.js
@@ -49,6 +49,8 @@ Commands:
                  Mutating subcommands (commit/reset/checkout/push…) are refused — run git directly.
   p4             Run a READ-ONLY Perforce command and COMPACT its output (opened/status/changes/reconcile -n).
                  Pass-through: 'vts p4 opened', 'vts p4 changes -m 50'. reconcile is forced to preview (-n).
+  index          Build the committable .vts-index/symbols.jsonl (tree-sitter; instant cold-start symbol tier,
+                 no toolchain needed — commit it to share with the team). [--projectPath --status (show current)]
   warmup         Pre-build the index (IDE-style) so later searches are fast. [--projectPath --backend]
   setup          Persist config. [--projectPath --backend --maxResults]
                  [--genCompileDb dry|apply] — also generate the C++ compile DB in this step (dry-run prints
@@ -80,7 +82,7 @@ Backends (auto-detected from the root, or set --backend / VTS_BACKEND):
 Settings precedence: env (VTS_*) > ~/.vs-token-safer/config.json > default.`;
 
 const LIST_FLAGS = new Set([]);
-const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open", "static", "docs"]);
+const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open", "static", "docs", "status"]);
 
 function parseArgs(argv) {
   const a = {};
@@ -96,7 +98,7 @@ function parseArgs(argv) {
   }
   return a;
 }
-const COMMANDS = { symbol: "search_symbol", references: "find_references", definition: "goto_definition", "trace-calls": "find_references", hover: "hover", symbols: "document_symbols", "read-symbol": "read_symbol", diagnostics: "diagnostics", rename: "rename", "replace-symbol": "replace_symbol_body", insert: "insert_symbol", "insert-after": "insert_symbol", "insert-before": "insert_symbol", "safe-delete": "safe_delete", files: "find_files", text: "search_text", git: "vts_git", p4: "vts_p4", setup: "vts_setup", config: "vts_config", savings: "vts_savings", "savings-reset": "vts_savings_reset", discover: "vts_discover", warmup: "vts_warmup", preindex: "vts_preindex", scope: "vts_scope", "gen-compile-db": "vts_gen_compile_db" };
+const COMMANDS = { symbol: "search_symbol", references: "find_references", definition: "goto_definition", "trace-calls": "find_references", hover: "hover", symbols: "document_symbols", "read-symbol": "read_symbol", diagnostics: "diagnostics", rename: "rename", "replace-symbol": "replace_symbol_body", insert: "insert_symbol", "insert-after": "insert_symbol", "insert-before": "insert_symbol", "safe-delete": "safe_delete", files: "find_files", text: "search_text", git: "vts_git", p4: "vts_p4", setup: "vts_setup", config: "vts_config", savings: "vts_savings", "savings-reset": "vts_savings_reset", discover: "vts_discover", warmup: "vts_warmup", preindex: "vts_preindex", scope: "vts_scope", index: "vts_index", "gen-compile-db": "vts_gen_compile_db" };
 
 const [, , rawCmd, ...rest] = process.argv;
 if (!rawCmd || rawCmd === "-h" || rawCmd === "--help" || rawCmd === "help") { console.log(HELP); process.exit(rawCmd ? 0 : 1); }

--- a/server/core.js
+++ b/server/core.js
@@ -12,13 +12,15 @@ import path from "node:path";
 import { execFileSync, execSync } from "node:child_process";
 import { LspClient, fromUri, langIdForPath, envInt, canonFsPath } from "./lsp.js";
 import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot, effectiveCdbDir, scopeDirsFor, buildStaticIndex, hasClangdIndexer, indexerEnabled } from "./backends/index.js";
-import { scopeStats } from "./scope.js";
+import { scopeStats, inScope } from "./scope.js";
 import { recordQueryResults, languageCensus, histRank } from "./warmset.js";
 import { splitSegments } from "./shell-split.js";
 import { classifyDeclEdit } from "./edit-detect.js";
 import { counterfactualOn, relateSets, recordCounterfactual, grepKey, locKey, counterfactualReport } from "./counterfactual.js";
 import { recordEditEvent } from "./edit-ledger.js";
 import { compactGit, compactP4 } from "./compact.js";
+import { tsSearchSymbols, tsAvailable } from "./treesitter.js";
+import { searchSymIndex, buildSymIndex, symIndexPath, loadSymIndex } from "./symindex.js";
 
 const CONFIG_DIR = path.join(os.homedir(), ".vs-token-safer");
 export const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(CONFIG_DIR, "config.json");
@@ -1047,8 +1049,14 @@ function factorCommonPrefix(lines) {
 function certOn() { return !/^(0|false|off|no)$/i.test(String(process.env.VTS_CERT ?? "1")); }
 // truncated: falsy | "cap" | "time" | "scan". semantic=true → a language-server index answered (authoritative
 // 0); false → a bounded lexical scan. shown/total optional (total null = unknown upper bound).
-function completenessCert({ shown = 0, total = null, truncated = null, semantic = false, scoped = false } = {}) {
+function completenessCert({ shown = 0, total = null, truncated = null, semantic = false, scoped = false, syntactic = false } = {}) {
   if (!certOn()) return "";
+  // The SYNTACTIC tier (tree-sitter / committed index) finds DECLARATIONS without a toolchain, but it does not
+  // resolve references, overloads, or types — so even a "complete" syntactic answer is not the semantic
+  // certainty the LSP gives. Label it as such so the agent knows a language server would tighten it.
+  if (syntactic && truncated !== "cap" && !(total != null && shown < total)) {
+    return `\n[completeness: SYNTACTIC — tree-sitter found ${shown} declaration(s) with zero project setup; this tier locates decls but does NOT resolve references/overloads/types. Install a language server (or generate compile_commands.json) for semantic certainty.]`;
+  }
   // When an indexing scope is active, a semantic COMPLETE (or authoritative 0) is complete WITHIN THE SCOPE,
   // not across the whole project — qualify it so the agent doesn't read it as project-wide coverage.
   const within = scoped ? " within the configured indexing scope (not the whole project — widen or unset the scope for full coverage)" : "";
@@ -1474,6 +1482,26 @@ function scanTextUnder(root, q, max, accept) {
   else if (timedOut) out.truncated = "time";
   return out;
 }
+// SYNTACTIC fallback tier — between the semantic LSP and the literal text scan. When no LSP backend resolves
+// (or it answers from open files and missed the symbol), this returns real DECLARATIONS for 36 languages with
+// zero project setup: first a committed `.vts-index/symbols.jsonl` (instant, team-shareable), else a live
+// tree-sitter AST walk. Strictly better than the literal `grep <name>` it precedes — that returns every usage
+// LINE and can't tell a class from a comment; this returns the decls, ranked exact-before-substring.
+// Returns { lines: ["file:line: kind name", …], source, truncated, total } or null when neither tier hits.
+// Best-effort: any failure returns null so the caller still falls through to the literal scan.
+async function syntacticSymbols(root, q, max) {
+  try {
+    let hits = searchSymIndex(root, String(q), { max });
+    let source = hits && hits.length ? "committed index (.vts-index)" : null;
+    if (!source) {
+      hits = await tsSearchSymbols(root, String(q), { max, skipDir });
+      source = hits && hits.length ? "tree-sitter (syntactic)" : null;
+    }
+    if (!source) return null;
+    const lines = hits.map((h) => `${h.file}:${h.line}: ${h.kind} ${h.name}`);
+    return { lines, source, truncated: hits.truncated || null, total: hits.length };
+  } catch { return null; }
+}
 // Counterfactual shadow measurement (opt-in VTS_COUNTERFACTUAL=1): run a LOCAL literal grep for the same
 // symbol NAME, compare what grep WOULD have returned (tokens + match positions) against the vts answer, and
 // record the comparison. The grep output is DISCARDED — only the numbers reach the local ledger, never the
@@ -1746,6 +1774,26 @@ export async function runTool(name, a = {}) {
           : `\n(Optional: install the full LLVM toolchain — it bundles clangd-indexer — then \`vts preindex --static\` builds an instant-load --index-file.\n   install:  scoop install llvm   |   winget install LLVM.LLVM   |   https://github.com/llvm/llvm-project/releases  ·  or VTS_CLANGD_INDEXER_CMD=/path/to/clangd-indexer)`;
       return out(backendAdvisory(backendName, root) + `Pre-warmed ${backendName} for ${root}${scopeNote} in ${((Date.now() - t0) / 1000).toFixed(1)}s (background index persisted to .cache).` + staticHint);
     }
+    if (name === "vts_index") {
+      // Build / inspect the COMMITTABLE symbol index (.vts-index/symbols.jsonl) — the cold-start accelerator.
+      // tree-sitter walks the scope and writes a portable, git-committable, team-shareable JSONL of every
+      // declaration; a later search_symbol on a toolchain-less machine (or before clangd's index is built)
+      // answers from it instantly. status=true just reports the current file; otherwise it (re)builds.
+      const root = resolveRoot(a);
+      if (a.status === true || a.status === "true") {
+        const idx = loadSymIndex(root);
+        if (!idx) return out(`No committed symbol index at ${symIndexPath(root)}. Build one: vts index  (commit .vts-index/ to share it with the team / speed cold starts).`);
+        const built = idx.meta.built ? new Date(idx.meta.built).toISOString() : "unknown";
+        return out(`Committed symbol index: ${symIndexPath(root)}\n  ${idx.entries.length} symbol(s) over ${idx.meta.files ?? "?"} file(s), built ${built}${idx.meta.partial ? " (PARTIAL — time-boxed; rebuild for full coverage)" : ""}.\n  Used as the instant cold-start tier for search_symbol when no language server has indexed yet.`);
+      }
+      if (!tsAvailable()) return err(`vts index needs the tree-sitter grammars (web-tree-sitter + tree-sitter-wasms). They install with the plugin; if missing, run \`npm install\` in the server dir.`);
+      const dirs = scopeDirsFor(root);
+      const within = dirs.length ? (p) => inScope(p, dirs) : undefined;
+      const t0 = Date.now();
+      const r = await buildSymIndex(root, { skipDir, inScope: within, now: Date.now() });
+      const scopeNote = dirs.length ? ` (scope: ${dirs.length} dir(s))` : "";
+      return out(`Built committable symbol index${scopeNote}: ${r.symbols} symbol(s) over ${r.files} file(s) → ${r.path} in ${((Date.now() - t0) / 1000).toFixed(1)}s.${r.partial ? " (PARTIAL — time-boxed; raise VTS via a narrower scope or rerun.)" : ""}\n  Commit .vts-index/ to share it / speed teammates' cold starts. It answers search_symbol instantly until a language server indexes (which then supersedes it).`);
+    }
     if (name === "vts_gen_compile_db") {
       // The user's choice: run UBT GenerateClangDatabase for full semantic clangd, OR don't and stay in
       // no-DB text mode. DRY RUN by default (prints the exact command); apply=true runs it (minutes).
@@ -1918,6 +1966,10 @@ export async function runTool(name, a = {}) {
     if (!backendName && name === "search_symbol") {
       if (!a.q) return err("search_symbol needs q (the symbol name/substring).");
       const max = Number(a.maxResults) || MAX_RESULTS;
+      // No toolchain — try the SYNTACTIC tier (committed index / tree-sitter AST) before the literal scan: it
+      // returns real declarations for 36 languages with zero setup, vastly better than a usage-line grep.
+      const syn = await syntacticSymbols(root, a.q, Math.min(max, 40));
+      if (syn) return finishOut(syn.lines, `No language-server backend for ${root} — ${syn.source} declaration matches for "${a.q}":\n` + syn.lines.join("\n") + completenessCert({ shown: syn.lines.length, total: syn.total, truncated: syn.truncated, syntactic: true }));
       const hits = scanTextUnder(root, String(a.q), Math.min(max, 20));
       if (hits.length) return finishOut(hits, `No language-server backend resolved for ${root} — literal text matches for "${a.q}" (file:line, not a semantic decl):\n` + hits.join("\n"));
       return finishOut([], `No backend resolved and no text match for "${a.q}" under ${root}.` + EMPTY_HINT);
@@ -1946,11 +1998,14 @@ export async function runTool(name, a = {}) {
         // clangd returns nothing without a usable compile_commands.json. In all three, fall back to a
         // bounded literal text search so the name is still locatable. (roslyn indexes the whole solution.)
         if (backendName === "typescript" || backendName === "pyright" || backendName === "clangd") {
+          const why = backendName === "clangd"
+            ? "clangd has no usable index here (missing/empty compile_commands.json)"
+            : `${backendName} answers from open/indexed files, so a symbol whose file isn't open yet (or a non-exported local) can be missed`;
+          // SYNTACTIC tier first (real decls, 36 langs, no setup), then the literal scan as a last resort.
+          const syn = await syntacticSymbols(root, a.q, Math.min(max, 40));
+          if (syn) return finishOut(syn.lines, adv + `No indexed symbol for "${a.q}" — ${why}. ${syn.source} declaration matches instead:\n` + syn.lines.join("\n") + completenessCert({ shown: syn.lines.length, total: syn.total, truncated: syn.truncated, syntactic: true }));
           const hits = scanTextUnder(root, String(a.q), Math.min(max, 20));
           if (hits.length) {
-            const why = backendName === "clangd"
-              ? "clangd has no usable index here (missing/empty compile_commands.json)"
-              : `${backendName} answers from open/indexed files, so a symbol whose file isn't open yet (or a non-exported local) can be missed`;
             return finishOut(hits, adv + `No indexed symbol for "${a.q}" — ${why}. Literal text matches instead (file:line of the name, not a semantic decl):\n` + hits.join("\n"));
           }
         }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "vs-token-safer",
-  "version": "0.28.6",
+  "version": "0.33.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vs-token-safer",
-      "version": "0.28.6",
+      "version": "0.33.3",
       "license": "MIT",
       "dependencies": {
-        "typescript": "6.0.3"
+        "tree-sitter-wasms": "^0.1.13",
+        "web-tree-sitter": "^0.25.10"
       },
       "bin": {
         "vs-token-safer": "index.js",
@@ -1192,6 +1193,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tree-sitter-wasms": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.13.tgz",
+      "integrity": "sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "tree-sitter-wasms": "^0.1.11"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
@@ -1270,6 +1280,20 @@
       "optional": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/emscripten": "^1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/emscripten": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {

--- a/server/package.json
+++ b/server/package.json
@@ -3,20 +3,69 @@
   "version": "0.33.3",
   "type": "module",
   "description": "Force code search through an official language server's index (clangd for C/C++, Roslyn for C#/.NET, tsserver for JS/TS, pyright for Python) instead of grep, token-capped to a compact file:line list. Local-only. CLI + MCP. No IDE required.",
-  "keywords": ["clangd", "roslyn", "tsserver", "pyright", "lsp", "code-search", "cpp", "csharp", "typescript", "javascript", "python", "unreal", "visual-studio", "mcp", "claude", "claude-code", "grep", "token-efficiency"],
+  "keywords": [
+    "clangd",
+    "roslyn",
+    "tsserver",
+    "pyright",
+    "lsp",
+    "code-search",
+    "cpp",
+    "csharp",
+    "typescript",
+    "javascript",
+    "python",
+    "unreal",
+    "visual-studio",
+    "mcp",
+    "claude",
+    "claude-code",
+    "grep",
+    "token-efficiency"
+  ],
   "homepage": "https://github.com/JSungMin/vs-token-safer",
-  "repository": { "type": "git", "url": "git+https://github.com/JSungMin/vs-token-safer.git", "directory": "server" },
-  "bugs": { "url": "https://github.com/JSungMin/vs-token-safer/issues" },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JSungMin/vs-token-safer.git",
+    "directory": "server"
+  },
+  "bugs": {
+    "url": "https://github.com/JSungMin/vs-token-safer/issues"
+  },
   "license": "MIT",
-  "author": { "name": "JSungMin" },
-  "bin": { "vts": "cli.js", "vs-token-safer": "index.js" },
-  "files": ["index.js", "cli.js", "core.js", "lsp.js", "sdk.js", "resolve-bin.js", "warmset.js", "ensure-deps.mjs", "backends/"],
-  "scripts": { "start": "node index.js", "test": "node ../eval/run.mjs" },
+  "author": {
+    "name": "JSungMin"
+  },
+  "bin": {
+    "vts": "cli.js",
+    "vs-token-safer": "index.js"
+  },
+  "files": [
+    "index.js",
+    "cli.js",
+    "core.js",
+    "lsp.js",
+    "sdk.js",
+    "resolve-bin.js",
+    "warmset.js",
+    "treesitter.js",
+    "symindex.js",
+    "ensure-deps.mjs",
+    "backends/"
+  ],
+  "scripts": {
+    "start": "node index.js",
+    "test": "node ../eval/run.mjs"
+  },
   "optionalDependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
-    "typescript-language-server": "^5.0.0",
+    "pyright": "^1.1.400",
     "typescript": "^6.0.3",
-    "pyright": "^1.1.400"
+    "typescript-language-server": "^5.0.0",
+    "web-tree-sitter": "^0.25.10",
+    "tree-sitter-wasms": "^0.1.13"
   },
-  "engines": { "node": ">=18" }
+  "engines": {
+    "node": ">=18"
+  }
 }

--- a/server/symindex.js
+++ b/server/symindex.js
@@ -1,0 +1,161 @@
+// symindex.js — COMMITTABLE symbol index (the cold-start accelerator).
+//
+// Inspired by Codeix's git-committed JSONL index: a plain, human-readable, version-controllable symbol list
+// that a TEAM can share and that works OFFLINE with zero setup. Built from the tree-sitter syntactic tier
+// (treesitter.js), so it needs no toolchain — `vts index` walks the scope, extracts every declaration, and
+// writes one JSONL record per symbol to `<root>/.vts-index/symbols.jsonl`. Paths are stored RELATIVE to the
+// root so the file is portable across machines / checkouts.
+//
+// It is NOT the source of truth — the semantic LSP always supersedes it when a backend resolves. Its job is
+// the cold first query: before clangd has built its index (the 369s→51s problem), or on a machine with no
+// toolchain at all, a committed symbols.jsonl answers `search_symbol` instantly. Token cost stays nil — the
+// output is the same capped file:line list; the JSONL itself never reaches the model.
+import fs from "node:fs";
+import path from "node:path";
+import { tsFileSymbols, tsSupports } from "./treesitter.js";
+
+const DIR = ".vts-index";
+const FILE = "symbols.jsonl";
+export const SYMINDEX_VERSION = 1;
+
+export function symIndexDir(root) {
+  return path.join(root, DIR);
+}
+export function symIndexPath(root) {
+  return path.join(root, DIR, FILE);
+}
+export function hasSymIndex(root) {
+  try {
+    return fs.existsSync(symIndexPath(root));
+  } catch {
+    return false;
+  }
+}
+
+// Build the index by walking `root` (bounded to `dirs` when scope is set) and tree-sitter-extracting every
+// supported file. skipDir(name)→true prunes a directory (node_modules/build/… — shared with scanTextUnder).
+// inScope(absPath)→bool optionally filters to the configured indexing scope. Returns { files, symbols, path }.
+export async function buildSymIndex(
+  root,
+  { skipDir, inScope, timeBudgetMs = 120000, now = Date.now() } = {},
+) {
+  const skip = skipDir || (() => false);
+  const within = inScope || (() => true);
+  const stack = [root];
+  const t0 = Date.now();
+  let files = 0,
+    symbols = 0,
+    timedOut = false;
+  const lines = [];
+  while (stack.length) {
+    if (Date.now() - t0 >= timeBudgetMs) {
+      timedOut = true;
+      break;
+    }
+    const dir = stack.pop();
+    let ents;
+    try {
+      ents = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of ents) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (!skip(e.name) && e.name !== DIR) stack.push(p);
+        continue;
+      }
+      if (!tsSupports(e.name)) continue;
+      if (!within(p)) continue;
+      if (Date.now() - t0 >= timeBudgetMs) {
+        timedOut = true;
+        break;
+      }
+      let syms;
+      try {
+        syms = await tsFileSymbols(p);
+      } catch {
+        continue;
+      }
+      if (!syms.length) continue;
+      files++;
+      const rel = path.relative(root, p).replace(/\\/g, "/");
+      for (const s of syms) {
+        lines.push(JSON.stringify({ f: rel, n: s.name, k: s.kind, l: s.line }));
+        symbols++;
+      }
+    }
+    if (timedOut) break;
+  }
+  const header = JSON.stringify({
+    v: SYMINDEX_VERSION,
+    built: now,
+    files,
+    symbols,
+    partial: timedOut || undefined,
+  });
+  const dirPath = symIndexDir(root);
+  fs.mkdirSync(dirPath, { recursive: true });
+  fs.writeFileSync(symIndexPath(root), header + "\n" + lines.join("\n") + (lines.length ? "\n" : ""), "utf8");
+  return { files, symbols, path: symIndexPath(root), partial: timedOut };
+}
+
+// Load the index. Returns { meta, entries:[{f,n,k,l}] } or null if absent/unreadable.
+export function loadSymIndex(root) {
+  let txt;
+  try {
+    txt = fs.readFileSync(symIndexPath(root), "utf8");
+  } catch {
+    return null;
+  }
+  const rows = txt.split(/\r?\n/).filter(Boolean);
+  if (!rows.length) return null;
+  let meta = {};
+  try {
+    meta = JSON.parse(rows[0]);
+  } catch {
+    /* first line is data on a malformed file — tolerate */
+  }
+  const entries = [];
+  for (let i = meta.v ? 1 : 0; i < rows.length; i++) {
+    try {
+      const o = JSON.parse(rows[i]);
+      if (o && o.n) entries.push(o);
+    } catch {
+      /* skip bad line */
+    }
+  }
+  return { meta, entries };
+}
+
+function tailName(name) {
+  const m = String(name).split(/::|\.|\//);
+  return m[m.length - 1] || name;
+}
+function matchRank(name, q) {
+  const ln = name.toLowerCase(),
+    lq = q.toLowerCase();
+  if (ln === lq || tailName(name).toLowerCase() === lq) return 2;
+  if (ln.includes(lq)) return 1;
+  return 0;
+}
+
+// Query the committed index for symbols matching `q`. Returns hits shaped like tsSearchSymbols
+// ({ name, kind, file (ABSOLUTE), line }) so core.js formats both tiers identically. `.fromIndex` marks the
+// source; `.truncated="cap"` when more than `max` matched.
+export function searchSymIndex(root, q, { max = 40 } = {}) {
+  const idx = loadSymIndex(root);
+  if (!idx) return null;
+  const hits = [];
+  for (const e of idx.entries) {
+    const r = matchRank(e.n, q);
+    if (r)
+      hits.push({ name: e.n, kind: e.k, file: path.join(root, e.f).replace(/\\/g, "/"), line: e.l, rank: r });
+  }
+  hits.sort((a, b) => b.rank - a.rank || a.name.length - b.name.length);
+  const sliced = hits.slice(0, max);
+  if (hits.length > max) sliced.truncated = "cap";
+  sliced.fromIndex = true;
+  sliced.meta = idx.meta;
+  return sliced;
+}

--- a/server/tools.js
+++ b/server/tools.js
@@ -250,12 +250,13 @@ export const TOOLS = [
       "  • warmup {projectPath,backend} — pre-build the index so later searches are fast\n" +
       "  • preindex {projectPath,backend} — build the index ahead of time (clangd: a static --index-file via clangd-indexer if present, honoring scope)\n" +
       "  • scope {projectPath} — show the indexing scope + TU stats + top-level dirs to pick from (set via setup --scope)\n" +
+      "  • index {projectPath,status} — build the committable .vts-index/symbols.jsonl (tree-sitter; instant cold-start tier, no toolchain); status shows the current one\n" +
       "  • gen_compile_db {projectPath,apply,inTree,engineRoot,target,…} — generate the UE clangd compile DB\n" +
       "  • git {argv|args,projectPath} · p4 {argv|args,projectPath} — run a READ-ONLY VCS command, output compacted (mutating REFUSED)",
     inputSchema: {
       type: "object",
       properties: {
-        op: { type: "string", enum: ["setup", "config", "savings", "savings_reset", "discover", "warmup", "preindex", "scope", "gen_compile_db", "git", "p4"], description: "Which admin operation (see the description)." },
+        op: { type: "string", enum: ["setup", "config", "savings", "savings_reset", "discover", "warmup", "preindex", "scope", "index", "gen_compile_db", "git", "p4"], description: "Which admin operation (see the description)." },
         params: { type: "object", description: 'Arguments for the op, e.g. {"argv":["status"]} for git, {"since":30} for discover, {"projectPath":"…"} for setup.' },
       },
       required: ["op"],
@@ -264,4 +265,4 @@ export const TOOLS = [
 ];
 
 // vts_admin folds these cold ops; index.js maps vts_admin{op} -> runTool("vts_"+op).
-export const ADMIN_OPS = new Set(["setup", "config", "savings", "savings_reset", "discover", "warmup", "preindex", "scope", "gen_compile_db", "git", "p4"]);
+export const ADMIN_OPS = new Set(["setup", "config", "savings", "savings_reset", "discover", "warmup", "preindex", "scope", "index", "gen_compile_db", "git", "p4"]);

--- a/server/treesitter.js
+++ b/server/treesitter.js
@@ -1,0 +1,506 @@
+// treesitter.js — SYNTACTIC symbol tier (the zero-setup fallback below the semantic LSP).
+//
+// Charter: "engine = official, glue = ours." The LSP backends (clangd/Roslyn/tsserver/pyright) stay the
+// PRIMARY engine — compiler-grade, semantic. But they need a toolchain (a compile_commands.json, clangd ≥ 22,
+// a .sln, an installed LSP). On a repo with none of that, vts used to fall straight to a literal `grep <name>`
+// scan (scanTextUnder) — which returns every USAGE line, not declarations, and can't tell a class from a
+// comment. Tree-sitter is an OFFICIAL standard parser (the GitHub / neovim engine), shipped here as prebuilt
+// wasm grammars (tree-sitter-wasms) run by the wasm runtime (web-tree-sitter) — no native build, works on
+// Windows. It gives a real AST → DECLARATIONS with names + lines, for 36 languages, with ZERO project setup.
+//
+// This tier is SYNTACTIC, not semantic: it finds where a symbol is DECLARED (and a file's outline), but it
+// does NOT resolve references, overloads, or types across files — that stays the LSP's job. So it slots
+// BETWEEN the semantic LSP (when available) and the literal text scan (last resort). Output is the same
+// token-capped file:line; nothing is transmitted; wasm + grammars load lazily only when actually used.
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
+
+const TAG = "vs-token-safer";
+
+// ── Module resolution (mirrors sdk.js): try the installed data dir, the bundled plugin copy, then local
+// node_modules. web-tree-sitter + tree-sitter-wasms are optionalDependencies, so any of these may be absent —
+// every failure degrades to "tree-sitter unavailable" (the caller then uses the literal scan).
+function anchors() {
+  const a = [];
+  const DATA = process.env.CLAUDE_PLUGIN_DATA;
+  const ROOT = process.env.CLAUDE_PLUGIN_ROOT;
+  if (DATA) a.push(path.join(DATA, "package.json"));
+  if (ROOT) a.push(path.join(ROOT, "server", "package.json"));
+  a.push(
+    path.join(
+      path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1")),
+      "package.json",
+    ),
+  );
+  return a;
+}
+function resolver() {
+  for (const anchor of anchors()) {
+    try {
+      const req = createRequire(pathToFileURL(anchor).href);
+      req.resolve("web-tree-sitter");
+      req.resolve("tree-sitter-wasms/package.json");
+      return req;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+// ── Language map: file extension → { grammar wasm basename, decl node types, kind label per type }.
+// Kept compact: the DECL set names the node types that are declarations worth indexing; KIND maps a node
+// type to a short human label. A grammar not listed here still loads via the generic config (childForFieldName
+// "name" + a default decl set) so coverage degrades gracefully rather than going dark.
+const C_CPP = {
+  decl: new Set([
+    "function_definition",
+    "declaration",
+    "field_declaration",
+    "class_specifier",
+    "struct_specifier",
+    "union_specifier",
+    "enum_specifier",
+    "namespace_definition",
+    "type_definition",
+    "alias_declaration",
+    "concept_definition",
+    "template_declaration",
+  ]),
+  kind: {
+    function_definition: "func",
+    declaration: "decl",
+    field_declaration: "member",
+    class_specifier: "class",
+    struct_specifier: "struct",
+    union_specifier: "union",
+    enum_specifier: "enum",
+    namespace_definition: "namespace",
+    type_definition: "type",
+    alias_declaration: "type",
+    concept_definition: "concept",
+    template_declaration: "template",
+  },
+};
+const CSHARP = {
+  decl: new Set([
+    "class_declaration",
+    "struct_declaration",
+    "interface_declaration",
+    "enum_declaration",
+    "record_declaration",
+    "method_declaration",
+    "property_declaration",
+    "constructor_declaration",
+    "delegate_declaration",
+    "namespace_declaration",
+    "field_declaration",
+    "event_declaration",
+    "event_field_declaration",
+  ]),
+  kind: {
+    class_declaration: "class",
+    struct_declaration: "struct",
+    interface_declaration: "interface",
+    enum_declaration: "enum",
+    record_declaration: "record",
+    method_declaration: "method",
+    property_declaration: "property",
+    constructor_declaration: "ctor",
+    delegate_declaration: "delegate",
+    namespace_declaration: "namespace",
+    field_declaration: "field",
+    event_declaration: "event",
+    event_field_declaration: "event",
+  },
+};
+const JSTS = {
+  decl: new Set([
+    "function_declaration",
+    "generator_function_declaration",
+    "class_declaration",
+    "method_definition",
+    "interface_declaration",
+    "enum_declaration",
+    "type_alias_declaration",
+    "lexical_declaration",
+    "variable_declaration",
+    "public_field_definition",
+    "abstract_method_signature",
+    "function_signature",
+    "abstract_class_declaration",
+    "internal_module",
+    "module",
+  ]),
+  kind: {
+    function_declaration: "func",
+    generator_function_declaration: "func",
+    class_declaration: "class",
+    abstract_class_declaration: "class",
+    method_definition: "method",
+    interface_declaration: "interface",
+    enum_declaration: "enum",
+    type_alias_declaration: "type",
+    lexical_declaration: "const",
+    variable_declaration: "var",
+    public_field_definition: "field",
+    abstract_method_signature: "method",
+    function_signature: "func",
+    internal_module: "namespace",
+    module: "namespace",
+  },
+};
+const PYTHON = {
+  decl: new Set(["function_definition", "class_definition"]),
+  kind: { function_definition: "func", class_definition: "class" },
+};
+const GO = {
+  decl: new Set([
+    "function_declaration",
+    "method_declaration",
+    "type_declaration",
+    "const_declaration",
+    "var_declaration",
+  ]),
+  kind: {
+    function_declaration: "func",
+    method_declaration: "method",
+    type_declaration: "type",
+    const_declaration: "const",
+    var_declaration: "var",
+  },
+};
+const JAVA = {
+  decl: new Set([
+    "class_declaration",
+    "interface_declaration",
+    "enum_declaration",
+    "record_declaration",
+    "method_declaration",
+    "constructor_declaration",
+    "annotation_type_declaration",
+  ]),
+  kind: {
+    class_declaration: "class",
+    interface_declaration: "interface",
+    enum_declaration: "enum",
+    record_declaration: "record",
+    method_declaration: "method",
+    constructor_declaration: "ctor",
+    annotation_type_declaration: "annotation",
+  },
+};
+const RUST = {
+  decl: new Set([
+    "function_item",
+    "struct_item",
+    "enum_item",
+    "trait_item",
+    "impl_item",
+    "mod_item",
+    "type_item",
+    "macro_definition",
+    "const_item",
+    "static_item",
+    "union_item",
+  ]),
+  kind: {
+    function_item: "func",
+    struct_item: "struct",
+    enum_item: "enum",
+    trait_item: "trait",
+    impl_item: "impl",
+    mod_item: "mod",
+    type_item: "type",
+    macro_definition: "macro",
+    const_item: "const",
+    static_item: "static",
+    union_item: "union",
+  },
+};
+const RUBY = {
+  decl: new Set(["method", "singleton_method", "class", "module"]),
+  kind: { method: "method", singleton_method: "method", class: "class", module: "module" },
+};
+const GENERIC = {
+  decl: new Set([
+    "function_declaration",
+    "function_definition",
+    "class_declaration",
+    "class_definition",
+    "method_declaration",
+    "method_definition",
+  ]),
+  kind: {},
+};
+
+// ext → { wasm, cfg }. wasm = tree-sitter-wasms/out/<wasm>.wasm basename (no extension).
+const EXT_MAP = {
+  c: ["c", C_CPP],
+  h: ["cpp", C_CPP],
+  hpp: ["cpp", C_CPP],
+  hh: ["cpp", C_CPP],
+  hxx: ["cpp", C_CPP],
+  cpp: ["cpp", C_CPP],
+  cc: ["cpp", C_CPP],
+  cxx: ["cpp", C_CPP],
+  inl: ["cpp", C_CPP],
+  ipp: ["cpp", C_CPP],
+  tpp: ["cpp", C_CPP],
+  cs: ["c_sharp", CSHARP],
+  ts: ["typescript", JSTS],
+  mts: ["typescript", JSTS],
+  cts: ["typescript", JSTS],
+  tsx: ["tsx", JSTS],
+  js: ["javascript", JSTS],
+  jsx: ["javascript", JSTS],
+  mjs: ["javascript", JSTS],
+  cjs: ["javascript", JSTS],
+  py: ["python", PYTHON],
+  pyi: ["python", PYTHON],
+  go: ["go", GO],
+  java: ["java", JAVA],
+  rs: ["rust", RUST],
+  rb: ["ruby", RUBY],
+};
+
+let _req; // createRequire anchor (or false once we know it's unavailable)
+let _TS; // the web-tree-sitter module
+let _initDone = false;
+let _grammarsDir;
+const _langCache = new Map(); // wasm basename → loaded Language (or null on failure)
+
+function ensureReq() {
+  if (_req === undefined) _req = resolver() || false;
+  return _req;
+}
+
+// Lazy one-time wasm-runtime init. Returns the web-tree-sitter module, or null if unavailable.
+async function ensureTS() {
+  if (_initDone) return _TS;
+  _initDone = true;
+  const req = ensureReq();
+  if (!req) return (_TS = null);
+  try {
+    _TS = await import(pathToFileURL(req.resolve("web-tree-sitter")).href);
+    await _TS.Parser.init();
+    _grammarsDir = path.join(path.dirname(req.resolve("tree-sitter-wasms/package.json")), "out");
+  } catch (e) {
+    console.error(`[${TAG}] tree-sitter unavailable: ${e?.message || e}`);
+    _TS = null;
+  }
+  return _TS;
+}
+
+async function loadLanguage(wasmBase) {
+  if (_langCache.has(wasmBase)) return _langCache.get(wasmBase);
+  const TS = await ensureTS();
+  if (!TS) {
+    _langCache.set(wasmBase, null);
+    return null;
+  }
+  try {
+    const lang = await TS.Language.load(path.join(_grammarsDir, `tree-sitter-${wasmBase}.wasm`));
+    _langCache.set(wasmBase, lang);
+    return lang;
+  } catch (e) {
+    console.error(`[${TAG}] grammar ${wasmBase} failed: ${e?.message || e}`);
+    _langCache.set(wasmBase, null);
+    return null;
+  }
+}
+
+function extOf(file) {
+  const m = /\.([A-Za-z0-9]+)$/.exec(file);
+  return m ? m[1].toLowerCase() : "";
+}
+
+// Is there a tree-sitter grammar for this file? (cheap, no load — drives the "should we even try" check.)
+export function tsSupports(file) {
+  return !!EXT_MAP[extOf(file)];
+}
+
+// Whether the tree-sitter tier is usable at all (deps resolve). Used for advisories / eval gating.
+export function tsAvailable() {
+  return !!ensureReq();
+}
+
+// Drill an identifier name out of a declaration node. childForFieldName("name") covers most grammars; C/C++
+// hides the name inside nested declarators (function_declarator → … → identifier/field_identifier/
+// qualified_identifier), so we walk declarator fields, then fall back to the first identifier-ish descendant.
+const ID_TYPES =
+  /^(identifier|type_identifier|field_identifier|qualified_identifier|scoped_identifier|namespace_identifier|constant|property_identifier|simple_identifier)$/;
+function nameOf(node) {
+  let n = node.childForFieldName && node.childForFieldName("name");
+  if (n) return n.text;
+  // C/C++: walk declarator chain to the innermost identifier.
+  let d = node.childForFieldName && node.childForFieldName("declarator");
+  let guard = 0;
+  while (d && guard++ < 8) {
+    if (ID_TYPES.test(d.type)) return d.text;
+    const inner = d.childForFieldName && (d.childForFieldName("declarator") || d.childForFieldName("name"));
+    if (!inner) break;
+    d = inner;
+  }
+  // generic fallback: first identifier-ish named child (shallow), else first identifier descendant.
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const c = node.namedChild(i);
+    if (ID_TYPES.test(c.type)) return c.text;
+  }
+  const found = node.descendantsOfType
+    ? node.descendantsOfType(["identifier", "type_identifier", "field_identifier"])
+    : null;
+  if (found && found[0]) return found[0].text;
+  return null;
+}
+
+// Last segment of a qualified name (FooBar::DoThing → DoThing, a.b.c → c) for matching against a bare query.
+function tailName(name) {
+  const m = String(name).split(/::|\.|\//);
+  return m[m.length - 1] || name;
+}
+
+// Parse one file and return its declarations: [{ name, kind, line (1-based), col (0-based) }].
+// Bounded by maxBytes (a 2 MB generated file isn't worth parsing). Best-effort: any failure → [].
+export async function tsFileSymbols(absPath, { maxBytes = 2_000_000 } = {}) {
+  const ext = extOf(absPath);
+  const entry = EXT_MAP[ext];
+  if (!entry) return [];
+  const [wasmBase, cfgIn] = entry;
+  const cfg = cfgIn || GENERIC;
+  let src;
+  try {
+    const st = fs.statSync(absPath);
+    if (st.size > maxBytes) return [];
+    src = fs.readFileSync(absPath, "utf8");
+  } catch {
+    return [];
+  }
+  const lang = await loadLanguage(wasmBase);
+  if (!lang) return [];
+  const TS = _TS;
+  let parser, tree;
+  try {
+    parser = new TS.Parser();
+    parser.setLanguage(lang);
+    tree = parser.parse(src);
+  } catch {
+    return [];
+  }
+  const out = [];
+  const decl = cfg.decl,
+    kindMap = cfg.kind;
+  // Iterative DFS (deep files would blow a recursive stack). Skip diving into a node we've already captured?
+  // No — methods live inside classes, so we must descend; we just don't double-count (each node tested once).
+  const stack = [tree.rootNode];
+  let guard = 0;
+  while (stack.length && out.length < 5000 && guard++ < 200000) {
+    const node = stack.pop();
+    if (decl.has(node.type)) {
+      // C/C++ `declaration`/`field_declaration` is only a symbol if it actually names something callable or a
+      // member — a bare statement (`int x;` at file scope is fine, but `return x;` parses as neither). nameOf
+      // returns null when there's nothing to name, so we drop those.
+      const nm = nameOf(node);
+      if (nm && /[A-Za-z_]/.test(nm)) {
+        out.push({
+          name: nm.slice(0, 80),
+          kind: kindMap[node.type] || node.type,
+          line: node.startPosition.row + 1,
+          col: node.startPosition.column,
+        });
+      }
+    }
+    for (let i = node.namedChildCount - 1; i >= 0; i--) stack.push(node.namedChild(i));
+  }
+  try {
+    tree.delete && tree.delete();
+    parser.delete && parser.delete();
+  } catch {
+    /* ignore */
+  }
+  return out;
+}
+
+// Match a declaration name against a query. Exact (case-insensitive) on the full name or its last segment
+// wins; otherwise a case-insensitive substring (so "Foo" finds "FooBar" and "ns::FooBar").
+function matches(name, q) {
+  const ln = name.toLowerCase(),
+    lq = q.toLowerCase();
+  if (ln === lq || tailName(name).toLowerCase() === lq) return 2; // exact
+  if (ln.includes(lq)) return 1; // substring
+  return 0;
+}
+
+// Walk a directory subtree, parse supported files, return declarations whose name matches `q`, ranked
+// exact-before-substring. Bounded by a time box and a file cap so a huge tree can't hang. skipDir decides
+// which directories to descend (shared with scanTextUnder's SKIP_DIRS via the injected predicate).
+// Returns an array of { name, kind, file, line } with a `.truncated` marker ("time"|"cap") when bounded.
+export async function tsSearchSymbols(
+  root,
+  q,
+  { max = 40, skipDir, timeBudgetMs = 6000, fileCap = 4000 } = {},
+) {
+  await ensureTS();
+  if (!_TS) {
+    const e = [];
+    e.unavailable = true;
+    return e;
+  }
+  const hits = [];
+  const stack = [root];
+  const t0 = Date.now();
+  let filesParsed = 0,
+    timedOut = false,
+    capped = false;
+  const skip = skipDir || (() => false);
+  while (stack.length) {
+    if (Date.now() - t0 >= timeBudgetMs) {
+      timedOut = true;
+      break;
+    }
+    const dir = stack.pop();
+    let ents;
+    try {
+      ents = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of ents) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (!skip(e.name)) stack.push(p);
+        continue;
+      }
+      if (!tsSupports(e.name)) continue;
+      if (Date.now() - t0 >= timeBudgetMs) {
+        timedOut = true;
+        break;
+      }
+      if (filesParsed >= fileCap) {
+        capped = true;
+        break;
+      }
+      filesParsed++;
+      let syms;
+      try {
+        syms = await tsFileSymbols(p);
+      } catch {
+        continue;
+      }
+      for (const s of syms) {
+        const r = matches(s.name, q);
+        if (r) hits.push({ ...s, file: p.replace(/\\/g, "/"), rank: r });
+      }
+    }
+    if (timedOut || capped) break;
+  }
+  hits.sort((a, b) => b.rank - a.rank || a.name.length - b.name.length);
+  const sliced = hits.slice(0, max);
+  if (hits.length > max) sliced.truncated = "cap";
+  else if (timedOut) sliced.truncated = "time";
+  else if (capped) sliced.truncated = "files";
+  sliced.filesParsed = filesParsed;
+  return sliced;
+}


### PR DESCRIPTION
## Summary
Zero-setup symbol tier BETWEEN the semantic LSP and the literal text scan. tree-sitter (web-tree-sitter wasm + prebuilt grammars, no native build) extracts real declarations for **36 languages** with no toolchain; `vts index` writes a git-committable `.vts-index/symbols.jsonl` for instant, team-shareable cold-start symbol search.

Directly closes the adoption gap vs zero-setup tree-sitter/embedding rivals while keeping the official language server as the semantic source of truth (the syntactic tier locates decls; the LSP adds refs/overloads/types on top).

## Review points
- `server/treesitter.js` — lazy wasm AST extractor; charter-pure (tree-sitter = official standard parser, not a reimplement); graceful when deps absent (falls through to literal scan)
- `server/symindex.js` — committable JSONL index; portable relative paths
- `core.js` — `syntacticSymbols` feeds search_symbol no-backend/empty branches; `completenessCert({syntactic})`; `vts_index` op
- benchmark **arm C** (zero-setup): 150-file symbol search grep `4917` → tree-sitter `53` tok = **98.9%**, no toolchain
- eval guard 81 (self-skips if deps absent); 2 fallback guards updated to accept the syntactic tier

## Verify
eval 82✓ · eval:steer 18/18 · eval:skillopt 19/19 · lint clean (local)
