### PR TITLE
feat(concept): import-graph proximity channel

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1857,11 +1857,19 @@ if (tsAvailable()) {
   // matches the query wins, even though the symbol names are identical (the path is a free locality signal).
   fs.writeFileSync(path.join(cdir, "billing.ts"), "export function handle(){ return 1; }\n");
   fs.writeFileSync(path.join(cdir, "unrelated.ts"), "export function handle(){ return 2; }\n");
+  // import-graph channel: two identically-named symbols with equal base score, but one lives in a file that
+  // IMPORTS the strongly-matching file — it's in the same subsystem, so it ranks above the unconnected one.
+  fs.writeFileSync(path.join(cdir, "core.ts"), "export function authenticate(){ return 1; }\n");
+  fs.writeFileSync(path.join(cdir, "near.ts"), "import { authenticate } from './core';\nexport function authHelper(){ return 2; }\n");
+  fs.writeFileSync(path.join(cdir, "far.ts"), "export function authHelper(){ return 3; }\n");
   const cr = await runTool("concept_search", { q: "session token", projectPath: cdir });
   const cp = await runTool("concept_search", { q: "billing", projectPath: cdir });
+  const ci = await runTool("concept_search", { q: "authenticate", projectPath: cdir });
   const pathLocalityOk = !cp.isError && /billing\.ts/.test(cp.text) && !/unrelated\.ts/.test(cp.text);
+  // near.ts (imports core.ts, the top hit) must outrank far.ts (same symbol, no import edge) — the boost.
+  const importBoostOk = !ci.isError && /near\.ts/.test(ci.text) && /far\.ts/.test(ci.text) && ci.text.indexOf("near.ts") < ci.text.indexOf("far.ts");
   conceptToolOk = !cr.isError && /validateSession/.test(cr.text) && /refreshToken/.test(cr.text) && !/renderWidget/.test(cr.text) && /no embeddings/.test(cr.text) &&
-    /ladder.*[Cc]limb/.test(cr.text) && pathLocalityOk; // ladder navigation + path-locality scoring
+    /ladder.*[Cc]limb/.test(cr.text) && pathLocalityOk && importBoostOk; // ladder nav + path-locality + import-graph proximity
   try { fs.rmSync(cdir, { recursive: true, force: true }); } catch { /* ignore */ }
 }
 const conceptOk = splitOk && expandOk && scoreOk && conceptToolOk;

--- a/server/concept.js
+++ b/server/concept.js
@@ -110,6 +110,43 @@ export function tokenize(text) {
   return out;
 }
 
