### PR TITLE
docs: reframe identity — the agent's repository access layer (humanized)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "vs-token-safer",
-  "description": "Token-efficient tooling for large C++/C# projects (Unreal, Visual Studio, .NET): search the codebase through an official language server's index (clangd / Roslyn) instead of grep, and analyze huge editor/build logs — both token-capped to a compact output. No IDE required.",
+  "description": "Tooling that keeps your repo out of the agent's context window. Search and edit code through a language server (or tree-sitter, or a fuzzy search built from the repo's own words), section-edit Markdown and config by heading, and read huge editor/build logs without pasting them into the chat. Answers come back as a short, capped file:line list, and nothing leaves your machine. No IDE required.",
   "owner": {
     "name": "JSungMin",
     "url": "https://github.com/JSungMin"
@@ -12,7 +12,7 @@
       "source": "./",
       "version": "0.33.8",
       "category": "development",
-      "description": "Force Claude Code to search C++/C# code through clangd/Roslyn's index instead of Bash grep, token-capped to a compact file:line list. No IDE required. Bundles gamedev-log-analyzer."
+      "description": "Sits between Claude Code and your codebase and hands back a short file:line list instead of dumping source. Real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a no-embeddings fuzzy search built from your repo's own naming when you don't know the exact name. Section-edits Markdown and config too. Local-only. Bundles gamedev-log-analyzer."
     },
     {
       "name": "gamedev-log-analyzer",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vs-token-safer",
-  "description": "Force Claude Code to search C++/C# code through an official language server's index (clangd / Roslyn) instead of Bash grep, token-capped to a compact file:line list. No IDE required. Faster and far fewer tokens on large Unreal C++/.NET codebases. Auto-installs gamedev-log-analyzer.",
+  "description": "Sits between Claude Code and your codebase and hands back a short file:line list instead of dumping source into the chat. It uses a real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a fuzzy search built from your repo's own naming when you don't know the exact name (no embeddings). It section-edits Markdown and config files the same way. Everything stays on your machine. No IDE required. Bundles gamedev-log-analyzer for reading huge editor/build logs.",
   "version": "0.33.8",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/vs-token-safer",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -444,6 +444,29 @@ repo while config pinned clangd for a UE tree) > forced `VTS_BACKEND`/config `ba
   Born from a live case: the model used `search_text "FindComponentByClass<UMyComp>"` → 8-of-49 time-boxed slice;
   `find_references` returned all 49 at 19×. Eval guard 58 (`symbolHuntInText` unit + integration).
 
+## Identity (what we are) — and the roadmap rule it implies
+vs-token-safer is not "a code search tool." It is the layer an agent talks to instead of reading the
+repository. You ask where something is, what calls it, or — when you don't know the name — what the auth flow
+is, and it hands back the smallest faithful answer (a capped `file:line` list, no bodies) instead of letting
+raw source flood the context window. It answers at the highest precision it can reach and tells you which rung
+it's on:
+- **exact** when the name is known and a toolchain is present → the language server (semantic, ground truth);
+- **syntactic** when there's no toolchain → tree-sitter (zero setup, 36 langs);
+- **fuzzy** when only the intent is known → a concept dictionary mined from the repo's own naming (no embeddings);
+- **section-level** when it's a doc/config, not code → Markdown/TOML/YAML/… addressed by heading.
+
+Three things make it ours, and none of them is a backend: (1) it covers the WHOLE repo an agent sees — code,
+the "I don't know the name" case, and documents; (2) every answer is capped to `file:line`, labeled with its
+precision (the completeness certificate), and the swap to it is ENFORCED, not merely offered; (3) it's all
+local — official engines, no embeddings, nothing transmitted. The name fits: "token-safer" is a safety device
+for the context budget, which is why it survives growing past C++/C# into fuzzy and docs (the naming umbrella).
+
+**Roadmap rule.** A feature earns its place one of two ways: it adds a rung to the precision ladder (a new way
+to answer when the agent knows more, or less, about what it's after), or it covers more of the repo (a new file
+type, a new kind of question). It must never break the three things that make the tool worth trusting — the
+answer stays capped, it stays honest about precision, and nothing leaves the machine. Judge every proposal by
+"which rung / which surface, and does it keep the discipline" before anything else.
+
 ## Next (see wiki "Status and TODO")
 P1 DONE: core rename, `index.js`/`sdk.js`/`ensure-deps.mjs`, grep-block `hooks/`, `skills/`+`commands/`,
 `.claude-plugin/*`+`.mcp.json`, README EN/KO + PRIVACY/SECURITY/CONTRIBUTING/CoC/BENCHMARK, `.github` CI,

--- a/README.ko.md
+++ b/README.ko.md
@@ -10,10 +10,13 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/JSungMin/vs-token-safer/pulls)
 [![Stars](https://img.shields.io/github/stars/JSungMin/vs-token-safer?style=social)](https://github.com/JSungMin/vs-token-safer/stargazers)
 
-> **거대한 Unreal C++ / Visual Studio / .NET 코드베이스를 `grep` 대신 공식 언어 서버 인덱스
-> (clangd / Roslyn / tsserver / pyright)로 검색하고 편집합니다.** 결과는 소스 본문 없이 `file:line`으로만,
-> 토큰 상한이 걸린 채 돌아옵니다. 여기에 수십 MB짜리 에디터 로그를 대화에 쏟아붓지 않고 읽어 주는 형제
-> 플러그인이 따라옵니다. 둘 다 단순 방식보다 토큰을 약 99% 덜 씁니다. **로컬 전용, IDE 불필요.**
+> 코딩 에이전트의 컨텍스트 창은 작고 저장소는 큽니다. **vs-token-safer는 그 사이에 앉습니다.**
+> 무엇이 어디 있는지, 무엇이 그걸 호출하는지, 이름을 모를 땐 "auth 흐름이 어떻게 되나"까지 물어보면,
+> 소스를 채팅에 쏟아붓는 대신 짧은 `file:line` 목록을 돌려줍니다. 될 땐 정확하게 — 진짜 언어 서버
+> (clangd / Roslyn / tsserver / pyright)로 — 안 될 땐 그래도 쓸모 있게(설치 없는 tree-sitter, 또는 저장소
+> 자체의 작명으로 만든 fuzzy 검색, 임베딩 없음). Markdown·설정 파일도 같은 방식으로, 헤딩 이름만으로
+> 섹션을 읽거나 고칩니다. 수십 MB 에디터 로그를 대화에 붙여넣지 않고 읽어 주는 형제 플러그인도 함께 옵니다.
+> **모든 것은 당신 기기 안에 머뭅니다.**
 
 <p align="center">
   <img src="docs/vts-demo.gif" alt="vs-token-safer 데모 — grep은 소스를 컨텍스트에 쏟아붓지만, 언어 서버 인덱스는 토큰 상한이 걸린 file:line만 돌려줍니다" width="760">

--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/JSungMin/vs-token-safer/pulls)
 [![Stars](https://img.shields.io/github/stars/JSungMin/vs-token-safer?style=social)](https://github.com/JSungMin/vs-token-safer/stargazers)
 
-> **Search and edit a large Unreal C++ / Visual Studio / .NET codebase through an official language
-> server's index (clangd / Roslyn / tsserver / pyright) instead of `grep` — token-capped to `file:line`,
-> never source bodies.** Plus a sibling plugin that reads tens-of-MB editor logs without dumping them into
-> the conversation. Both cost ~99% fewer tokens than the naive approach. **Local-only. No IDE required.**
+> Your coding agent has a small context window and your repo is large. **vs-token-safer sits in between.**
+> Ask where something is, what calls it, or even "how does the auth flow work" when you don't know the name,
+> and it hands back a short `file:line` list instead of dumping source into the chat. It's exact when it can
+> be — a real language server (clangd / Roslyn / tsserver / pyright) — still useful when it can't (tree-sitter
+> with no setup, or a fuzzy search built from your repo's own naming, no embeddings), and it works the same way
+> on your Markdown and config: read or edit a section by its heading without opening the whole file. A sibling
+> plugin reads tens-of-MB editor logs without pasting them into the conversation. **Everything stays on your
+> machine.**
 
 <p align="center">
   <img src="docs/vts-demo.gif" alt="vs-token-safer demo — grep dumps source into context; the language-server index returns a token-capped file:line list" width="760">

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "vs-token-safer",
   "version": "0.33.8",
   "type": "module",
-  "description": "Force code search through an official language server's index (clangd for C/C++, Roslyn for C#/.NET, tsserver for JS/TS, pyright for Python) instead of grep, token-capped to a compact file:line list. Local-only. CLI + MCP. No IDE required.",
+  "description": "Sits between an LLM coding agent and your repository and answers where/what/how questions with a short file:line list instead of raw source. It uses a real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a no-embeddings fuzzy search built from the repo's own naming when you don't know the exact name. It section-edits Markdown and config files the same way. Local-only, nothing transmitted. CLI + MCP. No IDE required.",
   "keywords": [
     "clangd",
     "roslyn",


### PR DESCRIPTION
Aligns the plugin's identity across marketplace.json / plugin.json / package.json descriptions, README EN+KO tagline, and a new CLAUDE.md Identity + roadmap-rule section. The tool now covers exact LSP symbols, a syntactic tier, a no-embeddings fuzzy tier, and section-level docs/config — so the copy reframes it as the layer an agent talks to instead of reading the repo (capped file:line, honest about precision, local). Copy humanized (plain language, no buzzword stacking). Docs/metadata only.