### PR TITLE
feat(concept): path-locality channel sharpens the fuzzy rung

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1850,11 +1850,18 @@ let conceptToolOk = true;
 if (tsAvailable()) {
   const cdir = path.join(os.tmpdir(), `vts-eval-${process.pid}-concept`);
   fs.mkdirSync(cdir, { recursive: true });
+  // write every fixture BEFORE the first query — conceptIndexFor caches the model per root on first use.
   fs.writeFileSync(path.join(cdir, "auth.ts"), "export function validateSession(){ return 1; }\nexport function refreshToken(){ return 2; }\n");
   fs.writeFileSync(path.join(cdir, "ui.ts"), "export function renderWidget(){ return 3; }\n");
+  // path-locality channel: two identically-named symbols, one in a topically-named file — the file whose PATH
+  // matches the query wins, even though the symbol names are identical (the path is a free locality signal).
+  fs.writeFileSync(path.join(cdir, "billing.ts"), "export function handle(){ return 1; }\n");
+  fs.writeFileSync(path.join(cdir, "unrelated.ts"), "export function handle(){ return 2; }\n");
   const cr = await runTool("concept_search", { q: "session token", projectPath: cdir });
+  const cp = await runTool("concept_search", { q: "billing", projectPath: cdir });
+  const pathLocalityOk = !cp.isError && /billing\.ts/.test(cp.text) && !/unrelated\.ts/.test(cp.text);
   conceptToolOk = !cr.isError && /validateSession/.test(cr.text) && /refreshToken/.test(cr.text) && !/renderWidget/.test(cr.text) && /no embeddings/.test(cr.text) &&
-    /ladder.*[Cc]limb/.test(cr.text); // precision-ladder navigation: the fuzzy rung points up to the exact rung
+    /ladder.*[Cc]limb/.test(cr.text) && pathLocalityOk; // ladder navigation + path-locality scoring
   try { fs.rmSync(cdir, { recursive: true, force: true }); } catch { /* ignore */ }
 }
 const conceptOk = splitOk && expandOk && scoreOk && conceptToolOk;

--- a/server/concept.js
+++ b/server/concept.js
@@ -202,29 +202,25 @@ export function expandQuery(model, qTokens, { k = 6, minAssoc = 1.5, minCooc = 2
   return weights;
 }
 
-// Score one symbol against the expanded query. `symTokens` = sub-tokens of the symbol name; `docTokens` =
-// sub-tokens of its attached comment/docstring (matched at a discount, since a name is a stronger signal than
-// a comment). Each enriched query token contributes its weight x best token-match x idf; the comment channel
-// adds a smaller bonus. The result is comparable across symbols (no length normalisation needed because idf
-// already damps ubiquitous tokens, and a longer name simply has more chances to match — which is fair).
-export function scoreSymbol(model, enriched, symTokens, docTokens = [], { docFactor = 0.5 } = {}) {
+// Score one symbol against the expanded query across three channels, strongest first: the symbol NAME, the
+// file PATH it lives in, and its attached comment/docstring. Related code clusters by directory and filename
+// (an auth helper lives under `auth/` in a `session.ts`), so a query token that matches the path is real,
+// free, local evidence — weaker than a name hit, comparable to a comment hit. Each enriched query token
+// contributes its weight x best token-match x idf per channel (path/doc at a discount). idf already damps
+// ubiquitous tokens, so no length normalisation is needed.
+export function scoreSymbol(model, enriched, symTokens, docTokens = [], { docFactor = 0.5, pathTokens = [], pathFactor = 0.4 } = {}) {
+  const bestMatch = (qt, toks) => {
+    let best = 0;
+    for (const t of toks) { const m = tokMatch(qt, t); if (m > best) best = m; }
+    return best;
+  };
   let score = 0;
   for (const [qt, w] of enriched) {
     const weight = w * idf(model, qt);
-    let best = 0;
-    for (const st of symTokens) {
-      const m = tokMatch(qt, st);
-      if (m > best) best = m;
-    }
-    if (best) score += weight * best;
-    if (docFactor && docTokens.length) {
-      let dbest = 0;
-      for (const dt of docTokens) {
-        const m = tokMatch(qt, dt);
-        if (m > dbest) dbest = m;
-      }
-      if (dbest && dbest * docFactor > 0) score += weight * dbest * docFactor;
-    }
+    const nameHit = bestMatch(qt, symTokens);
+    if (nameHit) score += weight * nameHit;
+    if (pathFactor && pathTokens.length) { const ph = bestMatch(qt, pathTokens); if (ph) score += weight * ph * pathFactor; }
+    if (docFactor && docTokens.length) { const dh = bestMatch(qt, docTokens); if (dh) score += weight * dh * docFactor; }
   }
   return score;
 }

--- a/server/core.js
+++ b/server/core.js
@@ -1529,10 +1529,13 @@ async function conceptIndexFor(root) {
         if (files >= fileCap) break;
         files++;
         let decls; try { decls = await tsFileDeclDocs(p); } catch { continue; }
+        // path tokens (the dir + filename, ext stripped) — a free locality signal shared by every decl in
+        // the file: a symbol under auth/session.ts scores for "auth session" even if its name doesn't say so.
+        const pt = tokenize(path.relative(root, p).replace(/\.[^./]+$/, ""));
         for (const d of decls) {
           const nt = splitIdent(d.name), dt = tokenize(d.doc);
           units.push([...nt, ...dt]);
-          symbols.push({ name: d.name, kind: d.kind, file: p.replace(/\\/g, "/"), line: d.line, nt, dt });
+          symbols.push({ name: d.name, kind: d.kind, file: p.replace(/\\/g, "/"), line: d.line, nt, dt, pt });
         }
       }
     }
@@ -1966,7 +1969,7 @@ export async function runTool(name, a = {}) {
       // throwaway local const/var that merely mentions a word — demote those so the real declarations rank up.
       const kindW = (k) => (/^(const|var|local|decl|field|member)$/.test(k) ? 0.35 : 1);
       const scoredAll = symbols
-        .map((s) => ({ s, sc: scoreSymbol(model, enriched, s.nt, s.dt) * kindW(s.kind) }))
+        .map((s) => ({ s, sc: scoreSymbol(model, enriched, s.nt, s.dt, { pathTokens: s.pt }) * kindW(s.kind) }))
         .filter((r) => r.sc > 0)
         .sort((a2, b2) => b2.sc - a2.sc);
       // Fuzzy results have a long low-relevance tail (a trivial local matching one weak expansion term). Cap


### PR DESCRIPTION
Adds a third scoring channel to concept_search: a symbol's FILE PATH tokens (dir + filename). Related code clusters by directory, so a path match is free local evidence — a symbol under auth/session.ts scores for 'auth session' even when its name doesn't. Tightens the documented expansion-noise weak spot with no learning, just a new deterministic, env-tunable, inspectable signal. eval guard isolates the path channel (two identical names; topically-named file wins). Patch → v0.33.11.