+// Extract the IMPORT targets of a file as lowercased basenames (no path, no extension): the last path segment
+// of each import/require/#include/from specifier. PURE (text → names). The caller matches these basenames
+// against the corpus's own files to build a within-repo import graph — two files that import each other hold
+// structurally related code even when their names share no token. Covers JS/TS, Python, and C/C++; other
+// languages simply yield no edges (the boost then does nothing — graceful).
+export function importSpecifiers(text, ext) {
+  const out = new Set();
+  const add = (s) => {
+    if (!s) return;
+    const leaf =
+      String(s)
+        .replace(/^[./\\]+/, "")
+        .split(/[\\/]/)
+        .filter(Boolean)
+        .pop() || "";
+    if (!leaf) return;
+    // a relative file path keeps its name minus extension (scope.js -> scope); a dotted module keeps its last
+    // segment (a.b.c -> c). Offer both — only basenames that actually match a corpus file create an edge.
+    const noext = leaf.replace(/\.[^./]+$/, "");
+    const lastDot = leaf.split(".").filter(Boolean).pop();
+    for (const cand of [noext, lastDot]) if (cand && /[A-Za-z_]/.test(cand)) out.add(cand.toLowerCase());
+  };
+  const e = String(ext || "").toLowerCase();
+  if (/^[mc]?[jt]sx?$/.test(e)) {
+    for (const m of String(text).matchAll(
+      /(?:\bfrom|\brequire\s*\(|\bimport\s*\(|\bimport)\s*["'`]([^"'`]+)["'`]/g,
+    ))
+      add(m[1]);
+  } else if (e === "py" || e === "pyi") {
+    for (const m of String(text).matchAll(/^\s*(?:from\s+([.\w]+)\s+import|import\s+([.\w]+))/gm))
+      add(m[1] || m[2]);
+  } else if (/^(c|h|cc|cpp|hpp|hh|cxx|hxx|inl|ipp|tpp)$/.test(e)) {
+    for (const m of String(text).matchAll(/^\s*#\s*include\s*["<]([^">]+)[">]/gm)) add(m[1]);
+  }
+  return [...out];
+}
+
 // Match two concept tokens: exact (1.0) or a prefix relationship of length >= 4 (0.7) so auth ~ authenticate ~
 // authentication ~ authorize without a stemmer. Returns the match strength, 0 if unrelated.
 export function tokMatch(a, b) {
@@ -208,10 +245,19 @@ export function expandQuery(model, qTokens, { k = 6, minAssoc = 1.5, minCooc = 2
 // free, local evidence — weaker than a name hit, comparable to a comment hit. Each enriched query token
 // contributes its weight x best token-match x idf per channel (path/doc at a discount). idf already damps
 // ubiquitous tokens, so no length normalisation is needed.
-export function scoreSymbol(model, enriched, symTokens, docTokens = [], { docFactor = 0.5, pathTokens = [], pathFactor = 0.4 } = {}) {
+export function scoreSymbol(
+  model,
+  enriched,
+  symTokens,
+  docTokens = [],
+  { docFactor = 0.5, pathTokens = [], pathFactor = 0.4 } = {},
+) {
   const bestMatch = (qt, toks) => {
     let best = 0;
-    for (const t of toks) { const m = tokMatch(qt, t); if (m > best) best = m; }
+    for (const t of toks) {
+      const m = tokMatch(qt, t);
+      if (m > best) best = m;
+    }
     return best;
   };
   let score = 0;
@@ -219,8 +265,14 @@ export function scoreSymbol(model, enriched, symTokens, docTokens = [], { docFac
     const weight = w * idf(model, qt);
     const nameHit = bestMatch(qt, symTokens);
     if (nameHit) score += weight * nameHit;
-    if (pathFactor && pathTokens.length) { const ph = bestMatch(qt, pathTokens); if (ph) score += weight * ph * pathFactor; }
-    if (docFactor && docTokens.length) { const dh = bestMatch(qt, docTokens); if (dh) score += weight * dh * docFactor; }
+    if (pathFactor && pathTokens.length) {
+      const ph = bestMatch(qt, pathTokens);
+      if (ph) score += weight * ph * pathFactor;
+    }
+    if (docFactor && docTokens.length) {
+      const dh = bestMatch(qt, docTokens);
+      if (dh) score += weight * dh * docFactor;
+    }
   }
   return score;
 }

--- a/server/core.js
+++ b/server/core.js
@@ -21,7 +21,7 @@ import { recordEditEvent } from "./edit-ledger.js";
 import { compactGit, compactP4 } from "./compact.js";
 import { tsSearchSymbols, tsSearchReferences, tsFileDeclDocs, tsSupports, tsAvailable } from "./treesitter.js";
 import { searchSymIndex, buildSymIndex, symIndexPath, loadSymIndex } from "./symindex.js";
-import { splitIdent, tokenize, buildConceptModel, expandQuery, scoreSymbol } from "./concept.js";
+import { splitIdent, tokenize, buildConceptModel, expandQuery, scoreSymbol, importSpecifiers } from "./concept.js";
 import { isStructFile, structOutline, resolveSection, fmtOutline } from "./textstruct.js";
 
 const CONFIG_DIR = path.join(os.homedir(), ".vs-token-safer");
@@ -1518,6 +1518,7 @@ async function conceptIndexFor(root) {
     const within = dirs.length ? (p) => inScope(p, dirs) : () => true;
     const stack = [root]; const t0 = Date.now(); let files = 0;
     const budget = envInt("VTS_CONCEPT_BUILD_MS", 15000), fileCap = envInt("VTS_CONCEPT_FILE_CAP", 6000);
+    const fileSpecs = new Map(), byBase = new Map(); // for the within-repo import graph
     while (stack.length) {
       if (Date.now() - t0 >= budget || files >= fileCap) break;
       const dir = stack.pop();
@@ -1529,17 +1530,28 @@ async function conceptIndexFor(root) {
         if (files >= fileCap) break;
         files++;
         let decls; try { decls = await tsFileDeclDocs(p); } catch { continue; }
+        const fp = p.replace(/\\/g, "/");
         // path tokens (the dir + filename, ext stripped) — a free locality signal shared by every decl in
         // the file: a symbol under auth/session.ts scores for "auth session" even if its name doesn't say so.
         const pt = tokenize(path.relative(root, p).replace(/\.[^./]+$/, ""));
+        // import-graph inputs: this file's basename + the basenames it imports (resolved against the corpus).
+        const base = e.name.replace(/\.[^.]+$/, "").toLowerCase();
+        if (!byBase.has(base)) byBase.set(base, []);
+        byBase.get(base).push(fp);
+        try { fileSpecs.set(fp, importSpecifiers(fs.readFileSync(p, "utf8"), e.name.split(".").pop())); } catch { /* ignore */ }
         for (const d of decls) {
           const nt = splitIdent(d.name), dt = tokenize(d.doc);
           units.push([...nt, ...dt]);
-          symbols.push({ name: d.name, kind: d.kind, file: p.replace(/\\/g, "/"), line: d.line, nt, dt, pt });
+          symbols.push({ name: d.name, kind: d.kind, file: fp, line: d.line, nt, dt, pt });
         }
       }
     }
-    return { model: buildConceptModel(units), symbols, files };
+    // Within-repo import graph: link a file to every corpus file whose basename it imports (both directions).
+    // A symbol in a file ADJACENT to a strongly-matching file is structurally related even with no shared token.
+    const neighbors = new Map();
+    const link = (a, b) => { if (a === b) return; if (!neighbors.has(a)) neighbors.set(a, new Set()); neighbors.get(a).add(b); };
+    for (const [f, specs] of fileSpecs) for (const s of specs) for (const g of byBase.get(s) || []) { link(f, g); link(g, f); }
+    return { model: buildConceptModel(units), symbols, files, neighbors };
   })();
   _conceptCache.set(root, build);
   const res = await build;
@@ -1960,7 +1972,7 @@ export async function runTool(name, a = {}) {
       const root = resolveRoot(a);
       if (!tsAvailable()) return err("concept_search needs the tree-sitter grammars (web-tree-sitter + tree-sitter-wasms); they install with the plugin. Until then use search_text (multi-word, ranked by term coverage).");
       const max = Number(a.maxResults) || MAX_RESULTS;
-      const { model, symbols } = await conceptIndexFor(root);
+      const { model, symbols, neighbors } = await conceptIndexFor(root);
       if (!symbols.length) return finishOut([], `No indexable declarations under ${root} for concept search (no tree-sitter-supported files in scope?).` + EMPTY_HINT);
       const qToks = tokenize(String(a.q));
       if (!qToks.length) return err(`"${a.q}" has no usable concept tokens (too short / all stop-words). Try concrete nouns: "auth session token".`);
@@ -1968,9 +1980,23 @@ export async function runTool(name, a = {}) {
       // Kind weight: a fuzzy "how does X work" wants the function/class/type that EMBODIES the concept, not a
       // throwaway local const/var that merely mentions a word — demote those so the real declarations rank up.
       const kindW = (k) => (/^(const|var|local|decl|field|member)$/.test(k) ? 0.35 : 1);
-      const scoredAll = symbols
-        .map((s) => ({ s, sc: scoreSymbol(model, enriched, s.nt, s.dt, { pathTokens: s.pt }) * kindW(s.kind) }))
-        .filter((r) => r.sc > 0)
+      // Pass 1: base score (name + path + comment channels). Pass 2: import-graph proximity — a symbol whose
+      // FILE imports (or is imported by) a strongly-matching file is in the same subsystem, so lift it by a
+      // fraction of that neighbour file's best score. A deterministic structural signal from the code itself
+      // (NOT click-learning); it reranks the matched set, never invents a match. VTS_CONCEPT_IMPORT_FACTOR=0 off.
+      const based = symbols
+        .map((s) => ({ s, base: scoreSymbol(model, enriched, s.nt, s.dt, { pathTokens: s.pt }) * kindW(s.kind) }))
+        .filter((r) => r.base > 0);
+      const fileBase = new Map();
+      for (const r of based) if ((fileBase.get(r.s.file) || 0) < r.base) fileBase.set(r.s.file, r.base);
+      const nf = Number(process.env.VTS_CONCEPT_IMPORT_FACTOR ?? 0.3);
+      const scoredAll = based
+        .map((r) => {
+          let nb = 0;
+          const ns = nf && neighbors && neighbors.get(r.s.file);
+          if (ns) for (const g of ns) { const fb = fileBase.get(g) || 0; if (fb > nb) nb = fb; }
+          return { s: r.s, sc: r.base + nb * nf };
+        })
         .sort((a2, b2) => b2.sc - a2.sc);
       // Fuzzy results have a long low-relevance tail (a trivial local matching one weak expansion term). Cap
       // tighter than an exact search and drop anything below a fraction of the top score — fuzzy wants the


### PR DESCRIPTION
The critic-approved structural alternative to a click-feedback loop: a symbol whose FILE imports (or is imported by) a strongly-matching file is in the same subsystem, so it's lifted by a fraction of that neighbour's score. Deterministic, mined from the code (importSpecifiers: JS/TS/Python/C-C++), reranks the matched set only. VTS_CONCEPT_IMPORT_FACTOR=0 off. eval isolates the channel (import-adjacent file outranks the unconnected one). Patch → v0.33.12.