### PR TITLE
fix(hook): do not block a file-ops find as a code search (backup/copy FP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,13 @@ repo while config pinned clangd for a UE tree) > forced `VTS_BACKEND`/config `ba
   FIND-DIR FIX (v2.2): a Bash `find <dir> -name X` rewrite now HONORS `<dir>` as the find_files root
   (`extractFindDir`) — it was dropped, so `find /abs/UE/path -name X` searched the configured vts repo and falsely
   reported "No files" (a live correctness bug on a UE worktree). `vts discover` also counts the Glob tool as a
-  find_files bypass. `VTS_REWRITE=0` → block
+  find_files bypass. FILE-OPS FIND FP FIX (v0.33.14): a `find` doing FILE-OPS — its own `-exec`/`-delete`/
+  `-type d` (`isFindFileOps`), or alongside a file-op exec in the same command (`hasFileOpsContext`:
+  cp/mv/tar/rsync/xargs/zip/du/… — a backup/copy `du …; find … -name "*.cpp"`) — is NOT a code search →
+  never blocked AND never rerouted to a (token-CAPPED) find_files, which would silently drop files from a
+  copy/delete. A genuine code-file `find -name "*.cpp"` with no file-op still rewrites to find_files. Live-found:
+  a UE-depot backup find got blocked + the capped reroute would corrupt the backup. grep stays strict (a literal
+  grep in a pipeline is usually content filtering). Eval guard 17b. `VTS_REWRITE=0` → block
   instead of rewrite; `excludeCommands` (config) / `VTS_EXCLUDE_COMMANDS` (csv) opt a command out; escape hatch
   `VTS_ENFORCE=0`. Messages i18n'd (`uiLang()`: Korean when `VTS_LANG`/config `lang`=`ko` OR OS locale `ko-*`,
   else English; `VTS_LANG=en|ko` forces). Copy is AGENT-DIRECTED — the actionable part instructs the assistant

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -283,6 +283,19 @@ const hAnchor = parseRw(runHook({ tool_name: "Bash", tool_input: { command: 'gre
 const hComplex = runHook({ tool_name: "Bash", tool_input: { command: "grep -rn 'a b' src/Thing.cpp" } }); // space → unsafe → block
 const hPipe = runHook({ tool_name: "Bash", tool_input: { command: "grep -rn Foo src/Thing.cpp | head" } }); // pipeline → block
 const hExcluded = runHook({ tool_name: "Bash", tool_input: { command: "rg Foo src/Thing.cpp" } }, { VTS_EXCLUDE_COMMANDS: "rg" });
+// FILE-OPS find FP fix: a `find` doing file-ops (its own -exec/-type d, or alongside cp/du/tar/xargs in the
+// command) is NOT a code search → never blocked AND never rerouted to a (capped) find_files; a capped list
+// would silently drop files from a backup/copy. A genuine code-file find with no file-op still rewrites
+// (hFind above). Live-found: a UE-depot backup `find … -name "*.cpp"` next to du/cp got blocked.
+const hFindExec = runHook({ tool_name: "Bash", tool_input: { command: 'find src -name "*.cpp" -exec cp {} /bak/ \\;' } });
+const hFindDuMulti = runHook({ tool_name: "Bash", tool_input: { command: 'du -sh Plugins/SmoothSync 2>/dev/null; find Plugins/SmoothSync -name "*.cpp"' } });
+const hFindXargs = runHook({ tool_name: "Bash", tool_input: { command: 'find src -name "*.h" | xargs -I{} cp {} /bak' } });
+const hFindTypeD = runHook({ tool_name: "Bash", tool_input: { command: "find src/engine -type d" } });
+const findFileOpsOk =
+  hFindExec.status === 0 && !parseRw(hFindExec).updatedInput &&
+  hFindDuMulti.status === 0 && !parseRw(hFindDuMulti).updatedInput &&
+  hFindXargs.status === 0 && !parseRw(hFindXargs).updatedInput &&
+  hFindTypeD.status === 0 && !parseRw(hFindTypeD).updatedInput;
 const rewriteOk =
   /cli\.js" files --q "\*\.cpp"/.test(hFind.updatedInput?.command || "") &&
   /cli\.js" symbol --q "SpawnActor"/.test(hGitGrep.updatedInput?.command || "") &&  // git grep identifier → symbol
@@ -291,7 +304,8 @@ const rewriteOk =
   /cli\.js" text --q "\^#include"/.test(hAnchor.updatedInput?.command || "") &&      // quoted anchor → text (regex)
   hComplex.status === 2 && /caught a code search/.test(hComplex.err) &&
   hPipe.status === 2 &&
-  hExcluded.status === 0 && !/caught a code search/.test(hExcluded.err) && !(parseRw(hExcluded).updatedInput); // excluded → untouched
+  hExcluded.status === 0 && !/caught a code search/.test(hExcluded.err) && !(parseRw(hExcluded).updatedInput) && // excluded → untouched
+  findFileOpsOk;
 
 // 18) search_text covers JS/TS/Py (scanTextUnder ext set, not just C/C++/C#), and search_symbol on a
 // typescript/pyright backend falls back to a literal text search when the index returns nothing (a

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -107,8 +107,20 @@ function isSearchSegment(segment) {
   return SEARCH_EXECS.has(exec) || (exec === "find" && /\s-i?name(\s|$)/.test(segment.toLowerCase())) || isGitGrepSegment(segment);
 }
 
+// A `find` doing FILE-OPS (not a search-to-read): an action flag (-exec/-delete/-print0/…) or `-type d`
+// means it's enumerating files to act on (backup, copy, cleanup), NOT hunting code for the model to read.
+// find_files (token-capped) is the WRONG substitute there — a capped list would silently drop files from a
+// copy/delete. So such a find is never treated as a code search (live-found: a UE-depot backup `find -name
+// "*.cpp"` alongside cp/du got blocked, and rerouting it to a capped find_files would corrupt the backup).
+const FIND_ACTION_RE = /\s-(exec|execdir|delete|ok|okdir|print0|fprint0?|fls|fprintf)\b/;
+const FIND_TYPE_DIR_RE = /\s-type\s+d\b/;
+function isFindFileOps(segment) {
+  return execOf(segment) === "find" && (FIND_ACTION_RE.test(segment) || FIND_TYPE_DIR_RE.test(segment));
+}
+
 function isCodeSearchSegment(segment) {
   if (!isSearchSegment(segment)) return false;
+  if (isFindFileOps(segment)) return false; // a file-ops find is not a code search
   const s = segment.toLowerCase();
   const textTarget =
     TEXT_TARGET_RE.test(s) ||
@@ -118,6 +130,19 @@ function isCodeSearchSegment(segment) {
   const codeExt = CODE_EXT_RE.test(s);
   const codeDir = CODE_DIR_RE.test(s);
   return (codeExt || codeDir) && !textTarget;
+}
+
+// File-operation executables — when ANY segment of a command is one of these, a `find` segment in the same
+// command is PLUMBING for that op (the file list feeds cp/tar/xargs/…), not an interactive code search. So
+// such a find is excluded from the block even without its own -exec (`find … -name '*.cpp' | xargs cp`,
+// `du …; find … -name '*.uproject'` during a backup). grep segments are NOT relaxed (a literal grep inside a
+// pipeline is usually content filtering, and the user can still VTS_ENFORCE=0 a non-search session).
+const FILE_OPS_EXECS = new Set([
+  "cp", "mv", "rm", "tar", "rsync", "xargs", "zip", "unzip", "7z", "cpio", "install",
+  "ln", "du", "df", "chmod", "chown", "mkdir", "touch", "dd", "scp", "robocopy", "pax",
+]);
+function hasFileOpsContext(segments) {
+  return segments.some((s) => FILE_OPS_EXECS.has(execOf(s)));
 }
 
 // The executable key used for excludeCommands matching (git grep → "git").
@@ -628,7 +653,12 @@ process.stdin.on("end", () => {
 
   // #5 honor excludeCommands — drop excluded execs from enforcement.
   const excluded = excludedCommands();
-  const codeSegs = segments.filter((s) => isCodeSearchSegment(s) && !excluded.has(excludeKeyOf(s)));
+  // A `find` in a command that also runs a file-op (cp/tar/xargs/du/…) is plumbing for that op, not a code
+  // search — exclude it so a backup/copy script isn't blocked (and isn't rerouted to a capped find_files).
+  const fileOps = hasFileOpsContext(segments);
+  const codeSegs = segments.filter(
+    (s) => isCodeSearchSegment(s) && !excluded.has(excludeKeyOf(s)) && !(fileOps && execOf(s) === "find"),
+  );
 
   if (codeSegs.length) {
     // #1 transparent rewrite: a whole command that is exactly one code-search segment, where we can build


### PR DESCRIPTION
## Problem (live-found on a UE depot)
A file-enumerating `find` run for a file operation got caught by the grep-block hook as if it were a code search. Worse, the steered alternative is token-capped, so rerouting a backup/copy command to it would silently drop files. A backup command (disk-usage check then a `-name` enumeration) was blocked; the agent had to recover with `cp`. The user flagged both the false block and the wasted tokens.

## Fix
A `find` is excluded from the code-search block when it is doing file-ops:
- its own action flag (`-exec`/`-execdir`/`-delete`/`-ok`/`-print0`/…) or `-type d` (`isFindFileOps`), or
- it runs alongside a file-op executable in the same command (`hasFileOpsContext`: cp/mv/rm/tar/rsync/xargs/zip/unzip/7z/cpio/install/ln/du/df/chmod/chown/mkdir/touch/dd/scp/robocopy).

Such a `find` is never blocked and never rerouted (a capped list would corrupt a copy/delete). A genuine code-file enumeration with no file-op still rewrites to the token-capped tool — the token win is preserved for real searches. Literal text search stays strict.

## Review points
- Not an enforcement hole: the hook steers a cooperative model, it isn't tamper-proofing; the only theoretical "bypass" is appending a file-op, which the model has no incentive to do.
- No regression for genuine searches (still rewritten); only file-ops enumeration is relaxed.
- Eval guard 17b extended: backup (du + enumerate), `-exec cp`, `| xargs cp`, `-type d` all allowed; genuine search + literal grep still rewrite. EVAL PASSED, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
