### PR TITLE
feat: syntactic-tier hardening - multi-language benchmark, tags-query tier, incremental index

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -6,13 +6,16 @@ the model's context. Benchmarks here are **A/B**: the same query **without the p
 `grep`/`rg`, i.e. what the model receives when it greps) versus **with the plugin** (Arm B — the
 clangd/Roslyn index, formatted and token-capped).
 
-> **Run it yourself (zero API, deterministic):** `npm run bench` sweeps a synthetic TypeScript corpus
-> across sizes and prints a grep-vs-vts token table + a per-model cost table — no API key, no spend, same
-> numbers on any machine. The token *delta* is model-independent; cost = `delta × input price`. Details,
-> methodology, and honest caveats in [`benchmarks/README.md`](benchmarks/README.md). Representative: at a
-> 150-file corpus the four everyday scenarios cut **~61%** of search tokens overall (find-references ~55%,
-> find-symbol ~84%, text ~54%, find-file ~32%); the reduction **climbs with repo size** (grep scales with
-> matches, vts stays capped). The numbers below are the large real-world UE ceiling.
+> **Run it yourself (zero API, deterministic):** `npm run bench` sweeps synthetic corpora in **three
+> languages** (TypeScript, Python, Go) across sizes and prints a per-language grep-vs-vts token table + a
+> per-model cost table — no API key, no spend, same numbers on any machine. The token *delta* is
+> model-independent; cost = `delta × input price`. Two axes on purpose: a single corpus could be
+> cherry-picked, so the same four scenarios run on a language vts has a **semantic** backend for
+> (TypeScript/Python) AND one it has **no** backend for (Go → the **syntactic** tree-sitter tier), at three
+> sizes each. Details, methodology, and honest caveats in [`benchmarks/README.md`](benchmarks/README.md).
+> Representative: at a 150-file corpus the all-language total cuts **~87%** of search tokens (per language:
+> TypeScript ~87%, Python ~83%, Go ~91%); the reduction **climbs with repo size** (grep scales with matches,
+> vts stays capped). The numbers below are the large real-world UE ceiling.
 
 > No source code, file paths, or project symbol names are reproduced here — only aggregate counts,
 > sizes, and timings. The query below is a **public Unreal Engine framework symbol** (`FGameplayTag`),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,17 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   and the literal text scan; the answer to "tree-sitter/embedding rivals are popular because they need no
   toolchain"). `treesitter.js`: lazy wasm tree-sitter (`web-tree-sitter` runtime + `tree-sitter-wasms` prebuilt
   grammars, both optionalDependencies — NO native build, Windows-safe; resolved via the sdk.js-style createRequire
-  anchors). `tsFileSymbols(abs)` walks an AST → real DECLARATIONS (name+kind+line) for **36 languages**;
-  `tsSearchSymbols(root,q)` ranks exact-before-substring across a scope (time+file-box); `nameOf` drills C/C++
-  declarator chains. Charter-pure: tree-sitter is an OFFICIAL standard parser (GitHub/neovim), not a reimplement;
+  anchors). `tsFileSymbols(abs)` walks an AST → real DECLARATIONS (name+kind+line). 36 grammars ship; decl
+  extraction is configured for **~17 languages** — 10 via a hand-tuned node-type walk (C/C++/C#/JS/TS/Py/Go/
+  Java/Rust/Ruby; `nameOf` drills C/C++ declarator chains) + 7 via canonical **`server/tags/<grammar>.scm`**
+  TAGS QUERIES (php/swift/kotlin/scala/dart/zig/bash) — a grammar with neither degrades to a GENERIC walk, never
+  dark. The tags tier is the EXTENSION POINT: a `TAGS` sentinel config in `EXT_MAP` + a `.scm` with canonical
+  `@definition.<kind>`/`@name`/`@reference.*` captures = a new language with NO JS (`defTagsQueryFor`/
+  `extractTagDefs`/`extractTagRefs`, validated against the bundled grammar; query-construct failure → graceful
+  fallback). References too: TAGS langs read `@reference.*` from the same .scm, others use inline `REF_QUERIES`.
+  `tsSearchSymbols(root,q)` ranks exact-before-substring across a scope (time+file-box).
+  Charter-pure: tree-sitter is an OFFICIAL standard parser (GitHub/neovim), not a reimplement (the tags-query
+  DSL is its own official interface, glue = ours);
   output stays token-capped file:line; nothing transmitted; SYNTACTIC means it locates decls but does NOT resolve
   refs/overloads/types (the LSP's job — so it's BELOW the semantic tier). `symindex.js`: COMMITTABLE index
   (Codeix-inspired) — `vts index` writes a portable, git-committable, team-shareable `.vts-index/symbols.jsonl`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,11 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   refs/overloads/types (the LSP's job — so it's BELOW the semantic tier). `symindex.js`: COMMITTABLE index
   (Codeix-inspired) — `vts index` writes a portable, git-committable, team-shareable `.vts-index/symbols.jsonl`
   (one record/decl, paths RELATIVE) via tree-sitter; `searchSymIndex` answers `search_symbol` INSTANTLY on a
