### PR TITLE
fix(roslyn): OS-aware VS Code globalStorage path (macOS/Linux C# regression)

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1821,6 +1821,21 @@ if (tsAvailable()) {
   console.log("  (tree-sitter deps absent — syntactic tier guard skipped, treated as pass)");
 }
 
+// 82) Roslyn dotnet-host path is OS-aware (Mac mini C# regression): VS Code's globalStorage dir differs per
+// platform; a Windows-only hardcode made the Roslyn .NET host miss on macOS/Linux → system dotnet (too old
+// for net10) → Roslyn never launched → no semantic C#. Assert the per-OS path tail by stubbing platform.
+const { vscodeGlobalStorage } = await import("../server/backends/index.js");
+const _origPlat = process.platform;
+const _setPlat = (p) => Object.defineProperty(process, "platform", { value: p, configurable: true });
+_setPlat("win32"); const _gW = vscodeGlobalStorage();
+_setPlat("darwin"); const _gM = vscodeGlobalStorage();
+_setPlat("linux"); const _gL = vscodeGlobalStorage();
+_setPlat(_origPlat);
+const roslynOsPathOk =
+  /AppData[\\/]Roaming[\\/]Code[\\/]User[\\/]globalStorage$/.test(_gW) &&
+  /Library[\\/]Application Support[\\/]Code[\\/]User[\\/]globalStorage$/.test(_gM) &&
+  /\.config[\\/]Code[\\/]User[\\/]globalStorage$/.test(_gL);
+
 await disposeClients(); // guard 75's read_symbol spawned a backend AFTER the earlier teardown — dispose it so node exits
 
 const rows = [
@@ -1906,6 +1921,7 @@ const rows = [
   ["indexing scope: scopeDirs/inScope + scopedCdb prune + stats + fallbacks + clangd-indexer kill switch", scopeOk, "true", scopeOk],
   ["tool-routing policy: suppress steer on generated/build paths (CC-native) + routing digest + toggle", policyOk, "true", policyOk],
   ["syntactic tier: tree-sitter decl extraction (36 langs, zero setup) + committable .vts-index symbol index", tsTierOk, "true", tsTierOk],
+  ["Roslyn dotnet-host path OS-aware (macOS/Linux C# regression: win32/darwin/linux globalStorage)", roslynOsPathOk, "true", roslynOsPathOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -84,12 +84,22 @@ function findRoslynMsDll() {
 }
 const ROSLYN_MS_DLL = findRoslynMsDll();
 
+// VS Code's per-user data dir (where globalStorage lives) is OS-specific: Windows %APPDATA%\Code,
+// macOS ~/Library/Application Support/Code, Linux ~/.config/Code. Hardcoding the Windows path made the
+// Roslyn dotnet-host lookup silently miss on macOS/Linux → it fell back to system `dotnet` (too old for
+// net10) → Roslyn never launched → C# had no semantic parse (live-reported on a Mac mini). Per-OS now.
+export function vscodeGlobalStorage() {
+  const home = os.homedir();
+  if (process.platform === "win32") return path.join(home, "AppData", "Roaming", "Code", "User", "globalStorage");
+  if (process.platform === "darwin") return path.join(home, "Library", "Application Support", "Code", "User", "globalStorage");
+  return path.join(home, ".config", "Code", "User", "globalStorage"); // linux / other
+}
 // Microsoft.CodeAnalysis.LanguageServer targets a recent .NET (currently net10), which the system
 // `dotnet` (often an older SDK) can't host. The VS Code C# extension acquires a private runtime via
 // the vscode-dotnet-runtime extension — find its newest dotnet host and use it to launch the dll.
 // Override with VTS_ROSLYN_CMD. Falls back to "dotnet" (works if a new-enough runtime is on PATH).
 function findRoslynDotnetHost() {
-  const base = path.join(os.homedir(), "AppData", "Roaming", "Code", "User", "globalStorage", "ms-dotnettools.vscode-dotnet-runtime", ".dotnet");
+  const base = path.join(vscodeGlobalStorage(), "ms-dotnettools.vscode-dotnet-runtime", ".dotnet");
   let dirs;
   try { dirs = fs.readdirSync(base).filter((n) => /^\d+\.\d+/.test(n)); } catch { return "dotnet"; }
   // Newest version folder first (e.g. "10.0.8~x64~aspnetcore"); pick the first with a dotnet.exe.


### PR DESCRIPTION
## Bug
On a Mac mini with VS Code + C# Dev Kit installed, C# queries returned 0 results, threw load errors, and degraded to the tree-sitter syntactic tier — Roslyn never launched.

## Root cause
`findRoslynDotnetHost` hardcoded the **Windows** VS Code globalStorage path (`%APPDATA%\Code\User\globalStorage\...`) to locate the private net10 dotnet runtime. On macOS/Linux that path doesn't exist → it fell back to the system `dotnet`, which is too old to host `Microsoft.CodeAnalysis.LanguageServer` (net10) → Roslyn failed to start. The DLL lookup (`~/.vscode/extensions`) was already cross-platform; only the host path was Windows-only.

## Fix
`vscodeGlobalStorage()` resolves per OS — `%APPDATA%\Code` (win32), `~/Library/Application Support/Code` (darwin), `~/.config/Code` (linux). Eval guard 82 stubs `process.platform` and asserts each path tail.

## Verify
eval 83✓ · lint clean. Hotfix → patch v0.33.6.
