### PR TITLE
feat: tree-sitter tags-query call references (syntactic find_references fallback)

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1781,7 +1781,7 @@ const policyOk = supGen && supDotGen && supNodeMod && supReal && supOff && digOk
 // 81) SYNTACTIC tier: tree-sitter declaration extraction (treesitter.js) + the committable symbol index
 // (symindex.js). The zero-setup fallback that works on any repo with no toolchain — a real AST decl, not a
 // literal usage grep. Skips gracefully if the optional tree-sitter deps aren't installed (CI without them).
-const { tsFileSymbols, tsSearchSymbols, tsAvailable } = await import("../server/treesitter.js");
+const { tsFileSymbols, tsSearchSymbols, tsSearchReferences, tsAvailable } = await import("../server/treesitter.js");
 const { buildSymIndex, loadSymIndex, searchSymIndex, hasSymIndex } = await import("../server/symindex.js");
 let tsTierOk = true;
 if (tsAvailable()) {
@@ -1807,7 +1807,15 @@ if (tsAvailable()) {
   const idxLoadOk = !!loaded && loaded.meta.v === 1 && loaded.meta.built === 1700000000000 && loaded.entries.length >= 4;
   const idxHits = searchSymIndex(tsDir, "buildWidgetTree");
   const idxSearchOk = !!idxHits && idxHits.fromIndex && idxHits.length === 1 && /b\.ts$/.test(idxHits[0].file) && idxHits[0].line === 2;
-  tsTierOk = fileExtractOk && searchOk && rankOk && idxPresent && idxLoadOk && idxSearchOk;
+  // (d) tree-sitter REFERENCES (tags-query call-site capture): the syntactic find_references fallback. A
+  // caller in Python + a caller in TS — both call sites captured, the decl line itself is NOT a reference.
+  fs.writeFileSync(path.join(tsDir, "sub", "d.py"), "from a import x\ndef caller():\n    return build_widget(3)\n");
+  fs.writeFileSync(path.join(tsDir, "sub", "e.ts"), "import { buildWidgetTree } from './b';\nexport const z = buildWidgetTree();\n");
+  const pyRefs = await tsSearchReferences(tsDir, "build_widget", { skipDir: (n) => SKIP.has(n) });
+  const tsRefs = await tsSearchReferences(tsDir, "buildWidgetTree", { skipDir: (n) => SKIP.has(n) });
+  const refOk = pyRefs.some((r) => /d\.py$/.test(r.file) && r.line === 3) && !pyRefs.some((r) => /c\.py$/.test(r.file)) // the def is not a ref
+    && tsRefs.some((r) => /e\.ts$/.test(r.file) && r.line === 2);
+  tsTierOk = fileExtractOk && searchOk && rankOk && idxPresent && idxLoadOk && idxSearchOk && refOk;
   try { fs.rmSync(tsDir, { recursive: true, force: true }); } catch { /* ignore */ }
 } else {
   console.log("  (tree-sitter deps absent — syntactic tier guard skipped, treated as pass)");

--- a/server/core.js
+++ b/server/core.js
@@ -19,7 +19,7 @@ import { classifyDeclEdit } from "./edit-detect.js";
 import { counterfactualOn, relateSets, recordCounterfactual, grepKey, locKey, counterfactualReport } from "./counterfactual.js";
 import { recordEditEvent } from "./edit-ledger.js";
 import { compactGit, compactP4 } from "./compact.js";
-import { tsSearchSymbols, tsAvailable } from "./treesitter.js";
+import { tsSearchSymbols, tsSearchReferences, tsAvailable } from "./treesitter.js";
 import { searchSymIndex, buildSymIndex, symIndexPath, loadSymIndex } from "./symindex.js";
 
 const CONFIG_DIR = path.join(os.homedir(), ".vs-token-safer");
@@ -2045,10 +2045,17 @@ export async function runTool(name, a = {}) {
         });
         const pick = ranked[0];
         if (!pick) {
-          // no indexed decl (ts/py open-files miss, clangd no-DB) → fall back to a literal usage scan so a
-          // code-modder still gets every textual hit, clearly labeled as text not semantic.
-          const hits = scanTextUnder(root, want, max);
+          // no indexed decl (ts/py open-files miss, clangd no-DB). SYNTACTIC reference fallback FIRST: a
+          // tree-sitter call-site capture (real call references, 11 langs, zero toolchain) — strictly better
+          // than the literal scan that follows (a call site, not every textual mention). Then literal scan.
           const idxAdv = clangdIndexAdvisory(backendName, root, a.path || null);
+          const tsRefs = await tsSearchReferences(root, want, { skipDir });
+          if (tsRefs && tsRefs.length) {
+            const refLines = tsRefs.map((r) => `${r.file}:${r.line}`);
+            const body = compactResults() ? compactLocationLines(refLines) : refLines.join("\n");
+            return finishOut(refLines, backendAdvisory(backendName, root) + `No indexed declaration for "${want}" — ${tsRefs.length} tree-sitter call reference(s) (syntactic, file:line; not semantic — a language server resolves which overload/scope):\n` + body + completenessCert({ shown: refLines.length, total: tsRefs.length, truncated: tsRefs.truncated, syntactic: true }) + idxAdv);
+          }
+          const hits = scanTextUnder(root, want, max);
           if (hits.length) return finishOut(hits, backendAdvisory(backendName, root) + `No indexed declaration for "${want}" — literal usage matches instead (file:line of the name, not semantic references):\n` + hits.join("\n") + idxAdv);
           return finishOut([], backendAdvisory(backendName, root) + `No declaration found for "${want}" (backend: ${backendName}).` + EMPTY_HINT + idxAdv);
         }

--- a/server/treesitter.js
+++ b/server/treesitter.js
@@ -504,3 +504,154 @@ export async function tsSearchSymbols(
   sliced.filesParsed = filesParsed;
   return sliced;
 }
+
+// ── REFERENCES (tree-sitter tags-query, the codebase-memory-mcp lesson). The node-type walk above finds
+// DECLARATIONS; tree-sitter's `tags.scm` convention also captures call SITES. So even with no language
+// server, find_references gets a real *call reference* fallback — strictly better than the literal `grep
+// <name>` it replaces (a call site, not every textual mention). Still SYNTACTIC: it does not resolve which
+// overload/scope, so the LSP stays the source of truth above it. Queries validated per grammar (11 langs);
+// a grammar without one (or a query that fails to construct) simply yields no syntactic refs (graceful).
+const REF_QUERIES = {
+  python: `(call function: [(identifier) @ref (attribute attribute: (identifier) @ref)])`,
+  javascript: `(call_expression function: [(identifier) @ref (member_expression property: (property_identifier) @ref)])`,
+  typescript: `(call_expression function: [(identifier) @ref (member_expression property: (property_identifier) @ref)])`,
+  tsx: `(call_expression function: [(identifier) @ref (member_expression property: (property_identifier) @ref)])`,
+  go: `(call_expression function: [(identifier) @ref (selector_expression field: (field_identifier) @ref)])`,
+  java: `(method_invocation name: (identifier) @ref)`,
+  c_sharp: `(invocation_expression (member_access_expression name: (identifier) @ref)) (invocation_expression function: (identifier) @ref)`,
+  c: `(call_expression function: (identifier) @ref)`,
+  cpp: `(call_expression function: [(identifier) @ref (field_expression field: (field_identifier) @ref) (qualified_identifier name: (identifier) @ref)])`,
+  rust: `(call_expression function: (identifier) @ref) (macro_invocation macro: (identifier) @ref)`,
+  ruby: `(call method: (identifier) @ref)`,
+};
+const _refQueryCache = new Map(); // wasm base → constructed Query | null
+
+async function refQueryFor(wasmBase) {
+  if (_refQueryCache.has(wasmBase)) return _refQueryCache.get(wasmBase);
+  const src = REF_QUERIES[wasmBase];
+  const lang = src ? await loadLanguage(wasmBase) : null;
+  let q = null;
+  if (lang && _TS) {
+    try {
+      q = new _TS.Query(lang, src);
+    } catch {
+      q = null;
+    }
+  }
+  _refQueryCache.set(wasmBase, q);
+  return q;
+}
+
+// Capture call references to `name` in one file. Returns [{ name, line (1-based), col }]. Best-effort → [].
+export async function tsFileReferences(absPath, name, { maxBytes = 2_000_000 } = {}) {
+  const entry = EXT_MAP[extOf(absPath)];
+  if (!entry) return [];
+  const wasmBase = entry[0];
+  const q = await refQueryFor(wasmBase);
+  if (!q) return [];
+  let src;
+  try {
+    const st = fs.statSync(absPath);
+    if (st.size > maxBytes) return [];
+    src = fs.readFileSync(absPath, "utf8");
+  } catch {
+    return [];
+  }
+  const lang = await loadLanguage(wasmBase);
+  if (!lang) return [];
+  let parser, tree;
+  try {
+    parser = new _TS.Parser();
+    parser.setLanguage(lang);
+    tree = parser.parse(src);
+  } catch {
+    return [];
+  }
+  const out = [];
+  const want = String(name);
+  try {
+    for (const c of q.captures(tree.rootNode)) {
+      if (c.node.text === want)
+        out.push({ name: want, line: c.node.startPosition.row + 1, col: c.node.startPosition.column });
+    }
+  } catch {
+    /* ignore */
+  }
+  try {
+    tree.delete && tree.delete();
+    parser.delete && parser.delete();
+  } catch {
+    /* ignore */
+  }
+  return out;
+}
+
+// Walk a subtree and collect call references to `name` across files (bounded). Same shape/markers as
+// tsSearchSymbols ({ name, line, col, file } + `.truncated`/`.filesParsed`; `.unavailable` if deps absent).
+export async function tsSearchReferences(
+  root,
+  name,
+  { skipDir, timeBudgetMs = 6000, fileCap = 4000, max = 200 } = {},
+) {
+  await ensureTS();
+  if (!_TS) {
+    const e = [];
+    e.unavailable = true;
+    return e;
+  }
+  const hits = [];
+  const stack = [root];
+  const t0 = Date.now();
+  let filesParsed = 0,
+    timedOut = false,
+    capped = false;
+  const skip = skipDir || (() => false);
+  while (stack.length) {
+    if (Date.now() - t0 >= timeBudgetMs) {
+      timedOut = true;
+      break;
+    }
+    const dir = stack.pop();
+    let ents;
+    try {
+      ents = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of ents) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (!skip(e.name)) stack.push(p);
+        continue;
+      }
+      if (!tsSupports(e.name)) continue;
+      if (Date.now() - t0 >= timeBudgetMs) {
+        timedOut = true;
+        break;
+      }
+      if (filesParsed >= fileCap) {
+        capped = true;
+        break;
+      }
+      filesParsed++;
+      let refs;
+      try {
+        refs = await tsFileReferences(p, name);
+      } catch {
+        continue;
+      }
+      for (const r of refs) hits.push({ ...r, file: p.replace(/\\/g, "/") });
+      if (hits.length > max) {
+        capped = true;
+        break;
+      }
+    }
+    if (timedOut || capped) break;
+  }
+  const sliced = hits.slice(0, max);
+  if (hits.length > max) sliced.truncated = "cap";
+  else if (timedOut) sliced.truncated = "time";
+  else if (capped) sliced.truncated = "files";
+  sliced.filesParsed = filesParsed;
+  return sliced;
+}