-  toolchain-less machine or before clangd's index builds (the 369s→51s cold problem). core.js `syntacticSymbols`
+  toolchain-less machine or before clangd's index builds (the 369s→51s cold problem). INCREMENTAL rebuild: the
+  header carries a per-file manifest `h:{rel:{mt,sz,h}}` (mtime+size fast-path → `warmset.fnv1a` content hash);
+  a rebuild REUSES unchanged files verbatim (no read, no re-parse — parsing is the cost), reads+hashes only
+  stat-changed files, re-parses only on a real content change, drops deleted files. So `vts index` after
+  editing a few files re-parses only those (returns `reused`/`reparsed`; shown in the op output). core.js `syntacticSymbols`
   (committed index → live tree-sitter, else literal scan) feeds the search_symbol no-backend / empty-result
   branches; `completenessCert({syntactic})` labels it. Op `vts_index{status}` (CLI `vts index [--status]`, folded
   into `vts_admin`). Eval guard 81; benchmark arm C (zero-setup: 150-file symbol search grep 4917 → tree-sitter

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -28,8 +28,11 @@ suite claims — it claims the floor.
 
 ## What it measures
 
-A synthetic TypeScript project (built in a temp dir so the `typescript-language-server` backend resolves
-symbols/refs without clangd or a compile DB). Four everyday code-search scenarios, each run as:
+Synthetic projects in **three languages** — TypeScript, Python, and Go — built in a temp dir. TypeScript and
+Python exercise the **semantic** tier (a language server resolves symbols/refs when installed); Go has **no
+wired backend**, so it exercises the **syntactic** tree-sitter tier and a bounded literal scan. Running the
+same scenarios across all three is the controlled, multi-repo claim — a single corpus could be cherry-picked
+on the one shape vts is best at. Four everyday code-search scenarios per language, each run as:
 
 - **Arm A — grep**: what the built-in Grep/Glob tool hands the model — every matching `relpath:line:text`
   (or a path list for file-by-name), **capped at 250 lines** (Claude's Grep tool truncates ~there). This is
@@ -44,15 +47,21 @@ files) and reports the reduction climbing — the honest shape of the win.
 
 ## Representative results
 
-(From `results/latest.md`; re-run to refresh. Exact numbers depend on the bundled tsserver version.)
+(From `results/latest.md`; re-run to refresh. Exact numbers depend on which backends are installed — a
+missing language server only changes vts's *tier* label, never the token-capped shape.)
 
-| caller files | grep tokens | vts tokens | reduction |
-|--:|--:|--:|--:|
-| 10  | ~1,400  | ~1,200 | ~15% |
-| 50  | ~6,600  | ~3,700 | ~45% |
-| 150 | ~16,600 | ~6,500 | **~61%** |
+All-language total at 150 caller files (per corpus, the not-cherry-picked claim):
 
-Per-scenario at 150 files: `find references` ~55%, `find symbol` ~84%, `text search` ~54%, `find file` ~32%.
+| Language | vts tier (designed) | grep tokens | vts tokens | reduction |
+|---|---|--:|--:|--:|
+| TypeScript | semantic (LSP) | ~16,600 | ~2,200 | **~87%** |
+| Python | semantic (LSP) | ~14,900 | ~2,500 | **~83%** |
+| Go | syntactic (tree-sitter, no backend) | ~16,000 | ~1,400 | **~91%** |
+| **All languages** | — | ~47,500 | ~6,100 | **~87%** |
+
+The reduction climbs with repo size in every language (10 / 50 / 150 caller files); on a tiny corpus a
+narrow text/file search is a wash, the semantic scenarios win even there. See `results/latest.md` for the
+full per-language, per-scenario, per-size breakdown.
 
 ## Honest caveats (read these)
 

--- a/benchmarks/results/latest.json
+++ b/benchmarks/results/latest.json
@@ -7,147 +7,453 @@
     50,
     150
   ],
-  "bySize": {
-    "10": [
-      {
-        "scenario": "find symbol declaration",
-        "grepTok": 439,
-        "grepLines": 23,
-        "grepCapped": false,
-        "vtsTok": 154,
-        "vtsMode": "semantic",
-        "vtsOk": true,
-        "reduction": 0.6492027334851936
+  "languages": [
+    "TypeScript",
+    "Python",
+    "Go"
+  ],
+  "byLang": {
+    "TypeScript": {
+      "bySize": {
+        "10": [
+          {
+            "scenario": "find symbol declaration",
+            "grepTok": 439,
+            "grepLines": 23,
+            "grepCapped": false,
+            "vtsTok": 152,
+            "vtsMode": "semantic",
+            "vtsOk": true,
+            "reduction": 0.6537585421412301
+          },
+          {
+            "scenario": "find all references",
+            "grepTok": 439,
+            "grepLines": 23,
+            "grepCapped": false,
+            "vtsTok": 120,
+            "vtsMode": "semantic",
+            "vtsOk": true,
+            "reduction": 0.7266514806378133
+          },
+          {
+            "scenario": "text search ('retry loop')",
+            "grepTok": 399,
+            "grepLines": 21,
+            "grepCapped": false,
+            "vtsTok": 438,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": -0.09774436090225569
+          },
+          {
+            "scenario": "find file by name ('caller')",
+            "grepTok": 132,
+            "grepLines": 20,
+            "grepCapped": false,
+            "vtsTok": 76,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.4242424242424242
+          }
+        ],
+        "50": [
+          {
+            "scenario": "find symbol declaration",
+            "grepTok": 1999,
+            "grepLines": 103,
+            "grepCapped": false,
+            "vtsTok": 152,
+            "vtsMode": "semantic",
+            "vtsOk": true,
+            "reduction": 0.9239619809904952
+          },
+          {
+            "scenario": "find all references",
+            "grepTok": 1999,
+            "grepLines": 103,
+            "grepCapped": false,
+            "vtsTok": 321,
+            "vtsMode": "semantic",
+            "vtsOk": true,
+            "reduction": 0.8394197098549274
+          },
+          {
+            "scenario": "text search ('retry loop')",
+            "grepTok": 1959,
+            "grepLines": 101,
+            "grepCapped": false,
+            "vtsTok": 1260,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.3568147013782542
+          },
+          {
+            "scenario": "find file by name ('caller')",
+            "grepTok": 682,
+            "grepLines": 100,
+            "grepCapped": false,
+            "vtsTok": 216,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.6832844574780059
+          }
+        ],
+        "150": [
+          {
+            "scenario": "find symbol declaration",
+            "grepTok": 4917,
+            "grepLines": 303,
+            "grepCapped": true,
+            "vtsTok": 168,
+            "vtsMode": "syntactic",
+            "vtsOk": true,
+            "reduction": 0.9658328248932275
+          },
+          {
+            "scenario": "find all references",
+            "grepTok": 4917,
+            "grepLines": 303,
+            "grepCapped": true,
+            "vtsTok": 433,
+            "vtsMode": "semantic",
+            "vtsOk": true,
+            "reduction": 0.9119381736831401
+          },
+          {
+            "scenario": "text search ('retry loop')",
+            "grepTok": 4917,
+            "grepLines": 301,
+            "grepCapped": true,
+            "vtsTok": 1287,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.738255033557047
+          },
+          {
+            "scenario": "find file by name ('caller')",
+            "grepTok": 1883,
+            "grepLines": 300,
+            "grepCapped": true,
+            "vtsTok": 328,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.8258098778544876
+          }
+        ]
       },
-      {
-        "scenario": "find all references",
-        "grepTok": 439,
-        "grepLines": 23,
-        "grepCapped": false,
-        "vtsTok": 122,
-        "vtsMode": "semantic",
-        "vtsOk": true,
-        "reduction": 0.7220956719817768
+      "syn": {
+        "10": {
+          "tok": 50,
+          "n": 2
+        },
+        "50": {
+          "tok": 50,
+          "n": 2
+        },
+        "150": {
+          "tok": 51,
+          "n": 2
+        }
       },
-      {
-        "scenario": "text search ('retry loop')",
-        "grepTok": 399,
-        "grepLines": 21,
-        "grepCapped": false,
-        "vtsTok": 439,
-        "vtsMode": "filesystem",
-        "vtsOk": true,
-        "reduction": -0.10025062656641603
-      },
-      {
-        "scenario": "find file by name ('caller')",
-        "grepTok": 132,
-        "grepLines": 20,
-        "grepCapped": false,
-        "vtsTok": 77,
-        "vtsMode": "filesystem",
-        "vtsOk": true,
-        "reduction": 0.41666666666666663
-      }
-    ],
-    "50": [
-      {
-        "scenario": "find symbol declaration",
-        "grepTok": 1999,
-        "grepLines": 103,
-        "grepCapped": false,
-        "vtsTok": 154,
-        "vtsMode": "semantic",
-        "vtsOk": true,
-        "reduction": 0.9229614807403702
-      },
-      {
-        "scenario": "find all references",
-        "grepTok": 1999,
-        "grepLines": 103,
-        "grepCapped": false,
-        "vtsTok": 323,
-        "vtsMode": "semantic",
-        "vtsOk": true,
-        "reduction": 0.8384192096048024
-      },
-      {
-        "scenario": "text search ('retry loop')",
-        "grepTok": 1959,
-        "grepLines": 101,
-        "grepCapped": false,
-        "vtsTok": 1261,
-        "vtsMode": "filesystem",
-        "vtsOk": true,
-        "reduction": 0.3563042368555386
-      },
-      {
-        "scenario": "find file by name ('caller')",
-        "grepTok": 682,
-        "grepLines": 100,
-        "grepCapped": false,
-        "vtsTok": 217,
-        "vtsMode": "filesystem",
-        "vtsOk": true,
-        "reduction": 0.6818181818181819
-      }
-    ],
-    "150": [
-      {
-        "scenario": "find symbol declaration",
-        "grepTok": 4917,
-        "grepLines": 303,
-        "grepCapped": true,
-        "vtsTok": 170,
-        "vtsMode": "semantic",
-        "vtsOk": true,
-        "reduction": 0.9654260728086231
-      },
-      {
-        "scenario": "find all references",
-        "grepTok": 4917,
-        "grepLines": 303,
-        "grepCapped": true,
-        "vtsTok": 435,
-        "vtsMode": "semantic",
-        "vtsOk": true,
-        "reduction": 0.9115314215985357
-      },
-      {
-        "scenario": "text search ('retry loop')",
-        "grepTok": 4917,
-        "grepLines": 301,
-        "grepCapped": true,
-        "vtsTok": 1288,
-        "vtsMode": "filesystem",
-        "vtsOk": true,
-        "reduction": 0.7380516575147448
-      },
-      {
-        "scenario": "find file by name ('caller')",
-        "grepTok": 1883,
-        "grepLines": 300,
-        "grepCapped": true,
-        "vtsTok": 329,
-        "vtsMode": "filesystem",
-        "vtsOk": true,
-        "reduction": 0.8252788104089219
-      }
-    ]
-  },
-  "syntacticBySize": {
-    "10": {
-      "tok": 52,
-      "n": 2
+      "ext": "ts"
     },
-    "50": {
-      "tok": 52,
-      "n": 2
+    "Python": {
+      "bySize": {
+        "10": [
+          {
+            "scenario": "find symbol declaration",
+            "grepTok": 536,
+            "grepLines": 33,
+            "grepCapped": false,
+            "vtsTok": 168,
+            "vtsMode": "syntactic",
+            "vtsOk": true,
+            "reduction": 0.6865671641791045
+          },
+          {
+            "scenario": "find all references",
+            "grepTok": 536,
+            "grepLines": 33,
+            "grepCapped": false,
+            "vtsTok": 125,
+            "vtsMode": "semantic",
+            "vtsOk": true,
+            "reduction": 0.7667910447761194
+          },
+          {
+            "scenario": "text search ('retry loop')",
+            "grepTok": 373,
+            "grepLines": 21,
+            "grepCapped": false,
+            "vtsTok": 401,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": -0.07506702412868638
+          },
+          {
+            "scenario": "find file by name ('caller')",
+            "grepTok": 132,
+            "grepLines": 20,
+            "grepCapped": false,
+            "vtsTok": 76,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.4242424242424242
+          }
+        ],
+        "50": [
+          {
+            "scenario": "find symbol declaration",
+            "grepTok": 2536,
+            "grepLines": 153,
+            "grepCapped": false,
+            "vtsTok": 168,
+            "vtsMode": "syntactic",
+            "vtsOk": true,
+            "reduction": 0.9337539432176656
+          },
+          {
+            "scenario": "find all references",
+            "grepTok": 2536,
+            "grepLines": 153,
+            "grepCapped": false,
+            "vtsTok": 346,
+            "vtsMode": "syntactic",
+            "vtsOk": true,
+            "reduction": 0.863564668769716
+          },
+          {
+            "scenario": "text search ('retry loop')",
+            "grepTok": 1833,
+            "grepLines": 101,
+            "grepCapped": false,
+            "vtsTok": 1135,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.3807965084560829
+          },
+          {
+            "scenario": "find file by name ('caller')",
+            "grepTok": 682,
+            "grepLines": 100,
+            "grepCapped": false,
+            "vtsTok": 216,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.6832844574780059
+          }
+        ],
+        "150": [
+          {
+            "scenario": "find symbol declaration",
+            "grepTok": 4221,
+            "grepLines": 453,
+            "grepCapped": true,
+            "vtsTok": 168,
+            "vtsMode": "syntactic",
+            "vtsOk": true,
+            "reduction": 0.9601990049751243
+          },
+          {
+            "scenario": "find all references",
+            "grepTok": 4221,
+            "grepLines": 453,
+            "grepCapped": true,
+            "vtsTok": 830,
+            "vtsMode": "syntactic",
+            "vtsOk": true,
+            "reduction": 0.8033641317223407
+          },
+          {
+            "scenario": "text search ('retry loop')",
+            "grepTok": 4604,
+            "grepLines": 301,
+            "grepCapped": true,
+            "vtsTok": 1182,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.7432667245873154
+          },
+          {
+            "scenario": "find file by name ('caller')",
+            "grepTok": 1883,
+            "grepLines": 300,
+            "grepCapped": true,
+            "vtsTok": 328,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.8258098778544876
+          }
+        ]
+      },
+      "syn": {
+        "10": {
+          "tok": 51,
+          "n": 2
+        },
+        "50": {
+          "tok": 51,
+          "n": 2
+        },
+        "150": {
+          "tok": 52,
+          "n": 2
+        }
+      },
+      "ext": "py"
     },
-    "150": {
-      "tok": 53,
-      "n": 2
+    "Go": {
+      "bySize": {
+        "10": [
+          {
+            "scenario": "find symbol declaration",
+            "grepTok": 415,
+            "grepLines": 23,
+            "grepCapped": false,
+            "vtsTok": 155,
+            "vtsMode": "syntactic",
+            "vtsOk": true,
+            "reduction": 0.6265060240963856
+          },
+          {
+            "scenario": "find all references",
+            "grepTok": 415,
+            "grepLines": 23,
+            "grepCapped": false,
+            "vtsTok": 184,
+            "vtsMode": "syntactic",
+            "vtsOk": true,
+            "reduction": 0.5566265060240965
+          },
+          {
+            "scenario": "text search ('retry loop')",
+            "grepTok": 378,
+            "grepLines": 21,
+            "grepCapped": false,
+            "vtsTok": 80,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.7883597883597884
+          },
+          {
+            "scenario": "find file by name ('caller')",
+            "grepTok": 142,
+            "grepLines": 20,
+            "grepCapped": false,
+            "vtsTok": 77,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.4577464788732394
+          }
+        ],
+        "50": [
+          {
+            "scenario": "find symbol declaration",
+            "grepTok": 1895,
+            "grepLines": 103,
+            "grepCapped": false,
+            "vtsTok": 155,
+            "vtsMode": "syntactic",
+            "vtsOk": true,
+            "reduction": 0.9182058047493403
+          },
+          {
+            "scenario": "find all references",
+            "grepTok": 1895,
+            "grepLines": 103,
+            "grepCapped": false,
+            "vtsTok": 364,
+            "vtsMode": "syntactic",
+            "vtsOk": true,
+            "reduction": 0.807915567282322
+          },
+          {
+            "scenario": "text search ('retry loop')",
+            "grepTok": 1858,
+            "grepLines": 101,
+            "grepCapped": false,
+            "vtsTok": 80,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.9569429494079655
+          },
+          {
+            "scenario": "find file by name ('caller')",
+            "grepTok": 732,
+            "grepLines": 100,
+            "grepCapped": false,
+            "vtsTok": 217,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.7035519125683061
+          }
+        ],
+        "150": [
+          {
+            "scenario": "find symbol declaration",
+            "grepTok": 4667,
+            "grepLines": 303,
+            "grepCapped": true,
+            "vtsTok": 156,
+            "vtsMode": "syntactic",
+            "vtsOk": true,
+            "reduction": 0.9665738161559888
+          },
+          {
+            "scenario": "find all references",
+            "grepTok": 4667,
+            "grepLines": 303,
+            "grepCapped": true,
+            "vtsTok": 848,
+            "vtsMode": "syntactic",
+            "vtsOk": true,
+            "reduction": 0.8182986929505035
+          },
+          {
+            "scenario": "text search ('retry loop')",
+            "grepTok": 4667,
+            "grepLines": 301,
+            "grepCapped": true,
+            "vtsTok": 81,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.982644096850225
+          },
+          {
+            "scenario": "find file by name ('caller')",
+            "grepTok": 1983,
+            "grepLines": 300,
+            "grepCapped": true,
+            "vtsTok": 329,
+            "vtsMode": "filesystem",
+            "vtsOk": true,
+            "reduction": 0.8340897629853756
+          }
+        ]
+      },
+      "syn": {
+        "10": {
+          "tok": 53,
+          "n": 2
+        },
+        "50": {
+          "tok": 53,
+          "n": 2
+        },
+        "150": {
+          "tok": 53,
+          "n": 2
+        }
+      },
+      "ext": "go"
     }
+  },
+  "aggregateAtMax": {
+    "files": 150,
+    "grepTok": 47547,
+    "vtsTok": 6138,
+    "reduction": 0.8709066818095779
   },
   "costAtMax": {
     "files": 150,
@@ -155,23 +461,23 @@
       {
         "model": "Haiku 4.5",
         "price": 1,
-        "grepCost": 0.016634,
-        "vtsCost": 0.002222,
-        "saved": 0.014412
+        "grepCost": 0.047547,
+        "vtsCost": 0.006138,
+        "saved": 0.041409
       },
       {
         "model": "Sonnet 4.x",
         "price": 3,
-        "grepCost": 0.049902,
-        "vtsCost": 0.006666,
-        "saved": 0.043236000000000004
+        "grepCost": 0.142641,
+        "vtsCost": 0.018414,
+        "saved": 0.12422699999999999
       },
       {
         "model": "Opus 4.x",
         "price": 15,
-        "grepCost": 0.24950999999999998,
-        "vtsCost": 0.03333,
-        "saved": 0.21617999999999998
+        "grepCost": 0.713205,
+        "vtsCost": 0.09207,
+        "saved": 0.621135
       }
     ]
   },

--- a/benchmarks/results/latest.md
+++ b/benchmarks/results/latest.md
@@ -1,55 +1,116 @@
 # vs-token-safer benchmark — Bash grep vs vts (deterministic, no API)
 
-Synthetic TypeScript corpus, 4 code-search scenarios, swept across corpus size.
-Token ≈ bytes ÷ 4 (same as the product ledger). Grep arm = matching `file:line:text` (or a path
-list for file-by-name) capped at 250 lines (Claude's Grep tool). vts arm = the
-token-capped `file:line` output. Reproduce: `npm run bench`.
+Synthetic corpora in **3 languages** (TypeScript, Python, Go), 4 code-search scenarios each, swept across corpus size. Token ≈ bytes ÷ 4
+(same as the product ledger). Grep arm = matching `file:line:text` (or a path list for file-by-name)
+capped at 250 lines (Claude's Grep tool). vts arm = the token-capped `file:line` output.
+Reproduce: `npm run bench`.
 
-## Reduction vs corpus size (the win scales)
+## Token reduction across languages (at 150 files — the not-cherry-picked claim)
+
+| Language | grep tokens | vts tokens | reduction |
+|---|--:|--:|--:|
+| TypeScript | 16634 | 2216 | **86.7%** |
+| Python | 14929 | 2508 | **83.2%** |
+| Go | 15984 | 1414 | **91.2%** |
+| **All languages** | **47547** | **6138** | **87.1%** |
+
+The win holds across languages vts has a language server for (TypeScript, Python — the SEMANTIC tier)
+and one it has no wired backend for (Go — tree-sitter answers symbol queries and a bounded literal scan
+answers references, the SYNTACTIC tier). Same token-capped shape either way. Which tier actually answered
+each scenario on THIS run (it degrades to syntactic/text-fallback when a language server isn't installed)
+is shown in the per-scenario tables below — the token reduction itself is deterministic regardless.
+
+## Reduction vs corpus size, per language (the win scales)
+
+### TypeScript
 
 | caller files | grep tokens | vts tokens | reduction |
 |--:|--:|--:|--:|
-| 10 | 1409 | 792 | **43.8%** |
-| 50 | 6639 | 1955 | **70.6%** |
-| 150 | 16634 | 2222 | **86.6%** |
+| 10 | 1409 | 786 | **44.2%** |
+| 50 | 6639 | 1949 | **70.6%** |
+| 150 | 16634 | 2216 | **86.7%** |
 
-Grep grows with the match count; vts stays capped — so the reduction climbs with repo size. On a
-tiny corpus a narrow text/file search is a wash (vts's header overhead ≈ grep); the semantic
-scenarios (symbol/refs) win even there because grep over-reports comments/strings/substrings.
+### Python
 
-## Per-scenario at 150 files
+| caller files | grep tokens | vts tokens | reduction |
+|--:|--:|--:|--:|
+| 10 | 1577 | 770 | **51.2%** |
+| 50 | 7587 | 1865 | **75.4%** |
+| 150 | 14929 | 2508 | **83.2%** |
+
+### Go
+
+| caller files | grep tokens | vts tokens | reduction |
+|--:|--:|--:|--:|
+| 10 | 1350 | 496 | **63.3%** |
+| 50 | 6380 | 816 | **87.2%** |
+| 150 | 15984 | 1414 | **91.2%** |
+
+Grep grows with the match count; vts stays capped — so the reduction climbs with repo size in every
+language. On a tiny corpus a narrow text/file search is a wash (vts's header overhead ≈ grep); the
+semantic scenarios (symbol/refs) win even there because grep over-reports comments/strings/qualified calls.
+
+## Per-scenario at 150 files, per language
+
+### TypeScript
 
 | Scenario | grep tokens | vts tokens | reduction | vts mode |
 |---|--:|--:|--:|---|
-| find symbol declaration | 4917 (capped) | 170 | **96.5%** | semantic |
-| find all references | 4917 (capped) | 435 | **91.2%** | semantic |
-| text search ('retry loop') | 4917 (capped) | 1288 | **73.8%** | filesystem |
-| find file by name ('caller') | 1883 (capped) | 329 | **82.5%** | filesystem |
-| **TOTAL** | **16634** | **2222** | **86.6%** | |
+| find symbol declaration | 4917 (capped) | 168 | **96.6%** | syntactic |
+| find all references | 4917 (capped) | 433 | **91.2%** | semantic |
+| text search ('retry loop') | 4917 (capped) | 1287 | **73.8%** | filesystem |
+| find file by name ('caller') | 1883 (capped) | 328 | **82.6%** | filesystem |
+| **TOTAL** | **16634** | **2216** | **86.7%** | |
 
-## Zero-setup symbol search: grep vs tree-sitter (no toolchain) vs LSP
+### Python
+
+| Scenario | grep tokens | vts tokens | reduction | vts mode |
+|---|--:|--:|--:|---|
+| find symbol declaration | 4221 (capped) | 168 | **96.0%** | syntactic |
+| find all references | 4221 (capped) | 830 | **80.3%** | syntactic |
+| text search ('retry loop') | 4604 (capped) | 1182 | **74.3%** | filesystem |
+| find file by name ('caller') | 1883 (capped) | 328 | **82.6%** | filesystem |
+| **TOTAL** | **14929** | **2508** | **83.2%** | |
+
+### Go
+
+| Scenario | grep tokens | vts tokens | reduction | vts mode |
+|---|--:|--:|--:|---|
+| find symbol declaration | 4667 (capped) | 156 | **96.7%** | syntactic |
+| find all references | 4667 (capped) | 848 | **81.8%** | syntactic |
+| text search ('retry loop') | 4667 (capped) | 81 | **98.3%** | filesystem |
+| find file by name ('caller') | 1983 (capped) | 329 | **83.4%** | filesystem |
+| **TOTAL** | **15984** | **1414** | **91.2%** | |
+
+## Zero-setup symbol search: grep vs tree-sitter (no toolchain) vs vts tier, per language
 
 The tree-sitter tier needs NO compile DB / language server — it indexes 36 languages instantly — yet
 returns the same token-capped `file:line` shape, so toolchain-free costs no more tokens than semantic.
 
-| caller files | grep tokens | tree-sitter (no setup) | LSP (semantic) | grep→tree-sitter |
-|--:|--:|--:|--:|--:|
-| 10 | 439 | 52 | 154 | **88.2%** |
-| 50 | 1999 | 52 | 154 | **97.4%** |
-| 150 | 4917 | 53 | 170 | **98.9%** |
+| Language | caller files | grep tokens | tree-sitter (no setup) | vts tier | grep→tree-sitter |
+|---|--:|--:|--:|--:|--:|
+| TypeScript | 10 | 439 | 50 | 152 | **88.6%** |
+| TypeScript | 50 | 1999 | 50 | 152 | **97.5%** |
+| TypeScript | 150 | 4917 | 51 | 168 | **99.0%** |
+| Python | 10 | 536 | 51 | 168 | **90.5%** |
+| Python | 50 | 2536 | 51 | 168 | **98.0%** |
+| Python | 150 | 4221 | 52 | 168 | **98.8%** |
+| Go | 10 | 415 | 53 | 155 | **87.2%** |
+| Go | 50 | 1895 | 53 | 155 | **97.2%** |
+| Go | 150 | 4667 | 53 | 156 | **98.9%** |
 
 Both vts tiers stay flat while grep grows; the tree-sitter tier is the cold-start / no-toolchain path,
 the LSP tier adds reference/overload/type resolution on top. Build a committable index with `vts index`.
 
-## Cost per model at 150 files (token delta × input price)
+## Cost per model at 150 files, all languages (token delta × input price)
 
 Saved = (grep − vts) input tokens × list input price. List prices, verify at anthropic.com/pricing.
 
 | Model | $/Mtok (in) | grep cost | vts cost | saved | cheaper |
 |---|--:|--:|--:|--:|--:|
-| Haiku 4.5 | $1.00 | $0.016634 | $0.002222 | $0.014412 | 86.6% |
-| Sonnet 4.x | $3.00 | $0.049902 | $0.006666 | $0.043236 | 86.6% |
-| Opus 4.x | $15.00 | $0.249510 | $0.033330 | $0.216180 | 86.6% |
+| Haiku 4.5 | $1.00 | $0.047547 | $0.006138 | $0.041409 | 87.1% |
+| Sonnet 4.x | $3.00 | $0.142641 | $0.018414 | $0.124227 | 87.1% |
+| Opus 4.x | $15.00 | $0.713205 | $0.092070 | $0.621135 | 87.1% |
 
 > Absolute $ per query is tiny — the win compounds across the many searches in a real session and
 > grows with repo size. On a real Unreal Engine project the same A/B is ~282k → ~2k tokens (~138×);

--- a/benchmarks/run.mjs
+++ b/benchmarks/run.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * vs-token-safer — reproducible token benchmark (A/B: Bash grep vs vts).
+ * vs-token-safer — reproducible token benchmark (A/B: Bash grep vs vts), swept across LANGUAGES and sizes.
  *
  * WHY this shape (and not promptfoo-with-a-live-model): vts is a TOOL that shapes the *input* context a
  * code-search puts in front of the model, not a prompt that shapes the model's *output*. So the honest,
@@ -9,20 +9,27 @@
  * (`npm run bench`). The per-model COST table is then `token-delta × that model's input price` — the
  * model matrix for free, with no run-to-run variance.
  *
- * THE KEY VARIABLE IS REPO SIZE. grep returns every matching line (full text), so its cost scales with
- * the match count; vts returns a token-capped `file:line` list, so it stays roughly flat. On a 10-file
- * toy a narrow text search is a wash (vts's header overhead ≈ grep); the win opens up as the repo grows.
- * So the benchmark SWEEPS corpus size and reports the reduction climbing — the honest shape of the win.
+ * TWO axes, because a SINGLE synthetic corpus is the benchmark's named weakness (it could be cherry-picked
+ * on the one language/shape vts is best at). So we vary BOTH:
+ *   1. REPO SIZE — grep returns every matching line (full text), so its cost scales with the match count;
+ *      vts returns a token-capped `file:line` list, so it stays roughly flat. The win opens up with size.
+ *   2. LANGUAGE — the SAME four scenarios run on a TypeScript, a Python, AND a Go corpus. TypeScript and
+ *      Python exercise the SEMANTIC tier (a language server, when installed); Go has NO wired backend, so
+ *      it exercises the SYNTACTIC tier (tree-sitter) and the literal-fallback — i.e. the cold / toolchain-
+ *      free path. If the token win held only on TS it would be cherry-picked; showing it across three
+ *      languages and three sizes is the controlled, multi-repo claim the paper asks for.
  *
  * Arms, per scenario:
  *   A) grep  — what the built-in Grep/Glob tool hands the model: matching `relpath:lineno:full-line` (or
  *              a path list for file-by-name), capped at GREP_LINE_CAP (Claude's Grep tool truncates ~250;
  *              the CONSERVATIVE baseline — uncapped grep-and-paste is far larger).
- *   B) vts   — the runTool output: a token-capped `file:line` list, no bodies.
+ *   B) vts   — the runTool output: a token-capped `file:line` list, no bodies. Its tier (semantic /
+ *              syntactic / text-fallback) is reported honestly per language.
  *
- * Token estimate = bytes / 4 (identical to server/core.js). Corpus = a synthetic TypeScript project in a
- * temp dir so the typescript-language-server backend resolves symbols/refs without clangd or a compile DB
- * (CI installs it via optionalDependencies). No real source/paths/symbols — synthetic only.
+ * Token estimate = bytes / 4 (identical to server/core.js). Corpora are synthetic projects in a temp dir
+ * (no real source/paths/symbols). The TOKEN delta is deterministic regardless of which backends are
+ * installed — a missing language server only changes vts's TIER label (semantic→text-fallback), not the
+ * fact that its output stays token-capped. Synthetic only; nothing transmitted.
  */
 import fs from "node:fs";
 import os from "node:os";
@@ -48,14 +55,23 @@ const PRICES = { "Haiku 4.5": 1.0, "Sonnet 4.x": 3.0, "Opus 4.x": 15.0 };
 const GREP_LINE_CAP = 250;      // Claude's built-in Grep tool truncates output ~here (conservative baseline)
 const SIZES = [10, 50, 150];    // caller files per corpus — sweep to show the win scaling with repo size
 
-// Build a synthetic TS project of `n` caller files. Target symbol `processPayment`: ONE declaration, a
-// call site + comment + retry note per caller (so refs/text scale with n), plus substring noise
-// (`processPaymentRefund`) grep over-reports. "retry loop" is a genuine text string (no symbol shape →
-// no vts steer-nudge), so the text scenario is a fair text-vs-text comparison.
-function buildCorpus(n) {
-  const root = path.join(TMP, `corpus-${n}`);
+// ── Corpus builders, one per language ───────────────────────────────────────────────────────────────
+// Each builds a project of `n` caller files exercising the SAME shape: ONE target-symbol declaration + a
+// substring-noise sibling + a per-caller call site, comment, and a "retry loop" text string (a genuine
+// text match with no symbol shape → no vts steer-nudge, so the text scenario is a fair text-vs-text test).
+// A node_modules/ junk tree (universally in vts SKIP_DIRS) lets the file-by-name arm show find_files
+// bounding past ignored dirs, not just capping.
+function junkAndReturn(root, ext, n) {
+  const junk = path.join(root, "node_modules", "vendor");
+  fs.mkdirSync(junk, { recursive: true });
+  for (let i = 0; i < n; i++) fs.writeFileSync(path.join(junk, `caller_vendor${i}.${ext}`), `const v${i} = ${i};\n`);
+  return root;
+}
+
+function buildTs(n) {
+  const root = path.join(TMP, `ts-${n}`);
   fs.mkdirSync(path.join(root, "src"), { recursive: true });
-  fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: `bench-${n}`, version: "1.0.0" }));
+  fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: `bench-ts-${n}`, version: "1.0.0" }));
   fs.writeFileSync(path.join(root, "tsconfig.json"), JSON.stringify({ compilerOptions: { module: "commonjs", target: "es2020", strict: true }, include: ["src"] }));
   fs.writeFileSync(path.join(root, "src", "payment.ts"),
     `// processPayment is the core billing entry point.\n` +
@@ -67,8 +83,7 @@ function buildCorpus(n) {
     `export function processPaymentRefund(amount: number): boolean { return amount > 0; }\n`);
   for (let i = 0; i < n; i++) {
     // Namespace import (not a named binding) so the ONLY symbol literally named `processPayment` is the
-    // declaration — find_references-by-name then resolves the real decl and returns the COMPLETE ref set
-    // (a fair same-answer token comparison). grep `\bprocessPayment\b` still matches `billing.processPayment`.
+    // declaration — find_references-by-name then resolves the real decl and returns the COMPLETE ref set.
     fs.writeFileSync(path.join(root, "src", `caller${i}.ts`),
       `import * as billing from "./payment";\n` +
       `// caller ${i}: drives processPayment inside a retry loop\n` +
@@ -79,51 +94,110 @@ function buildCorpus(n) {
       `  }\n` +
       `}\n`);
   }
-  // Dependency/build junk a real tree carries — `find`/grep traverse it (noise), vts walk-bounds past it
-  // (SKIP_DIRS: node_modules/Intermediate/Binaries/…). Named to match the file-by-name query so the
-  // file-search arm reflects find_files' actual value: skipping ignored dirs, not just capping.
-  const junk = path.join(root, "node_modules", "vendor");
-  fs.mkdirSync(junk, { recursive: true });
-  for (let i = 0; i < n; i++) fs.writeFileSync(path.join(junk, `caller_vendor${i}.ts`), `export const v${i} = ${i};\n`);
-  return root;
+  return junkAndReturn(root, "ts", n);
 }
 
+function buildPy(n) {
+  const root = path.join(TMP, `py-${n}`);
+  fs.mkdirSync(path.join(root, "src"), { recursive: true });
+  fs.writeFileSync(path.join(root, "pyproject.toml"), `[project]\nname = "bench-py-${n}"\nversion = "1.0.0"\n`);
+  fs.writeFileSync(path.join(root, "src", "payment.py"),
+    `# process_payment is the core billing entry point.\n` +
+    `def process_payment(amount, currency):\n` +
+    `    if amount <= 0:\n` +
+    `        return False\n` +
+    `    note = "calling process_payment in a retry loop"\n` +
+    `    return True\n\n` +
+    `def process_payment_refund(amount):\n` +
+    `    return amount > 0\n`);
+  for (let i = 0; i < n; i++) {
+    fs.writeFileSync(path.join(root, "src", `caller${i}.py`),
+      `from payment import process_payment\n` +
+      `# caller ${i}: drives process_payment inside a retry loop\n` +
+      `def run${i}():\n` +
+      `    for r in range(3):\n` +
+      `        ok = process_payment(${i + 1}, "USD")  # retry loop\n` +
+      `        if not ok:\n` +
+      `            continue\n`);
+  }
+  return junkAndReturn(root, "py", n);
+}
+
+function buildGo(n) {
+  const root = path.join(TMP, `go-${n}`);
+  fs.mkdirSync(path.join(root, "payment"), { recursive: true });
+  fs.writeFileSync(path.join(root, "go.mod"), `module benchgo\n\ngo 1.21\n`);
+  fs.writeFileSync(path.join(root, "payment", "payment.go"),
+    `package payment\n\n` +
+    `// ProcessPayment is the core billing entry point.\n` +
+    `func ProcessPayment(amount int, currency string) bool {\n` +
+    `\tif amount <= 0 {\n\t\treturn false\n\t}\n` +
+    `\tnote := "calling ProcessPayment in a retry loop"\n\t_ = note\n` +
+    `\treturn true\n}\n\n` +
+    `func ProcessPaymentRefund(amount int) bool { return amount > 0 }\n`);
+  for (let i = 0; i < n; i++) {
+    fs.writeFileSync(path.join(root, "payment", `caller${i}.go`),
+      `package payment\n\n` +
+      `// caller ${i}: drives ProcessPayment inside a retry loop\n` +
+      `func Run${i}() {\n` +
+      `\tfor r := 0; r < 3; r++ {\n` +
+      `\t\tok := ProcessPayment(${i + 1}, "USD") // retry loop\n` +
+      `\t\t_ = ok\n` +
+      `\t}\n}\n`);
+  }
+  return junkAndReturn(root, "go", n);
+}
+
+// Each corpus: how to build it, its target symbol (named per the language's convention), and the backend to
+// pin (null = let vts auto-detect; Go has no wired backend, so search_symbol falls to the SYNTACTIC tier).
+const CORPORA = [
+  { lang: "TypeScript", ext: "ts", sym: "processPayment", backend: "typescript", build: buildTs, tier: "semantic" },
+  { lang: "Python", ext: "py", sym: "process_payment", backend: "pyright", build: buildPy, tier: "semantic" },
+  { lang: "Go", ext: "go", sym: "ProcessPayment", backend: null, build: buildGo, tier: "syntactic" },
+];
+
 // Arm A: grep over file CONTENT → `relpath:lineno:line` per match, capped.
-function grepContent(root, re) {
+function grepContent(root, ext, re) {
   const out = [];
-  for (const p of walkTs(root)) {
+  for (const p of walkExt(root, ext)) {
     const rel = path.relative(root, p).replace(/\\/g, "/");
     fs.readFileSync(p, "utf8").split("\n").forEach((line, i) => { if (re.test(line)) out.push(`${rel}:${i + 1}:${line}`); });
   }
   return capList(out);
 }
 // Arm A for file-by-name: the path list a `find -name`/Glob hands back.
-function grepFiles(root, re) {
-  const out = walkTs(root).map((p) => path.relative(root, p).replace(/\\/g, "/")).filter((rel) => re.test(rel));
+function grepFiles(root, ext, re) {
+  const out = walkExt(root, ext).map((p) => path.relative(root, p).replace(/\\/g, "/")).filter((rel) => re.test(rel));
   return capList(out);
 }
-function walkTs(dir, acc = []) {
+function walkExt(dir, ext, acc = []) {
+  const rx = new RegExp(`\\.${ext}$`);
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     const p = path.join(dir, e.name);
-    if (e.isDirectory()) walkTs(p, acc); else if (/\.ts$/.test(e.name)) acc.push(p);
+    if (e.isDirectory()) walkExt(p, ext, acc); else if (rx.test(e.name)) acc.push(p);
   }
   return acc;
 }
 function capList(out) { const c = out.slice(0, GREP_LINE_CAP); return { tok: tok(c.join("\n")), lines: out.length, capped: out.length > GREP_LINE_CAP }; }
 
-// Arm B: vts runTool.
-async function vtsArm(root, toolName, args, kind) {
-  const r = await runTool(toolName, { projectPath: root, backend: "typescript", ...args });
-  // "mode": symbol/refs are SEMANTIC when the index resolved them; search_text/find_files are FILESYSTEM.
+// Arm B: vts runTool. `backend` is omitted when null so vts auto-detects (and, for Go, falls to syntactic).
+async function vtsArm(root, backend, toolName, args, kind) {
+  const r = await runTool(toolName, { projectPath: root, ...(backend ? { backend } : {}), ...args });
+  // "mode": which tier answered. semantic = the language server resolved it; syntactic = tree-sitter (no
+  // toolchain); text-fallback = literal scan; filesystem = find_files/search_text (always literal).
   let mode = "filesystem";
-  if (kind === "semantic") mode = (!r.isError && !/Literal text matches|No backend resolved/.test(r.text)) ? "semantic" : "text-fallback";
+  if (kind === "semantic") {
+    if (r.isError) mode = "error";
+    else if (/tree-sitter \(syntactic\)|tree-sitter call reference/.test(r.text)) mode = "syntactic";
+    else if (/Literal text matches|No backend resolved/.test(r.text)) mode = "text-fallback";
+    else mode = "semantic";
+  }
   return { tok: tok(r.text), ok: !r.isError, mode };
 }
 
 // Arm C: the SYNTACTIC tier (tree-sitter, ZERO toolchain) — what vts returns for a symbol search on a repo
 // with NO language server installed. This is the embedding/tree-sitter competitors' home turf; we measure
-// that our zero-setup answer keeps the same token-capped `file:line` shape (no bodies), so going toolchain-
-// free costs no more tokens than the semantic tier — while still being real declarations, not a usage grep.
+// that our zero-setup answer keeps the same token-capped `file:line` shape (no bodies), across languages.
 async function syntacticArm(root, q) {
   const SKIP = new Set(["node_modules", ".git", "build", "dist"]);
   const hits = await tsSearchSymbols(root, q, { skipDir: (n) => SKIP.has(n) });
@@ -131,80 +205,113 @@ async function syntacticArm(root, q) {
   return { tok: tok(lines.join("\n")), n: lines.length };
 }
 
-const scenarios = [
-  { name: "find symbol declaration", grep: (root) => grepContent(root, /\bprocessPayment\b/), vts: (root) => vtsArm(root, "search_symbol", { q: "processPayment" }, "semantic") },
-  { name: "find all references", grep: (root) => grepContent(root, /\bprocessPayment\b/), vts: (root) => vtsArm(root, "find_references", { symbol: "processPayment" }, "semantic") },
-  { name: "text search ('retry loop')", grep: (root) => grepContent(root, /retry loop/), vts: (root) => vtsArm(root, "search_text", { q: "retry loop" }, "text") },
-  { name: "find file by name ('caller')", grep: (root) => grepFiles(root, /caller/), vts: (root) => vtsArm(root, "find_files", { q: "caller" }, "file") },
-];
-
-// ── Sweep ────────────────────────────────────────────────────────────────────────────────────────
-const bySize = {};
-const synBySize = {};
-for (const n of SIZES) {
-  const root = buildCorpus(n);
-  const rows = [];
-  for (const s of scenarios) {
-    const a = s.grep(root);
-    const b = await s.vts(root);
-    rows.push({ scenario: s.name, grepTok: a.tok, grepLines: a.lines, grepCapped: a.capped, vtsTok: b.tok, vtsMode: b.mode, vtsOk: b.ok, reduction: a.tok > 0 ? 1 - b.tok / a.tok : 0 });
-  }
-  bySize[n] = rows;
-  // Arm C: zero-toolchain symbol search via the syntactic (tree-sitter) tier, same query as scenario 1.
-  if (tsAvailable()) synBySize[n] = await syntacticArm(root, "processPayment");
+function scenariosFor(c) {
+  const symRe = new RegExp(`\\b${c.sym}\\b`);
+  return [
+    { name: "find symbol declaration", grep: (root) => grepContent(root, c.ext, symRe), vts: (root) => vtsArm(root, c.backend, "search_symbol", { q: c.sym }, "semantic") },
+    { name: "find all references", grep: (root) => grepContent(root, c.ext, symRe), vts: (root) => vtsArm(root, c.backend, "find_references", { symbol: c.sym }, "semantic") },
+    { name: "text search ('retry loop')", grep: (root) => grepContent(root, c.ext, /retry loop/), vts: (root) => vtsArm(root, c.backend, "search_text", { q: "retry loop" }, "text") },
+    { name: "find file by name ('caller')", grep: (root) => grepFiles(root, c.ext, /caller/), vts: (root) => vtsArm(root, c.backend, "find_files", { q: "caller" }, "file") },
+  ];
 }
 
-// ── Report ───────────────────────────────────────────────────────────────────────────────────────
+// ── Sweep (language × size) ──────────────────────────────────────────────────────────────────────────
+const byLang = {}; // lang → { bySize: {n: rows}, syn: {n: {tok,n}}, modeAtMax }
+for (const c of CORPORA) {
+  const scenarios = scenariosFor(c);
+  const bySize = {}, syn = {};
+  for (const n of SIZES) {
+    const root = c.build(n);
+    const rows = [];
+    for (const s of scenarios) {
+      const a = s.grep(root);
+      const b = await s.vts(root);
+      rows.push({ scenario: s.name, grepTok: a.tok, grepLines: a.lines, grepCapped: a.capped, vtsTok: b.tok, vtsMode: b.mode, vtsOk: b.ok, reduction: a.tok > 0 ? 1 - b.tok / a.tok : 0 });
+    }
+    bySize[n] = rows;
+    if (tsAvailable()) syn[n] = await syntacticArm(root, c.sym);
+  }
+  byLang[c.lang] = { bySize, syn, ext: c.ext };
+}
+
+// ── Report ───────────────────────────────────────────────────────────────────────────────────────────
 const totalsFor = (rows) => { const g = rows.reduce((n, r) => n + r.grepTok, 0), v = rows.reduce((n, r) => n + r.vtsTok, 0); return { g, v, red: g > 0 ? 1 - v / g : 0 }; };
+const big = SIZES[SIZES.length - 1];
 
 let md = `# vs-token-safer benchmark — Bash grep vs vts (deterministic, no API)\n\n`;
-md += `Synthetic TypeScript corpus, ${scenarios.length} code-search scenarios, swept across corpus size.\n`;
-md += `Token ≈ bytes ÷ 4 (same as the product ledger). Grep arm = matching \`file:line:text\` (or a path\n`;
-md += `list for file-by-name) capped at ${GREP_LINE_CAP} lines (Claude's Grep tool). vts arm = the\n`;
-md += `token-capped \`file:line\` output. Reproduce: \`npm run bench\`.\n\n`;
+md += `Synthetic corpora in **${CORPORA.length} languages** (${CORPORA.map((c) => c.lang).join(", ")}), `;
+md += `${scenariosFor(CORPORA[0]).length} code-search scenarios each, swept across corpus size. Token ≈ bytes ÷ 4\n`;
+md += `(same as the product ledger). Grep arm = matching \`file:line:text\` (or a path list for file-by-name)\n`;
+md += `capped at ${GREP_LINE_CAP} lines (Claude's Grep tool). vts arm = the token-capped \`file:line\` output.\n`;
+md += `Reproduce: \`npm run bench\`.\n\n`;
 
-md += `## Reduction vs corpus size (the win scales)\n\n`;
-md += `| caller files | grep tokens | vts tokens | reduction |\n|--:|--:|--:|--:|\n`;
-for (const n of SIZES) { const t = totalsFor(bySize[n]); md += `| ${n} | ${t.g} | ${t.v} | **${pct(t.red)}** |\n`; }
-md += `\nGrep grows with the match count; vts stays capped — so the reduction climbs with repo size. On a\n`;
-md += `tiny corpus a narrow text/file search is a wash (vts's header overhead ≈ grep); the semantic\n`;
-md += `scenarios (symbol/refs) win even there because grep over-reports comments/strings/substrings.\n\n`;
-
-const big = SIZES[SIZES.length - 1];
-md += `## Per-scenario at ${big} files\n\n`;
-md += `| Scenario | grep tokens | vts tokens | reduction | vts mode |\n|---|--:|--:|--:|---|\n`;
-for (const r of bySize[big]) {
-  const mode = !r.vtsOk ? "ERROR" : r.vtsMode;
-  md += `| ${r.scenario} | ${r.grepTok}${r.grepCapped ? " (capped)" : ""} | ${r.vtsTok} | **${pct(r.reduction)}** | ${mode} |\n`;
+// 1. Headline: reduction across languages at the largest size — the multi-repo, not-cherry-picked claim.
+md += `## Token reduction across languages (at ${big} files — the not-cherry-picked claim)\n\n`;
+md += `| Language | grep tokens | vts tokens | reduction |\n|---|--:|--:|--:|\n`;
+let aggG = 0, aggV = 0;
+for (const c of CORPORA) {
+  const t = totalsFor(byLang[c.lang].bySize[big]);
+  aggG += t.g; aggV += t.v;
+  md += `| ${c.lang} | ${t.g} | ${t.v} | **${pct(t.red)}** |\n`;
 }
-const bt = totalsFor(bySize[big]);
-md += `| **TOTAL** | **${bt.g}** | **${bt.v}** | **${pct(bt.red)}** | |\n\n`;
+md += `| **All languages** | **${aggG}** | **${aggV}** | **${pct(aggG > 0 ? 1 - aggV / aggG : 0)}** |\n\n`;
+md += `The win holds across languages vts has a language server for (TypeScript, Python — the SEMANTIC tier)\n`;
+md += `and one it has no wired backend for (Go — tree-sitter answers symbol queries and a bounded literal scan\n`;
+md += `answers references, the SYNTACTIC tier). Same token-capped shape either way. Which tier actually answered\n`;
+md += `each scenario on THIS run (it degrades to syntactic/text-fallback when a language server isn't installed)\n`;
+md += `is shown in the per-scenario tables below — the token reduction itself is deterministic regardless.\n\n`;
 
-// Zero-setup tier: the answer to "why are tree-sitter/embedding tools popular?" — they need no toolchain.
-// vts now matches that (tree-sitter syntactic tier) AND keeps a semantic tier above it. This table shows the
-// symbol-declaration query three ways: grep (baseline), tree-sitter (ZERO setup — our fallback), LSP (semantic).
-if (Object.keys(synBySize).length) {
-  md += `## Zero-setup symbol search: grep vs tree-sitter (no toolchain) vs LSP\n\n`;
+// 2. Per-language reduction vs size (the win scales, in every language).
+md += `## Reduction vs corpus size, per language (the win scales)\n\n`;
+for (const c of CORPORA) {
+  md += `### ${c.lang}\n\n| caller files | grep tokens | vts tokens | reduction |\n|--:|--:|--:|--:|\n`;
+  for (const n of SIZES) { const t = totalsFor(byLang[c.lang].bySize[n]); md += `| ${n} | ${t.g} | ${t.v} | **${pct(t.red)}** |\n`; }
+  md += `\n`;
+}
+md += `Grep grows with the match count; vts stays capped — so the reduction climbs with repo size in every\n`;
+md += `language. On a tiny corpus a narrow text/file search is a wash (vts's header overhead ≈ grep); the\n`;
+md += `semantic scenarios (symbol/refs) win even there because grep over-reports comments/strings/qualified calls.\n\n`;
+
+// 3. Per-scenario detail at max, per language.
+md += `## Per-scenario at ${big} files, per language\n\n`;
+for (const c of CORPORA) {
+  md += `### ${c.lang}\n\n| Scenario | grep tokens | vts tokens | reduction | vts mode |\n|---|--:|--:|--:|---|\n`;
+  for (const r of byLang[c.lang].bySize[big]) {
+    const mode = !r.vtsOk ? "ERROR" : r.vtsMode;
+    md += `| ${r.scenario} | ${r.grepTok}${r.grepCapped ? " (capped)" : ""} | ${r.vtsTok} | **${pct(r.reduction)}** | ${mode} |\n`;
+  }
+  const bt = totalsFor(byLang[c.lang].bySize[big]);
+  md += `| **TOTAL** | **${bt.g}** | **${bt.v}** | **${pct(bt.red)}** | |\n\n`;
+}
+
+// 4. Zero-setup tier across languages: grep vs tree-sitter (no toolchain) vs LSP — the competitors' home turf.
+const synLangs = CORPORA.filter((c) => Object.keys(byLang[c.lang].syn).length);
+if (synLangs.length) {
+  md += `## Zero-setup symbol search: grep vs tree-sitter (no toolchain) vs vts tier, per language\n\n`;
   md += `The tree-sitter tier needs NO compile DB / language server — it indexes 36 languages instantly — yet\n`;
   md += `returns the same token-capped \`file:line\` shape, so toolchain-free costs no more tokens than semantic.\n\n`;
-  md += `| caller files | grep tokens | tree-sitter (no setup) | LSP (semantic) | grep→tree-sitter |\n|--:|--:|--:|--:|--:|\n`;
-  for (const n of SIZES) {
-    const syn = synBySize[n]; if (!syn) continue;
-    const g = bySize[n][0].grepTok, v = bySize[n][0].vtsTok;
-    md += `| ${n} | ${g} | ${syn.tok} | ${v} | **${pct(g > 0 ? 1 - syn.tok / g : 0)}** |\n`;
+  md += `| Language | caller files | grep tokens | tree-sitter (no setup) | vts tier | grep→tree-sitter |\n|---|--:|--:|--:|--:|--:|\n`;
+  for (const c of synLangs) {
+    for (const n of SIZES) {
+      const syn = byLang[c.lang].syn[n]; if (!syn) continue;
+      const g = byLang[c.lang].bySize[n][0].grepTok, v = byLang[c.lang].bySize[n][0].vtsTok;
+      md += `| ${c.lang} | ${n} | ${g} | ${syn.tok} | ${v} | **${pct(g > 0 ? 1 - syn.tok / g : 0)}** |\n`;
+    }
   }
   md += `\nBoth vts tiers stay flat while grep grows; the tree-sitter tier is the cold-start / no-toolchain path,\n`;
   md += `the LSP tier adds reference/overload/type resolution on top. Build a committable index with \`vts index\`.\n\n`;
 }
 
-md += `## Cost per model at ${big} files (token delta × input price)\n\n`;
+// 5. Cost per model on the all-language aggregate at max size.
+md += `## Cost per model at ${big} files, all languages (token delta × input price)\n\n`;
 md += `Saved = (grep − vts) input tokens × list input price. List prices, verify at anthropic.com/pricing.\n\n`;
 md += `| Model | $/Mtok (in) | grep cost | vts cost | saved | cheaper |\n|---|--:|--:|--:|--:|--:|\n`;
+const aggRed = aggG > 0 ? 1 - aggV / aggG : 0;
 const costRows = [];
 for (const [model, price] of Object.entries(PRICES)) {
-  const gc = (bt.g / 1e6) * price, vc = (bt.v / 1e6) * price;
+  const gc = (aggG / 1e6) * price, vc = (aggV / 1e6) * price;
   costRows.push({ model, price, grepCost: gc, vtsCost: vc, saved: gc - vc });
-  md += `| ${model} | $${price.toFixed(2)} | $${gc.toFixed(6)} | $${vc.toFixed(6)} | $${(gc - vc).toFixed(6)} | ${pct(bt.red)} |\n`;
+  md += `| ${model} | $${price.toFixed(2)} | $${gc.toFixed(6)} | $${vc.toFixed(6)} | $${(gc - vc).toFixed(6)} | ${pct(aggRed)} |\n`;
 }
 md += `\n> Absolute $ per query is tiny — the win compounds across the many searches in a real session and\n`;
 md += `> grows with repo size. On a real Unreal Engine project the same A/B is ~282k → ~2k tokens (~138×);\n`;
@@ -212,7 +319,12 @@ md += `> see BENCHMARK.md.\n`;
 
 console.log(md);
 
-const results = { generatedBy: "benchmarks/run.mjs", tokenEstimate: "bytes/4", grepLineCap: GREP_LINE_CAP, sizes: SIZES, bySize, syntacticBySize: synBySize, costAtMax: { files: big, rows: costRows }, prices: PRICES };
+const results = {
+  generatedBy: "benchmarks/run.mjs", tokenEstimate: "bytes/4", grepLineCap: GREP_LINE_CAP, sizes: SIZES,
+  languages: CORPORA.map((c) => c.lang), byLang,
+  aggregateAtMax: { files: big, grepTok: aggG, vtsTok: aggV, reduction: aggRed },
+  costAtMax: { files: big, rows: costRows }, prices: PRICES,
+};
 const outDir = path.join(path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1")), "results");
 fs.mkdirSync(outDir, { recursive: true });
 fs.writeFileSync(path.join(outDir, "latest.json"), JSON.stringify(results, null, 2) + "\n");
@@ -222,7 +334,8 @@ await disposeClients();
 try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* ignore */ }
 
 // Non-fatal sanity: the largest corpus should show a solid overall reduction and no errored scenario.
-const errored = bySize[big].filter((r) => !r.vtsOk);
-if (errored.length) { console.error(`\n[warn] ${errored.length} scenario(s) errored at ${big} files — is the typescript backend installed?`); for (const r of errored) console.error(`  - ${r.scenario}`); }
-else if (bt.red < 0.5) console.error(`\n[warn] overall reduction at ${big} files is ${pct(bt.red)} (<50%) — unexpected; check the backend resolved semantic results.`);
+let errored = 0;
+for (const c of CORPORA) errored += byLang[c.lang].bySize[big].filter((r) => !r.vtsOk).length;
+if (errored) console.error(`\n[warn] ${errored} scenario(s) errored at ${big} files — is a backend installed? (token delta is still valid; tiers degrade to text-fallback)`);
+else if (aggRed < 0.5) console.error(`\n[warn] all-language reduction at ${big} files is ${pct(aggRed)} (<50%) — unexpected; check the backends resolved.`);
 console.log(`\nResults written to benchmarks/results/latest.{json,md}. Reproduce: npm run bench`);

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1815,7 +1815,17 @@ if (tsAvailable()) {
   const tsRefs = await tsSearchReferences(tsDir, "buildWidgetTree", { skipDir: (n) => SKIP.has(n) });
   const refOk = pyRefs.some((r) => /d\.py$/.test(r.file) && r.line === 3) && !pyRefs.some((r) => /c\.py$/.test(r.file)) // the def is not a ref
     && tsRefs.some((r) => /e\.ts$/.test(r.file) && r.line === 2);
-  tsTierOk = fileExtractOk && searchOk && rankOk && idxPresent && idxLoadOk && idxSearchOk && refOk;
+  // (e) NO-BACKEND find_references tool path: a Go repo (vts has no wired Go backend) must NOT hard-error on
+  // getClient — it falls to the SYNTACTIC tree-sitter call-reference tier (the search_symbol no-backend parity
+  // for references). Go has no entry in pickBackend's detect order, so backendName is falsy here.
+  const goDir = path.join(os.tmpdir(), `vts-eval-${process.pid}-gonobe`);
+  fs.mkdirSync(goDir, { recursive: true });
+  fs.writeFileSync(path.join(goDir, "go.mod"), "module nobe\n\ngo 1.21\n");
+  fs.writeFileSync(path.join(goDir, "pay.go"), "package pay\nfunc ProcessPayment(n int) bool { return n > 0 }\nfunc Run() { ok := ProcessPayment(3); _ = ok }\n");
+  const goRefs = await runTool("find_references", { symbol: "ProcessPayment", projectPath: goDir });
+  const noBackendRefOk = !goRefs.isError && /tree-sitter call reference/.test(goRefs.text) && /pay\.go:3/.test(goRefs.text) && !/pay\.go:2\b/.test(goRefs.text); // call site captured, decl line is not a ref
+  try { fs.rmSync(goDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  tsTierOk = fileExtractOk && searchOk && rankOk && idxPresent && idxLoadOk && idxSearchOk && refOk && noBackendRefOk;
   try { fs.rmSync(tsDir, { recursive: true, force: true }); } catch { /* ignore */ }
 } else {
   console.log("  (tree-sitter deps absent — syntactic tier guard skipped, treated as pass)");

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1781,7 +1781,7 @@ const policyOk = supGen && supDotGen && supNodeMod && supReal && supOff && digOk
 // 81) SYNTACTIC tier: tree-sitter declaration extraction (treesitter.js) + the committable symbol index
 // (symindex.js). The zero-setup fallback that works on any repo with no toolchain — a real AST decl, not a
 // literal usage grep. Skips gracefully if the optional tree-sitter deps aren't installed (CI without them).
-const { tsFileSymbols, tsSearchSymbols, tsSearchReferences, tsAvailable } = await import("../server/treesitter.js");
+const { tsFileSymbols, tsFileReferences, tsSearchSymbols, tsSearchReferences, tsAvailable } = await import("../server/treesitter.js");
 const { buildSymIndex, loadSymIndex, searchSymIndex, hasSymIndex } = await import("../server/symindex.js");
 let tsTierOk = true;
 if (tsAvailable()) {
@@ -1825,7 +1825,16 @@ if (tsAvailable()) {
   const goRefs = await runTool("find_references", { symbol: "ProcessPayment", projectPath: goDir });
   const noBackendRefOk = !goRefs.isError && /tree-sitter call reference/.test(goRefs.text) && /pay\.go:3/.test(goRefs.text) && !/pay\.go:2\b/.test(goRefs.text); // call site captured, decl line is not a ref
   try { fs.rmSync(goDir, { recursive: true, force: true }); } catch { /* ignore */ }
-  tsTierOk = fileExtractOk && searchOk && rankOk && idxPresent && idxLoadOk && idxSearchOk && refOk && noBackendRefOk;
+  // (f) TAGS-QUERY tier: canonical .scm extraction (server/tags/<grammar>.scm) for a language with NO
+  // hand-tuned node config — the file-driven mechanism that extends the syntactic rung past the flagship
+  // languages (php/swift/kotlin/scala/dart/zig/bash). Proves a tags.scm yields real defs + a call ref.
+  fs.writeFileSync(path.join(tsDir, "sub", "f.php"), "<?php\nfunction greetUser($n){ return $n; }\nclass AccountWidget { function build(){} }\ngreetUser(1);\n");
+  const phpSyms = await tsFileSymbols(path.join(tsDir, "sub", "f.php"));
+  const phpRefs = await tsFileReferences(path.join(tsDir, "sub", "f.php"), "greetUser");
+  const tagsTierOk = phpSyms.some((s) => s.name === "greetUser" && s.kind === "func")
+    && phpSyms.some((s) => s.name === "AccountWidget" && s.kind === "class")
+    && phpRefs.some((r) => r.line === 4) && !phpRefs.some((r) => r.line === 2); // call site, not the decl
+  tsTierOk = fileExtractOk && searchOk && rankOk && idxPresent && idxLoadOk && idxSearchOk && refOk && noBackendRefOk && tagsTierOk;
   try { fs.rmSync(tsDir, { recursive: true, force: true }); } catch { /* ignore */ }
 } else {
   console.log("  (tree-sitter deps absent — syntactic tier guard skipped, treated as pass)");

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -846,8 +846,8 @@ const hKoBlock = runHook({ tool_name: "Bash", tool_input: { command: "grep -rn F
 const hKoNudge = runHook({ tool_name: "Grep", tool_input: { pattern: "Foo", glob: "*.ts" } }, { VTS_LANG: "ko" }).err; // identifier → blocked; KO nudge is in the block stderr
 const hEnBlock = runHook({ tool_name: "Bash", tool_input: { command: "grep -rn Foo src/Thing.cpp" } }, { VTS_REWRITE: "0", VTS_LANG: "en" });
 const i18nOk =
-  hKoBlock.status === 2 && /코드 검색을 가로챘어요/.test(hKoBlock.err) && /find_references symbol="Foo"/.test(hKoNudge) &&
-  /Grep 툴로 코드 검색/.test(hKoNudge) &&
+  hKoBlock.status === 2 && /코드검색 가로챔/.test(hKoBlock.err) && /find_references symbol="Foo"/.test(hKoNudge) &&
+  /심볼검색 가로챔/.test(hKoNudge) && // identifier Grep → symbol-hunt block, KO
   hEnBlock.status === 2 && /caught a code search/.test(hEnBlock.err); // en explicit still English
 
 // 45) backend pool lifecycle (memory guard): the live language-server pool is BOUNDED so a session that
@@ -978,7 +978,7 @@ const hKwAlt = runHook({ tool_name: "Grep", tool_input: { pattern: "GET|POST|HEA
 const hSymOff = runHook({ tool_name: "Grep", tool_input: { pattern: "void.*FooWidget\\(", path: "src/lib" } }, { VTS_GREP_BLOCK: "0" });
 const hSymDoc = runHook({ tool_name: "Grep", tool_input: { pattern: "FooWidget", glob: "*.md" } });
 const enforceV2Ok =
-  hSymHunt.status === 2 && /search_text q="/.test(hSymHunt.err) && /caught a SYMBOL/.test(hSymHunt.err) && // structural-cue regex → block
+  hSymHunt.status === 2 && /search_text q="/.test(hSymHunt.err) && /caught a symbol search/.test(hSymHunt.err) && // structural-cue regex → block
   hIdentBlk.status === 2 && /find_references symbol="FooWidget"/.test(hIdentBlk.err) &&                    // bare identifier → block
   hCamelAlt.status === 2 && /search_text q="/.test(hCamelAlt.err) &&                                       // CamelCase alternation → block (v2.1)
   hFreeform.status === 0 && hKwAlt.status === 0 &&     // keyword alternations (no CamelCase) → NOT blocked (warn)

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1834,7 +1834,22 @@ if (tsAvailable()) {
   const tagsTierOk = phpSyms.some((s) => s.name === "greetUser" && s.kind === "func")
     && phpSyms.some((s) => s.name === "AccountWidget" && s.kind === "class")
     && phpRefs.some((r) => r.line === 4) && !phpRefs.some((r) => r.line === 2); // call site, not the decl
-  tsTierOk = fileExtractOk && searchOk && rankOk && idxPresent && idxLoadOk && idxSearchOk && refOk && noBackendRefOk && tagsTierOk;
+  // (g) INCREMENTAL .vts-index: a rebuild with no changes REUSES every file (no re-parse); after a single
+  // file's content changes, only that file re-parses (mtime+size fast-path → fnv1a content hash). The
+  // cold→warm rebuild win — `vts index` after editing a few files re-parses only those, not the whole tree.
+  const incrDir = path.join(os.tmpdir(), `vts-eval-${process.pid}-incr`);
+  fs.mkdirSync(incrDir, { recursive: true });
+  fs.writeFileSync(path.join(incrDir, "x.ts"), "export function alphaFn(){ return 1; }\n");
+  fs.writeFileSync(path.join(incrDir, "y.ts"), "export class BetaClass {}\n");
+  const ib1 = await buildSymIndex(incrDir, { skipDir: (n) => SKIP.has(n), now: 1 });
+  const ib2 = await buildSymIndex(incrDir, { skipDir: (n) => SKIP.has(n), now: 2 }); // no change → all reused
+  fs.writeFileSync(path.join(incrDir, "y.ts"), "export class BetaClass {}\nexport function gammaFn(){ return 2; }\n"); // size changes → stat differs
+  const ib3 = await buildSymIndex(incrDir, { skipDir: (n) => SKIP.has(n), now: 3 }); // y.ts changed → 1 re-parse, x.ts reused
+  const incrHit = searchSymIndex(incrDir, "gammaFn");
+  const incrOk = ib1.reparsed === 2 && ib1.reused === 0 && ib2.reparsed === 0 && ib2.reused === 2
+    && ib3.reparsed === 1 && ib3.reused === 1 && !!(incrHit && incrHit.length);
+  try { fs.rmSync(incrDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  tsTierOk = fileExtractOk && searchOk && rankOk && idxPresent && idxLoadOk && idxSearchOk && refOk && noBackendRefOk && tagsTierOk && incrOk;
   try { fs.rmSync(tsDir, { recursive: true, force: true }); } catch { /* ignore */ }
 } else {
   console.log("  (tree-sitter deps absent — syntactic tier guard skipped, treated as pass)");

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -415,17 +415,16 @@ function notTextLogTarget(ti) {
 }
 // Block default-ON; VTS_GREP_BLOCK=0/false/off reverts the symbol-hunt escalation to warn-only.
 const grepBlockOn = () => !/^(0|false|off|no)$/i.test(String(process.env.VTS_GREP_BLOCK ?? "1"));
-// Reassuring block copy for a symbol-hunt Grep — leads with the win (tokens + accuracy), frames the red box
-// as a friendly "hold on", and embeds the READY-TO-USE search_symbol/search_text call (grepNudgeFor).
+// Truncate a caught pattern/command for display (the "what was intercepted" line).
+const clip = (s, n = 56) => { s = String(s).replace(/\s+/g, " ").trim(); return s.length > n ? s.slice(0, n) + "…" : s; };
+// Concise block copy for a symbol-hunt Grep: what was caught · the ready semantic call · the win · opt-out.
 function grepBlockMsg(ti) {
-  const head = KO
-    ? "✨ vs-token-safer가 심볼 검색을 가로챘어요 — 고장이 아니라 의도된 동작이고, 토큰 절약 + 정확도↑입니다. 🎉\n" +
-      "(빨간 박스는 훅이 \"잠깐\"이라고 말하는 신호일 뿐, 실패가 아니에요.)\n" +
-      "이 패턴은 '심볼 사냥'이라 시맨틱 도구가 더 작고 정확합니다 (정규식 거짓양성 없음 — `void.*Foo\\(`는 `SetActiveFoo`도 긁어요):\n"
-    : "✨ vs-token-safer caught a SYMBOL search — intended, not broken; it saves tokens AND improves accuracy. 🎉\n" +
-      "(The red box is just the hook saying \"hold on\" — not a failure.)\n" +
-      "This pattern is a symbol hunt → a semantic tool is smaller + exact (no regex false positives — `void.*Foo\\(` also catches `SetActiveFoo`):\n";
-  return head + grepNudgeFor(ti) + (KO ? "\nwarn-only로 되돌리려면: VTS_GREP_BLOCK=0." : "\nPrefer warn-only? VTS_GREP_BLOCK=0.");
+  const pat = String(ti.pattern || "");
+  const ident = /^[A-Za-z_][A-Za-z0-9_]*$/.test(pat);
+  const call = ident ? `find_references symbol="${pat}" / search_symbol q="${pat}"` : `search_text q="${clip(pat, 40)}"`;
+  return KO
+    ? `✨ vs-token-safer: 심볼검색 가로챔 (토큰↓·정확도↑) — /${clip(pat)}/\n→ ${call} — 시맨틱, file:line, 보통 ~90%↓ (정규식 거짓양성 없음). warn전환: VTS_GREP_BLOCK=0`
+    : `✨ vs-token-safer: caught a symbol search (fewer tokens, exact) — /${clip(pat)}/\n→ ${call} — semantic, file:line, ~90% smaller (no regex false positives). Warn-only: VTS_GREP_BLOCK=0`;
 }
 // Glob / Search TOOL — the built-in filename search. vts's find_files is the token-capped, walk-bounded
 // equivalent (skips Intermediate/Binaries/node_modules, time-boxed) — the built-in Glob has no result cap
@@ -480,14 +479,8 @@ function globBlockMsg(ti) {
   const hint = globRootHint(ti);
   const call = `find_files q="${base}"${hint ? ` projectPath="${hint}"` : ""}`;
   return KO
-    ? "✨ vs-token-safer가 파일명 검색을 가로챘어요 — 고장이 아니라 의도된 동작이고, 거대 트리 타임아웃을 막아줍니다. 🎉\n" +
-      "(빨간 박스는 \"잠깐\"의 신호일 뿐, 실패가 아니에요.) find_files는 walk-bound(Intermediate/Binaries/node_modules " +
-      "스킵 + 시간박스)라 UE 트리에서도 안 멈춰요.\n어시스턴트는 이렇게 다시 실행하세요: " + call +
-      " (루트를 좁힐수록 빠름). 끄기: VTS_GREP_BLOCK=0 / VTS_ENFORCE=0."
-    : "✨ vs-token-safer caught a filename search — intended, not broken; it avoids a giant-tree timeout. 🎉\n" +
-      "(The red box is just a \"hold on\", not a failure.) find_files is walk-bounded (skips Intermediate/Binaries/" +
-      "node_modules + time-boxed) so it won't hang on a UE tree.\nAssistant: re-run as: " + call +
-      " (narrow the root for speed). Disable: VTS_GREP_BLOCK=0 / VTS_ENFORCE=0.";
+    ? `✨ vs-token-safer: 파일명검색 가로챔 (거대 트리 타임아웃 방지) — \`${clip(ti.pattern)}\`\n→ ${call} — walk-bound(Intermediate/Binaries/node_modules 스킵)·토큰캡. warn전환: VTS_GREP_BLOCK=0`
+    : `✨ vs-token-safer: caught a filename search (avoids giant-tree timeout) — \`${clip(ti.pattern)}\`\n→ ${call} — walk-bounded (skips Intermediate/Binaries/node_modules), token-capped. Warn-only: VTS_GREP_BLOCK=0`;
 }
 const LOG_NUDGE = KO
   ? "[vs-token-safer] 이 검색은 LOG가 대상입니다. 언어 서버 인덱스는 소스 코드만 다뤄요 — 로그 분석은 grep 대신 " +
@@ -496,37 +489,25 @@ const LOG_NUDGE = KO
     "analysis use gamedev-log (/gamedev-log-analyzer:logs, or the gamedev-log CLI: summary / search / locate " +
     "/ fields / diff) instead of grep. Disable: VTS_ENFORCE=0.";
 
-const BLOCK_MSG = KO
-  ? "✨ vs-token-safer가 코드 검색을 가로챘어요 — 고장난 게 아니라 의도된 동작이고, 토큰을 왕창 아꼈습니다. 🎉\n" +
-    "(빨간 박스는 훅이 \"잠깐\"이라고 말하는 유일한 방법이에요 — 실패가 아니라 친절한 안내입니다.)\n" +
-    "같은 검색을 언어 서버 인덱스로 하면 file:line으로 토큰캡되어 보통 ~90% 작고(큰 repo면 20~60배),\n" +
-    "grep의 거짓 양성(주석·문자열·유사명)도 없습니다. 어시스턴트는 이 검색을 의도에 맞는 vts 도구로 다시 실행하세요:\n" +
-    "  - 심볼 / 클래스 / 함수 / 타입   → search_symbol   (q, projectPath, backend, maxResults)\n" +
-    "  - 참조 / 사용처                 → find_references (symbol — 이름만; 코드수정 primitive)\n" +
-    "  - 정의로 이동                   → goto_definition (path, line, character — 0-based)\n" +
-    "  - 원시 텍스트 / 문자열 / 주석   → search_text     (q, projectPath) — 토큰캡 grep\n" +
-    "  - 파일명 검색                   → find_files      (q, projectPath) — glob 또는 부분일치\n" +
-    "또는 컨텍스트 격리 `code-locator` 서브에이전트에 위임할 수 있습니다.\n" +
-    "CLI(비-MCP): `vts symbol --q <이름> --projectPath <루트>` (vts text / files / hover 도).\n" +
-    "백엔드는 루트에서 자동 감지(compile_commands.json→clangd, .sln/.csproj→roslyn, tsconfig/package.json→typescript, pyproject/*.py→pyright).\n" +
-    "팁: 단순한 grep 하나는 자동 변환됩니다(빨간 박스 없음) — 이번 건 여러 부분이라 차단됐으니 위 중 하나를 실행하세요. " +
-    "로그/설정 텍스트는 비코드 파일이나 gamedev-log로. 끄기: VTS_ENFORCE=0."
-  : "✨ vs-token-safer caught a code search before it flooded your context — nothing broke, this is on\n" +
-    "purpose, and it just saved you a pile of tokens. 🎉 (A red box is the only way a hook can say\n" +
-    "\"hold on\" — it's a friendly redirect, not a failure.) The very same lookup through the language-server\n" +
-    "index comes back token-capped to file:line, usually ~90% smaller (often 20–60× on a big repo), and\n" +
-    "WITHOUT grep's false positives. The assistant should re-run this lookup with the vts tool matching the intent:\n" +
-    "  - symbol / class / function / type → search_symbol  (args: q, projectPath, backend, maxResults)\n" +
-    "  - references / usages of a symbol  → find_references (args: symbol — just the name; the edit primitive)\n" +
-    "  - definition of a symbol           → goto_definition (args: path, line, character — 0-based)\n" +
-    "  - raw text / string / comment      → search_text     (args: q, projectPath) — token-capped grep\n" +
-    "  - file by name                     → find_files      (args: q, projectPath) — glob or substring\n" +
-    "Or delegate the whole lookup to the context-isolated `code-locator` subagent.\n" +
-    "CLI alternative (no MCP): `vts symbol --q <name> --projectPath <root>` (also: vts text / files / hover).\n" +
-    "Backend auto-detects from the root (compile_commands.json → clangd, .sln/.csproj → roslyn,\n" +
-    "tsconfig/package.json → typescript, pyproject.toml/*.py → pyright).\n" +
-    "Tip: a SINGLE simple grep is auto-rewritten for you (no red box at all) — this one had several parts,\n" +
-    "so just run one of the above. Logs/config text → target a non-code file or gamedev-log. Opt out anytime: VTS_ENFORCE=0.";
+// Concise block copy for a Bash code-grep that couldn't be safely auto-rewritten (a pipeline / complex
+// pattern). Shows: what was intercepted · the equivalent vts call (best-effort from the first code segment)
+// · the typical token win · opt-out. Multi-part commands fall to a short tool list when no single call fits.
+function suggestCallFor(seg) {
+  const exec = execOf(seg);
+  if (exec === "find") { const g = extractFindName(seg); return g ? `find_files q="${g}"` : null; }
+  const pat = extractGrepPattern(seg, exec === "git");
+  if (!pat) return null;
+  if (IDENT.test(pat)) return `search_symbol q="${pat}" (or find_references symbol="${pat}")`;
+  return `search_text q="${clip(pat, 40)}"`;
+}
+function blockMsg(codeSegs) {
+  const seg = codeSegs[0] || "";
+  const call = suggestCallFor(seg) || "search_symbol / search_text / find_files";
+  const caught = clip(seg);
+  return KO
+    ? `✨ vs-token-safer: 코드검색 가로챔 (토큰 절약) — \`${caught}\`\n→ ${call} — file:line로 토큰캡, 보통 ~90%↓ (큰 repo면 20~60×), grep 거짓양성 없음.\n단일 grep은 자동 변환됨(이 건 멀티세그먼트라 차단). 끄기: VTS_ENFORCE=0`
+    : `✨ vs-token-safer: caught a code search (saves tokens) — \`${caught}\`\n→ ${call} — token-capped to file:line, ~90% smaller (20–60× on a big repo), no grep false positives.\nA single grep auto-rewrites (this was multi-segment). Disable: VTS_ENFORCE=0`;
+}
 
 let input = "";
 process.stdin.on("data", (d) => (input += d));
@@ -636,9 +617,9 @@ process.stdin.on("end", () => {
           permissionDecision: "allow",
           permissionDecisionReason: `Rerouted ${v.bin} ${v.sub} → vts ${v.tool} (output grouped/deduped/token-capped).`,
           updatedInput: { ...ti, command: v.cmd },
-          additionalContext:
-            `[vs-token-safer] Compacted \`${v.bin} ${v.sub}\` output (grouped/deduped/capped) to save tokens. ` +
-            `Disable VCS compaction: VTS_COMPACT_VCS=0. Disable all rewrites: VTS_REWRITE=0.`,
+          additionalContext: KO
+            ? `[vs-token-safer] \`${v.bin} ${v.sub}\` → vts ${v.tool}: 출력 그룹/dedup/토큰캡으로 절약. 끄기: VTS_COMPACT_VCS=0.`
+            : `[vs-token-safer] \`${v.bin} ${v.sub}\` → vts ${v.tool}: output grouped/deduped/capped to save tokens. Disable: VTS_COMPACT_VCS=0.`,
         },
       }) + "\n");
       process.exit(0);
@@ -662,16 +643,15 @@ process.stdin.on("end", () => {
             permissionDecision: "allow",
             permissionDecisionReason: `Rerouted code search → vts ${rw.tool} (language-server-grade, token-capped to file:line).`,
             updatedInput: { ...ti, command: rw.cmd },
-            additionalContext:
-              `[vs-token-safer] Rewrote your search → \`vts ${rw.tool}\` (q="${rw.q}"), token-capped to file:line. ` +
-              `For SYMBOLS (class/function/type) prefer the vs-search MCP search_symbol — semantic, not text. ` +
-              `Disable rewrite: VTS_REWRITE=0 (then it blocks instead). Disable entirely: VTS_ENFORCE=0.`,
+            additionalContext: KO
+              ? `[vs-token-safer] grep → vts ${rw.tool} q="${rw.q}" — file:line 토큰캡(보통 ~90%↓). 심볼이면 search_symbol(시맨틱) 권장. 끄기: VTS_REWRITE=0.`
+              : `[vs-token-safer] grep → vts ${rw.tool} q="${rw.q}" — token-capped file:line (~90% smaller). For symbols prefer search_symbol (semantic). Disable: VTS_REWRITE=0.`,
           },
         }) + "\n");
         process.exit(0);
       }
     }
-    process.stderr.write(BLOCK_MSG + setup + "\n");
+    process.stderr.write(blockMsg(codeSegs) + setup + "\n");
     process.exit(2); // block
   }
   // Docs/text grep with an explicit file target (not code, not log) → reroute to `vts text --path <file>`,
@@ -685,9 +665,9 @@ process.stdin.on("end", () => {
           permissionDecision: "allow",
           permissionDecisionReason: `Rerouted docs/text grep → vts search_text scoped to ${dr.file} (token-capped).`,
           updatedInput: { ...ti, command: dr.cmd },
-          additionalContext:
-            `[vs-token-safer] Rewrote your grep over ${dr.file} → \`vts text --path ${dr.file}\` (q="${dr.q}"), ` +
-            `token-capped — search_text path= auto-includes that file's extension. Disable: VTS_REWRITE=0 / VTS_ENFORCE=0.`,
+          additionalContext: KO
+            ? `[vs-token-safer] grep ${dr.file} → vts text --path ${dr.file} (q="${dr.q}") — 토큰캡. 끄기: VTS_REWRITE=0.`
+            : `[vs-token-safer] grep ${dr.file} → vts text --path ${dr.file} (q="${dr.q}") — token-capped. Disable: VTS_REWRITE=0.`,
         },
       }) + "\n");
       process.exit(0);

--- a/server/core.js
+++ b/server/core.js
@@ -1905,7 +1905,9 @@ export async function runTool(name, a = {}) {
       const t0 = Date.now();
       const r = await buildSymIndex(root, { skipDir, inScope: within, now: Date.now() });
       const scopeNote = dirs.length ? ` (scope: ${dirs.length} dir(s))` : "";
-      return out(`Built committable symbol index${scopeNote}: ${r.symbols} symbol(s) over ${r.files} file(s) → ${r.path} in ${((Date.now() - t0) / 1000).toFixed(1)}s.${r.partial ? " (PARTIAL — time-boxed; raise VTS via a narrower scope or rerun.)" : ""}\n  Commit .vts-index/ to share it / speed teammates' cold starts. It answers search_symbol instantly until a language server indexes (which then supersedes it).`);
+      // Incremental note: how many files were reused (no re-parse) vs re-parsed this run — the cold→warm win.
+      const incrNote = r.reparsed != null && (r.reused || r.reparsed) ? ` [incremental: re-parsed ${r.reparsed}, reused ${r.reused} unchanged]` : "";
+      return out(`Built committable symbol index${scopeNote}: ${r.symbols} symbol(s) over ${r.files} file(s) → ${r.path} in ${((Date.now() - t0) / 1000).toFixed(1)}s${incrNote}.${r.partial ? " (PARTIAL — time-boxed; raise VTS via a narrower scope or rerun.)" : ""}\n  Commit .vts-index/ to share it / speed teammates' cold starts. It answers search_symbol instantly until a language server indexes (which then supersedes it).`);
     }
     if (name === "vts_gen_compile_db") {
       // The user's choice: run UBT GenerateClangDatabase for full semantic clangd, OR don't and stay in

--- a/server/core.js
+++ b/server/core.js
@@ -2150,6 +2150,24 @@ export async function runTool(name, a = {}) {
       if (hits.length) return finishOut(hits, `No language-server backend resolved for ${root} — literal text matches for "${a.q}" (file:line, not a semantic decl):\n` + hits.join("\n"));
       return finishOut([], `No backend resolved and no text match for "${a.q}" under ${root}.` + EMPTY_HINT);
     }
+    // find_references with NO backend (a Go/Rust/… repo we have no language server for): the SYNTACTIC
+    // reference fallback (tree-sitter call sites, then a literal scan) — the SAME tier search_symbol uses
+    // above. Without this, getClient(root, null) hard-errors before the by-name fallback inside the handler
+    // can run, so find_references-by-name dead-ends on a toolchain-less repo (live-found on a Go corpus).
+    if (!backendName && name === "find_references") {
+      if (!a.symbol) return err("find_references needs `symbol` (a name) when no language-server backend is available — a position query (path/line/character) requires a backend.");
+      const want = String(a.symbol);
+      const fmax = Number(a.maxResults) || MAX_RESULTS;
+      const tsRefs = await tsSearchReferences(root, want, { skipDir });
+      if (tsRefs && tsRefs.length) {
+        const refLines = tsRefs.map((r) => `${r.file}:${r.line}`);
+        const body = compactResults() ? compactLocationLines(refLines) : refLines.join("\n");
+        return finishOut(refLines, `No language-server backend for ${root} — ${tsRefs.length} tree-sitter call reference(s) for "${want}" (syntactic, file:line; not semantic — a language server resolves which overload/scope):\n` + body + completenessCert({ shown: refLines.length, total: tsRefs.length, truncated: tsRefs.truncated, syntactic: true }));
+      }
+      const hits = scanTextUnder(root, want, fmax);
+      if (hits.length) return finishOut(hits, `No language-server backend for ${root} — literal usage matches for "${want}" (file:line of the name, not semantic references):\n` + hits.join("\n"));
+      return finishOut([], `No backend resolved and no tree-sitter/text reference for "${want}" under ${root}.` + EMPTY_HINT);
+    }
     if (!backendName) return err(`No backend resolved. Pass backend=clangd|roslyn|typescript|pyright, set VTS_BACKEND, or ensure the project root has compile_commands.json (C++), a .sln/.csproj (C#), a tsconfig/package.json (JS/TS), or a pyproject.toml/*.py (Python).`);
     const max = Number(a.maxResults) || MAX_RESULTS;
     const lang = langIdForPath(a.path, backendName); // languageId for didOpen (hover/document_symbols/rename); unused by search_symbol

--- a/server/package.json
+++ b/server/package.json
@@ -53,7 +53,8 @@
     "concept.js",
     "textstruct.js",
     "ensure-deps.mjs",
-    "backends/"
+    "backends/",
+    "tags/"
   ],
   "scripts": {
     "start": "node index.js",

--- a/server/symindex.js
+++ b/server/symindex.js
@@ -13,6 +13,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { tsFileSymbols, tsSupports } from "./treesitter.js";
+import { fnv1a } from "./warmset.js";
 
 const DIR = ".vts-index";
 const FILE = "symbols.jsonl";
@@ -34,19 +35,35 @@ export function hasSymIndex(root) {
 
 // Build the index by walking `root` (bounded to `dirs` when scope is set) and tree-sitter-extracting every
 // supported file. skipDir(name)→true prunes a directory (node_modules/build/… — shared with scanTextUnder).
-// inScope(absPath)→bool optionally filters to the configured indexing scope. Returns { files, symbols, path }.
+// inScope(absPath)→bool optionally filters to the configured indexing scope.
+//
+// INCREMENTAL (default): the header carries a per-file manifest `h: {rel: {mt, sz, h}}` — mtime, size, and an
+// FNV-1a content hash (same pure, zero-dep hash warmset uses for its include-graph cache). On a rebuild, a
+// file whose mtime+size still match its manifest entry is REUSED verbatim — no read, no tree-sitter parse
+// (parsing is the expensive part the cold-index problem is about). A file whose stat changed is READ and
+// hashed; if the content hash still matches (mtime jitter, bytes unchanged) it's reused too, else it's
+// re-parsed. Deleted files drop out; new files parse. So `vts index` after editing a handful of files
+// re-parses only those, not the whole tree. Returns { files, symbols, path, reused, reparsed, partial }.
 export async function buildSymIndex(
   root,
-  { skipDir, inScope, timeBudgetMs = 120000, now = Date.now() } = {},
+  { skipDir, inScope, timeBudgetMs = 120000, now = Date.now(), incremental = true } = {},
 ) {
   const skip = skipDir || (() => false);
   const within = inScope || (() => true);
+  // Prior index → reuse map (rel → its records) + the per-file stat/hash manifest.
+  const prior = incremental ? loadSymIndex(root) : null;
+  const priorHashes = (prior && prior.meta && prior.meta.h) || {};
+  const priorByFile = new Map();
+  if (prior) for (const e of prior.entries) { const a = priorByFile.get(e.f) || []; a.push({ f: e.f, n: e.n, k: e.k, l: e.l }); priorByFile.set(e.f, a); }
   const stack = [root];
   const t0 = Date.now();
   let files = 0,
     symbols = 0,
-    timedOut = false;
+    timedOut = false,
+    reused = 0,
+    reparsed = 0;
   const lines = [];
+  const newHashes = {};
   while (stack.length) {
     if (Date.now() - t0 >= timeBudgetMs) {
       timedOut = true;
@@ -71,17 +88,50 @@ export async function buildSymIndex(
         timedOut = true;
         break;
       }
-      let syms;
+      const rel = path.relative(root, p).replace(/\\/g, "/");
+      let st;
       try {
-        syms = await tsFileSymbols(p);
+        st = fs.statSync(p);
       } catch {
         continue;
       }
-      if (!syms.length) continue;
+      const mt = Math.round(st.mtimeMs),
+        sz = st.size;
+      const pri = priorHashes[rel];
+      let recs, h;
+      if (pri && pri.mt === mt && pri.sz === sz) {
+        // unchanged by stat → reuse, no read, no parse (the fast path)
+        recs = priorByFile.get(rel) || [];
+        h = pri.h;
+        reused++;
+      } else {
+        // stat changed (or new file): read + hash. If the content hash still matches, reuse (mtime jitter).
+        let src;
+        try {
+          src = fs.readFileSync(p, "utf8");
+        } catch {
+          continue;
+        }
+        h = fnv1a(src);
+        if (pri && pri.h === h) {
+          recs = priorByFile.get(rel) || [];
+          reused++;
+        } else {
+          let syms;
+          try {
+            syms = await tsFileSymbols(p);
+          } catch {
+            continue;
+          }
+          recs = syms.map((s) => ({ f: rel, n: s.name, k: s.kind, l: s.line }));
+          reparsed++;
+        }
+      }
+      newHashes[rel] = { mt, sz, h }; // remember every seen file (incl. empty) so it isn't re-read next time
+      if (!recs.length) continue;
       files++;
-      const rel = path.relative(root, p).replace(/\\/g, "/");
-      for (const s of syms) {
-        lines.push(JSON.stringify({ f: rel, n: s.name, k: s.kind, l: s.line }));
+      for (const r of recs) {
+        lines.push(JSON.stringify(r));
         symbols++;
       }
     }
@@ -93,11 +143,12 @@ export async function buildSymIndex(
     files,
     symbols,
     partial: timedOut || undefined,
+    h: newHashes,
   });
   const dirPath = symIndexDir(root);
   fs.mkdirSync(dirPath, { recursive: true });
   fs.writeFileSync(symIndexPath(root), header + "\n" + lines.join("\n") + (lines.length ? "\n" : ""), "utf8");
-  return { files, symbols, path: symIndexPath(root), partial: timedOut };
+  return { files, symbols, path: symIndexPath(root), partial: timedOut, reused, reparsed };
 }
 
 // Load the index. Returns { meta, entries:[{f,n,k,l}] } or null if absent/unreadable.

--- a/server/tags/bash.scm
+++ b/server/tags/bash.scm
@@ -1,0 +1,3 @@
+; Bash — function definitions + command call references.
+(function_definition name: (word) @name) @definition.function
+(command name: (command_name (word) @name)) @reference.call

--- a/server/tags/dart.scm
+++ b/server/tags/dart.scm
@@ -1,0 +1,4 @@
+; Dart — top-level functions and methods (both are function_signature) + classes. Methods are captured as
+; functions (kind precision is secondary in the syntactic tier); avoids a method/function double-capture.
+(function_signature name: (identifier) @name) @definition.function
+(class_definition name: (identifier) @name) @definition.class

--- a/server/tags/kotlin.scm
+++ b/server/tags/kotlin.scm
@@ -1,0 +1,5 @@
+; Kotlin — functions, classes, objects. Names are direct identifier children (no `name` field).
+(function_declaration (simple_identifier) @name) @definition.function
+(class_declaration (type_identifier) @name) @definition.class
+(object_declaration (type_identifier) @name) @definition.object
+(call_expression (simple_identifier) @name) @reference.call

--- a/server/tags/php.scm
+++ b/server/tags/php.scm
@@ -1,0 +1,9 @@
+; PHP — canonical tags query (definitions + call references). Capture names follow the tree-sitter
+; tags.scm convention: @definition.<kind> on the declaration node, @name on its identifier.
+(function_definition name: (name) @name) @definition.function
+(method_declaration name: (name) @name) @definition.method
+(class_declaration name: (name) @name) @definition.class
+(interface_declaration name: (name) @name) @definition.interface
+(trait_declaration name: (name) @name) @definition.trait
+(function_call_expression function: (name) @name) @reference.call
+(member_call_expression name: (name) @name) @reference.call

--- a/server/tags/scala.scm
+++ b/server/tags/scala.scm
@@ -1,0 +1,6 @@
+; Scala — defs, classes, objects, traits.
+(function_definition name: (identifier) @name) @definition.function
+(class_definition name: (identifier) @name) @definition.class
+(object_definition name: (identifier) @name) @definition.object
+(trait_definition name: (identifier) @name) @definition.trait
+(call_expression function: (identifier) @name) @reference.call

--- a/server/tags/swift.scm
+++ b/server/tags/swift.scm
@@ -1,0 +1,6 @@
+; Swift — functions, types, protocols. The function/class name is a direct identifier child (no `name`
+; field in this grammar), so it is captured positionally.
+(function_declaration (simple_identifier) @name) @definition.function
+(class_declaration (type_identifier) @name) @definition.class
+(protocol_declaration (type_identifier) @name) @definition.protocol
+(call_expression (simple_identifier) @name) @reference.call

--- a/server/tags/zig.scm
+++ b/server/tags/zig.scm
@@ -1,0 +1,4 @@
+; Zig — functions and (struct/union/enum) type bindings via variable declarations.
+(function_declaration (identifier) @name) @definition.function
+(variable_declaration (identifier) @name) @definition.type
+(call_expression function: (identifier) @name) @reference.call

--- a/server/treesitter.js
+++ b/server/treesitter.js
@@ -6,7 +6,11 @@
 // scan (scanTextUnder) — which returns every USAGE line, not declarations, and can't tell a class from a
 // comment. Tree-sitter is an OFFICIAL standard parser (the GitHub / neovim engine), shipped here as prebuilt
 // wasm grammars (tree-sitter-wasms) run by the wasm runtime (web-tree-sitter) — no native build, works on
-// Windows. It gives a real AST → DECLARATIONS with names + lines, for 36 languages, with ZERO project setup.
+// Windows. It gives a real AST → DECLARATIONS with names + lines, with ZERO project setup. 36 grammars ship;
+// declaration extraction is configured for ~17 languages today — 10 with a hand-tuned node-type walk (the
+// flagship set: C/C++/C#/JS/TS/Py/Go/Java/Rust/Ruby, where C++ declarator-drilling needs care) and 7 more via
+// canonical `tags.scm` queries (php/swift/kotlin/scala/dart/zig/bash) — and a grammar with neither degrades
+// to a generic walk rather than going dark. Adding a language = a hand config OR a server/tags/<grammar>.scm.
 //
 // This tier is SYNTACTIC, not semantic: it finds where a symbol is DECLARED (and a file's outline), but it
 // does NOT resolve references, overloads, or types across files — that stays the LSP's job. So it slots
@@ -235,6 +239,11 @@ const GENERIC = {
   ]),
   kind: {},
 };
+// Sentinel config: "extract declarations via the canonical tags query in server/tags/<grammar>.scm" instead
+// of a hand-tuned node-type walk. This is how coverage EXTENDS beyond the flagship languages — the official
+// tree-sitter tags-query DSL (`@definition.<kind>` + `@name`) is loaded from a file, so adding a language is
+// adding a .scm (+ an EXT_MAP entry), no JS. Charter-pure: tree-sitter's own query interface, glue = ours.
+const TAGS = { tags: true };
 
 // ext → { wasm, cfg }. wasm = tree-sitter-wasms/out/<wasm>.wasm basename (no extension).
 const EXT_MAP = {
@@ -264,6 +273,20 @@ const EXT_MAP = {
   java: ["java", JAVA],
   rs: ["rust", RUST],
   rb: ["ruby", RUBY],
+  // Tags-query tier (canonical .scm extraction; validated against the bundled grammars). Extends the
+  // syntactic rung past the hand-tuned flagship languages — see server/tags/*.scm.
+  php: ["php", TAGS],
+  php5: ["php", TAGS],
+  phtml: ["php", TAGS],
+  sh: ["bash", TAGS],
+  bash: ["bash", TAGS],
+  swift: ["swift", TAGS],
+  kt: ["kotlin", TAGS],
+  kts: ["kotlin", TAGS],
+  scala: ["scala", TAGS],
+  sc: ["scala", TAGS],
+  dart: ["dart", TAGS],
+  zig: ["zig", TAGS],
 };
 
 let _req; // createRequire anchor (or false once we know it's unavailable)
@@ -362,6 +385,65 @@ function tailName(name) {
   return m[m.length - 1] || name;
 }
 
+// ── TAGS-QUERY tier (the canonical, file-driven extractor for languages without a hand-tuned node config).
+// A `server/tags/<grammar>.scm` written in tree-sitter's own query DSL captures `@definition.<kind>` on each
+// declaration node and `@name` on its identifier; we read those out of the query matches. The file ships
+// with the package (next to this module), so it resolves in every install layout without createRequire.
+function tagsDir() {
+  const here = path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"));
+  return path.join(here, "tags");
+}
+const _defTagsCache = new Map(); // wasm base → constructed Query | null (absent/failed)
+async function defTagsQueryFor(wasmBase) {
+  if (_defTagsCache.has(wasmBase)) return _defTagsCache.get(wasmBase);
+  let q = null;
+  try {
+    const src = fs.readFileSync(path.join(tagsDir(), `${wasmBase}.scm`), "utf8");
+    const lang = await loadLanguage(wasmBase);
+    if (lang && _TS) q = new _TS.Query(lang, src);
+  } catch {
+    q = null; // no .scm for this grammar, or it failed to construct against the bundled version → graceful
+  }
+  _defTagsCache.set(wasmBase, q);
+  return q;
+}
+// Map a `@definition.<suffix>` capture to a short kind label (parity with the hand-tuned KIND maps).
+const TAG_KIND = {
+  function: "func", method: "method", class: "class", struct: "struct", interface: "interface",
+  enum: "enum", trait: "trait", type: "type", module: "namespace", namespace: "namespace",
+  constant: "const", field: "field", macro: "macro", object: "object", protocol: "protocol", union: "union",
+};
+// Pull declarations out of a tags query's matches: each match carries a `@definition.<kind>` and a `@name`.
+function extractTagDefs(q, root) {
+  const out = [];
+  for (const m of q.matches(root)) {
+    let nameNode = null, kind = null;
+    for (const c of m.captures) {
+      if (c.name === "name") nameNode = c.node;
+      else if (c.name.startsWith("definition.")) kind = TAG_KIND[c.name.slice(11)] || c.name.slice(11);
+    }
+    if (nameNode && kind && /[A-Za-z_]/.test(nameNode.text))
+      out.push({ name: nameNode.text.slice(0, 80), kind, line: nameNode.startPosition.row + 1, col: nameNode.startPosition.column });
+  }
+  return out;
+}
+// Pull call references named `want` out of a tags query's `@reference.*` captures. A reference pattern
+// captures the call target either directly (`@reference.call`) or via `@name` alongside a `@reference.*`;
+// match the named node's text and dedupe by position.
+function extractTagRefs(q, root, want) {
+  const out = [];
+  for (const m of q.matches(root)) {
+    const hasRef = m.captures.some((c) => c.name.startsWith("reference"));
+    if (!hasRef) continue;
+    for (const c of m.captures) {
+      if ((c.name.startsWith("reference") || c.name === "name") && c.node.text === want)
+        out.push({ name: want, line: c.node.startPosition.row + 1, col: c.node.startPosition.column });
+    }
+  }
+  const seen = new Set();
+  return out.filter((r) => { const k = `${r.line}:${r.col}`; if (seen.has(k)) return false; seen.add(k); return true; });
+}
+
 // Parse one file and return its declarations: [{ name, kind, line (1-based), col (0-based) }].
 // Bounded by maxBytes (a 2 MB generated file isn't worth parsing). Best-effort: any failure → [].
 export async function tsFileSymbols(absPath, { maxBytes = 2_000_000 } = {}) {
@@ -388,6 +470,23 @@ export async function tsFileSymbols(absPath, { maxBytes = 2_000_000 } = {}) {
     tree = parser.parse(src);
   } catch {
     return [];
+  }
+  // Tags-query tier: a file-driven .scm extracts declarations for languages without a hand-tuned node config.
+  if (cfg.tags) {
+    const q = await defTagsQueryFor(wasmBase);
+    let defs = [];
+    try {
+      if (q) defs = extractTagDefs(q, tree.rootNode);
+    } catch {
+      defs = [];
+    }
+    try {
+      tree.delete && tree.delete();
+      parser.delete && parser.delete();
+    } catch {
+      /* ignore */
+    }
+    return defs.slice(0, 5000);
   }
   const out = [];
   const decl = cfg.decl,
@@ -547,7 +646,9 @@ export async function tsFileReferences(absPath, name, { maxBytes = 2_000_000 } =
   const entry = EXT_MAP[extOf(absPath)];
   if (!entry) return [];
   const wasmBase = entry[0];
-  const q = await refQueryFor(wasmBase);
+  const cfg = entry[1] || GENERIC;
+  // TAGS languages carry their `@reference.*` captures in the same .scm; others use the inline REF_QUERIES.
+  const q = cfg.tags ? await defTagsQueryFor(wasmBase) : await refQueryFor(wasmBase);
   if (!q) return [];
   let src;
   try {
@@ -567,12 +668,16 @@ export async function tsFileReferences(absPath, name, { maxBytes = 2_000_000 } =
   } catch {
     return [];
   }
-  const out = [];
+  let out = [];
   const want = String(name);
   try {
-    for (const c of q.captures(tree.rootNode)) {
-      if (c.node.text === want)
-        out.push({ name: want, line: c.node.startPosition.row + 1, col: c.node.startPosition.column });
+    if (cfg.tags) {
+      out = extractTagRefs(q, tree.rootNode, want);
+    } else {
+      for (const c of q.captures(tree.rootNode)) {
+        if (c.node.text === want)
+          out.push({ name: want, line: c.node.startPosition.row + 1, col: c.node.startPosition.column });
+      }
     }
   } catch {
     /* ignore */
@@ -665,7 +770,9 @@ export async function tsFileDeclDocs(absPath, { maxBytes = 2_000_000, gap = 3 } 
   const entry = EXT_MAP[extOf(absPath)];
   if (!entry) return [];
   const [wasmBase, cfgIn] = entry;
-  const cfg = cfgIn || GENERIC;
+  // TAGS-tier languages have no node-type `decl` set — use the GENERIC walk for the concept-unit doc pass
+  // (best-effort; the tags tier itself drives symbol/reference, this only feeds the fuzzy concept dictionary).
+  const cfg = cfgIn && cfgIn.decl ? cfgIn : GENERIC;
   let src;
   try {
     const st = fs.statSync(absPath);


### PR DESCRIPTION
Three syntactic-tier improvements (prove it, broaden it, speed it) plus a hook-copy fix.

## 1. Controlled multi-language benchmark (Closes the paper's single-corpus gap)
The benchmark was one synthetic TypeScript corpus - cherry-pickable on the one language vts is best at. Now it sweeps a second axis, LANGUAGE, alongside size: the same four scenarios run on TypeScript, Python (semantic tier) and Go (no wired backend -> the syntactic tree-sitter tier + bounded literal scan), at three sizes each. Per-language + all-language reduction tables, honest per-scenario tier labels. ~87% all-language at 150 files (TS ~87 / Py ~83 / Go ~91). Deterministic, zero-API.

Also fixes a real bug the Go arm surfaced: `find_references` on a repo with NO language-server backend hard-errored on getClient before the by-name tree-sitter fallback could run. Added a no-backend find_references branch (tree-sitter call references, then literal scan), mirroring search_symbol.

## 2. tags-query tier (extend coverage past the flagship languages)
36 grammars ship but declaration extraction was configured for only ~10 languages. Added a file-driven TAGS tier: a `server/tags/<grammar>.scm` in tree-sitter's own query DSL (@definition.<kind> + @name + @reference.*) drives extraction for languages without a hand config. Ships validated queries for 7 new languages (php/swift/kotlin/scala/dart/zig/bash, ~10 -> 17). A grammar with neither a hand config nor a .scm degrades to the GENERIC walk; a query that fails to construct falls back gracefully. The flagship node-type walk (C++ etc.) is untouched - no regression. Adding a language = a .scm + an EXT_MAP entry, no JS.

## 3. Incremental .vts-index rebuild
A full `vts index` re-parsed every file every time. The JSONL header now carries a per-file manifest h:{rel:{mt,sz,h}} (mtime+size fast-path -> FNV-1a content hash, the same hash warmset uses). On rebuild an unchanged file is reused verbatim (no read, no parse); a stat-changed file is read+hashed, reused on hash match (mtime jitter) else re-parsed; deleted files drop. Re-parses only what changed. Backward-compatible (old index rebuilds fully once). Returns/reports reused vs reparsed.

## + hook copy (user feedback)
Trimmed the grep/glob block messages to three signals - what was intercepted, the equivalent vts call, the rough token win (~90%) - and dropped the long friendly paragraph.

## Review points
- charter intact: output stays token-capped file:line, labeled by precision, nothing transmitted, no embeddings; tree-sitter tags-query DSL is the engine's official interface (glue = ours).
- eval guard 81 extended: (e) no-backend find_references syntactic fallback, (f) php tags extraction, (g) incremental reuse/reparse. EVAL PASSED, lint clean.
- synthetic fixtures only; no proprietary paths/symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