### PR DESCRIPTION
## Summary
The codebase-memory-mcp lesson applied: tree-sitter's `tags.scm` convention captures call **sites**, not just declarations. `find_references` now has a real **syntactic** fallback (a captured call reference, 11 languages, zero toolchain) BEFORE the literal scan — strictly better than grep (a call site, not every textual mention).

Still syntactic — it does not resolve which overload/scope, so the official language server stays the semantic source of truth above it. **Deliberately NOT copied** from codebase-memory-mcp: its reimplemented type-resolution layer (we keep the real LSP as the tier above).

> Targeted at `main` directly: `dev` is transiently behind on the v0.33.4 bump (the dev resync was deferred), so a dev→main PR would downgrade the version. A single `main:dev` resync afterward brings dev fully current.

## Review points
- `server/treesitter.js` — `REF_QUERIES` validated per grammar (py/js/ts/tsx/go/java/c#/c/cpp/rust/ruby), cached Query, `tsFileReferences`/`tsSearchReferences` (bounded, graceful)
- `core.js` — find_references-by-name no-decl branch tries `tsSearchReferences` before `scanTextUnder`; compacted file:line + `completenessCert(syntactic)`
- eval guard 81 extended: call-site capture across files, decl ≠ reference

## Verify
eval 82✓ · steer 18/18 · skillopt 19/19 · lint clean (local). Patch → v0.33.5.
