### PR TITLE
feat(viz): dashboard surfaces the precision ladder + lead the text-to-symbol steer

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1554,7 +1554,23 @@ const htmlSelfContainedOk =
   /<!doctype html>/i.test(html) && /fetch\("\/data"\)/.test(html) &&
   !/src\s*=\s*["']https?:/i.test(html) && !/cdn|unpkg|jsdelivr|googleapis/i.test(html) && // no external script / CDN
   /\/vendor\/three\.module\.min\.js/.test(html) && /import \* as THREE/.test(html) &&     // 3D: vendored Three.js, same-origin
-  /fetch\("\/callgraph/.test(html);                                                       // call-graph mode wired
+  /fetch\("\/callgraph/.test(html) &&                                                     // call-graph mode wired
+  /precision ladder/i.test(html) && /ladderPanel/.test(html) && /surfacePanel/.test(html) && /certsPanel/.test(html); // paper-identity panels present
+// PRECISION-LADDER data model: 4 rungs (exact→syntactic→fuzzy→section), savings attributed without
+// double-counting (exact = the LSP tools; fuzzy = concept_search; syntactic/section show reach, 0 saved),
+// + surface coverage + the completeness-certificate legend. The fixture ledger has search_symbol (54k saved)
+// + find_references (36k saved) → exact tier = 90k / 5 runs; syntactic/section = 0 saved + a reach string.
+const exactT = vd.tiers.find((t) => t.key === "exact");
+const synT = vd.tiers.find((t) => t.key === "syntactic");
+const tiersOk =
+  vd.tiers.length === 4 &&
+  vd.tiers.map((t) => t.rung).join("") === "1234" &&
+  vd.tiers.map((t) => t.name).join(",") === "Exact,Syntactic,Fuzzy,Section" &&
+  !!exactT && exactT.saved === 90000 && exactT.runs === 5 && exactT.cert === "COMPLETE" && // attributed, no double-count
+  !!synT && synT.saved === 0 && /17 languages/.test(synT.reach || "") &&                   // syntactic: reach, not saved
+  vd.surfaces.syntacticLangs === 17 && Array.isArray(vd.surfaces.docFormats) && vd.surfaces.docFormats.length === 9 && vd.surfaces.docFormats.includes("markdown") &&
+  vd.surfaces.semantic && vd.surfaces.semantic.clangd === 3 &&
+  vd.certs.length === 4 && vd.certs.map((c) => c.key).join(",") === "COMPLETE,SYNTACTIC,PARTIAL,INCONCLUSIVE";
 const { startServer } = await import("../server/serve.js");
 const { server, port, url } = await startServer(vizRoot, 0); // port 0 → OS-assigned ephemeral
 const httpGet = (p) => new Promise((res, rej) => { http.get({ host: "127.0.0.1", port, path: p }, (r) => { let b = ""; r.on("data", (d) => (b += d)); r.on("end", () => res({ status: r.statusCode, body: b, ct: r.headers["content-type"] })); }).on("error", rej); });
@@ -1574,7 +1590,7 @@ const serveOk =
 await new Promise((r) => server.close(r));
 try { fs.rmSync(vizRoot, { recursive: true, force: true }); } catch { /* ignore */ }
 fs.writeFileSync(GDS, "{}"); // reset so it doesn't leak into any later savings assertion
-const dashboardOk = vizDataOk && htmlSelfContainedOk && serveOk && combinedReportOk;
+const dashboardOk = vizDataOk && htmlSelfContainedOk && serveOk && combinedReportOk && tiersOk;
 
 // 74) result RERANK (Semble-inspired, charter-pure): rankSymbols reorders the OFFICIAL engine's results
 // BEFORE the top-N cap, so the row the model wants survives the cap. Lexical tier (exact > prefix > word/camel
@@ -2025,7 +2041,7 @@ const rows = [
   ["clangd index advisory: file-not-in-DB vs index-incomplete (%), toggle", idxAdvOk, "true", idxAdvOk],
   ["call hierarchy folded into find_references (direction=callers/callees, depth-bounded)", traceOk, "true", traceOk],
   ["include-graph content-hash (FNV-1a) + mtime+size composite key", contentHashOk, "true", contentHashOk],
-  ["dashboard: 3D viz + vendored Three.js route + combined gamedev savings + 127.0.0.1", dashboardOk, "true", dashboardOk],
+  ["dashboard: precision-ladder + surfaces + cert panels, 3D viz + vendored Three.js, combined savings, 127.0.0.1", dashboardOk, "true", dashboardOk],
   ["on-demand call graph + symbol autocomplete: buildCallGraph/listSymbols + /callgraph + /symbols routes", callGraphAllOk, "true", callGraphAllOk],
   ["result rerank (Semble-inspired, charter-pure): lexical+kind+history, stable, before the cap", rerankOk, "true", rerankOk],
   ["effective cuts: focus (exact→few) + concept (multi-term rank) + read-avoidance ledger", effectiveCutsOk, "true", effectiveCutsOk],

--- a/server/core.js
+++ b/server/core.js
@@ -182,11 +182,14 @@ function textSymbolSteer(q, truncated) {
   if (!textSteerOn()) return "";
   const sym = symbolHuntInText(q);
   if (!sym) return "";
-  const strong = /::|<|>/.test(String(q));
+  // "strong" cue = a code expression (`::`/`<>`) OR a BARE identifier (the whole query is one symbol name,
+  // e.g. `SmoothSyncBudget`). A bare-identifier text search ALWAYS has a strictly better semantic tool, so
+  // steer even when it completed (not just when truncated) — that's the case the model keeps reaching for.
+  const strong = /::|<|>/.test(String(q)) || /^[A-Za-z_][A-Za-z0-9_]{2,}$/.test(String(q).trim());
   if (!truncated && !strong) return "";
   return truncated
     ? `\n↪ "${sym}" looks like a symbol and this text scan was TRUNCATED. find_references symbol="${sym}" is semantic + COMPLETE (no time-box) and ~10–20× smaller; search_symbol q="${sym}" for the declaration.`
-    : `\n↪ Hunting where "${sym}" is declared/used? find_references symbol="${sym}" / search_symbol q="${sym}" use the LSP index — semantic and token-capped, unlike a text scan.`;
+    : `\n↪ "${sym}" is a symbol — find_references symbol="${sym}" (all uses, semantic, file:line only, COMPLETE) or search_symbol q="${sym}" (its declaration) is far smaller than a text scan, which returns full line text.`;
 }
 // Appended to a FOCUSED symbol/definition result: the model just located a declaration, the moment right
 // BEFORE it would Read the whole file to Edit it. Point it at the symbol-edit tools, which edit by NAME and
@@ -2084,7 +2087,12 @@ export async function runTool(name, a = {}) {
       // time-boxed text scan). Only on a CODE scan — a doc/single-file target is an intentional text lookup.
       const steer = (!docs && !a.path) ? textSymbolSteer(a.q, hits.truncated) : "";
       const textCert = completenessCert({ shown: hits.length, total: hits.truncated ? null : hits.length, truncated: hits.truncated || null, semantic: false });
-      return finishOut(hits, `${hits.length} match(es) for "${a.q}" (${scopeLabel})${tt}:\n` + factorCommonPrefix(hits) + steer + textCert);
+      const textBody = `${hits.length} match(es) for "${a.q}" (${scopeLabel})${tt}:\n` + factorCommonPrefix(hits) + textCert;
+      // LEAD with the symbol-hunt steer (not trail it): the model acts on the first lines it reads, so an
+      // actionable "use find_references instead" buried under 60 matches is seen too late (live: a symbol
+      // text-search ran, the model used the partial body before reaching the trailing steer). A plain text
+      // search has no steer → body unchanged.
+      return finishOut(hits, steer ? steer.replace(/^\n+/, "") + "\n\n" + textBody : textBody);
     }
     // vts_git / vts_p4 — run the real VCS command and COMPACT its output before it reaches the model. The
     // language-server index can't help here (status/log/diff/opened aren't source symbols), but the raw dump

--- a/server/dashboard.html
+++ b/server/dashboard.html
@@ -213,6 +213,101 @@ body.graph-focused .graph-focus-btn::before{content:"✕  ";font-size:10px}
 }
 body.graph-focused .graph-kb-hint{display:block}
 
+/* ── Precision Ladder ─────────────────────────────────────────────────── */
+/* Rung accent palette */
+:root{
+  --rung1:#0070F3;   /* exact  — language server */
+  --rung2:#38BDF8;   /* syntactic — tree-sitter  */
+  --rung3:#A78BFA;   /* fuzzy — concept dict     */
+  --rung4:#34D399;   /* section — doc/config     */
+  --rung1-dim:rgba(0,112,243,.12);
+  --rung2-dim:rgba(56,189,248,.12);
+  --rung3-dim:rgba(167,139,250,.12);
+  --rung4-dim:rgba(52,211,153,.12);
+}
+
+.ladder-wrap{display:flex;gap:0;align-items:stretch;position:relative}
+/* connector line under rungs */
+.ladder-wrap::before{
+  content:"";position:absolute;bottom:-1px;left:0;right:0;
+  height:1px;background:var(--border);z-index:0;
+}
+
+.rung-card{
+  flex:1;min-width:0;
+  border-right:1px solid var(--border);
+  padding:16px 18px 14px;
+  position:relative;
+  transition:background .14s;
+  cursor:default;
+}
+.rung-card:last-child{border-right:none}
+.rung-card:hover{background:var(--panel-hover)}
+
+/* staircase step notch — bottom right corner cut */
+.rung-card::after{
+  content:"";
+  position:absolute;bottom:0;right:0;
+  width:0;height:0;
+  border-style:solid;
+  border-width:0 0 10px 10px;
+  border-color:transparent transparent var(--bg) transparent;
+  pointer-events:none;
+}
+/* step offset per rung so they visually descend */
+.rung-card[data-rung="1"]{padding-top:10px}
+.rung-card[data-rung="2"]{padding-top:16px}
+.rung-card[data-rung="3"]{padding-top:22px}
+.rung-card[data-rung="4"]{padding-top:28px}
+
+.rung-num{
+  font-family:var(--mono);font-size:10px;font-weight:700;
+  letter-spacing:.05em;text-transform:uppercase;
+  margin-bottom:6px;display:flex;align-items:center;gap:6px;
+}
+.rung-pip{
+  width:7px;height:7px;border-radius:50%;flex-shrink:0;
+}
+.rung-name{font-size:13px;font-weight:600;margin-bottom:3px;line-height:1.3}
+.rung-engine{
+  font-family:var(--mono);font-size:10px;color:var(--faint);
+  margin-bottom:6px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+}
+.rung-when{font-size:11px;color:var(--dim);line-height:1.4;margin-bottom:8px;min-height:2.8em}
+.rung-footer{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-top:auto}
+.cert-badge{
+  display:inline-flex;align-items:center;gap:4px;
+  font-family:var(--mono);font-size:10px;font-weight:600;
+  padding:2px 7px;border-radius:3px;letter-spacing:.03em;
+  border:1px solid;
+}
+.rung-stat{
+  font-family:var(--mono);font-size:10px;color:var(--faint);
+  white-space:nowrap;
+}
+.rung-stat span{color:var(--ink)}
+
+/* ── Surface Coverage card ─────────────────────────────────────────── */
+.surf-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px 16px}
+.surf-section-label{
+  font-size:10px;font-weight:700;text-transform:uppercase;
+  letter-spacing:.05em;color:var(--faint);margin-bottom:5px;
+}
+.surf-row{
+  display:flex;align-items:center;gap:6px;margin-bottom:5px;
+  font-size:11px;color:var(--dim);
+}
+.surf-row:last-child{margin-bottom:0}
+.surf-dot{
+  width:6px;height:6px;border-radius:50%;flex-shrink:0;background:var(--faint);
+}
+.surf-val{font-family:var(--mono);font-size:11px;color:var(--ink);white-space:nowrap}
+
+/* ── Cert legend card ──────────────────────────────────────────────── */
+.cert-legend{display:flex;flex-direction:column;gap:8px}
+.cert-row{display:flex;align-items:flex-start;gap:8px}
+.cert-desc{font-size:11px;color:var(--dim);line-height:1.4;flex:1}
+
 /* Focus ring */
 :focus-visible{outline:1px solid var(--accent);outline-offset:2px}
 
@@ -273,6 +368,26 @@ body.graph-focused .graph-kb-hint{display:block}
           <div class="stat-sub">tool invocations</div>
         </div>
       </div>
+    </div>
+
+    <!-- Precision Ladder (full width) -->
+    <div class="col-12 panel" id="ladderPanel" style="padding:0;display:none">
+      <div style="padding:12px 18px 0;border-bottom:1px solid var(--border)">
+        <div class="panel-title" style="margin-bottom:0;padding-bottom:10px">Precision Ladder — how vts answers</div>
+      </div>
+      <div class="ladder-wrap" id="ladderWrap">
+        <!-- injected by renderLadder() -->
+      </div>
+    </div>
+
+    <!-- Row: Surfaces + Certs (shown when /data has tiers) -->
+    <div class="col-8 panel" id="surfacePanel" style="display:none">
+      <div class="panel-title">Surface Coverage</div>
+      <div id="surfaceContent"><div class="empty">loading…</div></div>
+    </div>
+    <div class="col-4 panel" id="certsPanel" style="display:none">
+      <div class="panel-title">Completeness Certificates</div>
+      <div class="cert-legend" id="certsContent"></div>
     </div>
 
     <!-- Row 2: 30-day chart -->
@@ -605,6 +720,142 @@ function renderTools(tools){
   container.innerHTML=html;
 }
 
+/* ── Cert badge helpers ──────────────────────────────────────────────── */
+const CERT_COLORS={
+  COMPLETE:  {color:"#34D399",bg:"rgba(52,211,153,.12)"},
+  SYNTACTIC: {color:"#38BDF8",bg:"rgba(56,189,248,.12)"},
+  PARTIAL:   {color:"#FACC15",bg:"rgba(250,204,21,.12)"},
+  INCONCLUSIVE:{color:"#737373",bg:"rgba(115,115,115,.12)"},
+};
+const RUNG_COLORS=["","#0070F3","#38BDF8","#A78BFA","#34D399"];
+const RUNG_BG=["","rgba(0,112,243,.12)","rgba(56,189,248,.12)","rgba(167,139,250,.12)","rgba(52,211,153,.12)"];
+
+function certBadgeHtml(certKey){
+  const c=CERT_COLORS[certKey]||{color:"#737373",bg:"rgba(115,115,115,.12)"};
+  return `<span class="cert-badge" style="color:${c.color};background:${c.bg};border-color:${c.color}">${certKey}</span>`;
+}
+
+/* ── Precision Ladder ────────────────────────────────────────────────── */
+function renderLadder(tiers){
+  const panel=document.getElementById("ladderPanel");
+  const wrap=document.getElementById("ladderWrap");
+  if(!tiers||!tiers.length){return;}
+  panel.style.display="";
+
+  let html="";
+  tiers.forEach(function(t){
+    const rung=t.rung||1;
+    const color=RUNG_COLORS[rung]||"#737373";
+    const bg=RUNG_BG[rung]||"transparent";
+    const hasSaved=(typeof t.saved==="number")&&t.saved>0;
+    const hasRuns=(typeof t.runs==="number")&&t.runs>0;
+    const reach=t.reach||"";
+
+    let statHtml="";
+    if(hasSaved){
+      statHtml+=`<span class="rung-stat"><span>${fmtTok(t.saved)}</span> tok saved</span>`;
+    }
+    if(hasRuns){
+      statHtml+=`<span class="rung-stat"><span>${t.runs.toLocaleString()}</span> runs</span>`;
+    }
+    if(!hasSaved&&reach){
+      statHtml+=`<span class="rung-stat"><span>${reach}</span></span>`;
+    }
+
+    html+=`<div class="rung-card" data-rung="${rung}" style="background:${bg}">
+      <div class="rung-num" style="color:${color}">
+        <span class="rung-pip" style="background:${color}"></span>
+        Rung ${rung}
+      </div>
+      <div class="rung-name" style="color:${color}">${t.name||""}</div>
+      <div class="rung-engine">${t.engine||""}</div>
+      <div class="rung-when">${t.when||""}</div>
+      <div class="rung-footer">
+        ${certBadgeHtml(t.cert||"COMPLETE")}
+        ${statHtml}
+      </div>
+    </div>`;
+  });
+  wrap.innerHTML=html;
+}
+
+/* ── Surface Coverage ────────────────────────────────────────────────── */
+function renderSurfaces(surfaces){
+  const panel=document.getElementById("surfacePanel");
+  const content=document.getElementById("surfaceContent");
+  if(!surfaces){return;}
+  panel.style.display="";
+
+  const sem=surfaces.semantic||{};
+  const semEntries=[
+    {key:"clangd",label:"C++",color:"#F7768E"},
+    {key:"typescript",label:"TS/JS",color:"#38BDF8"},
+    {key:"roslyn",label:"C#",color:"#A78BFA"},
+    {key:"pyright",label:"Python",color:"#34D399"},
+  ].filter(function(e){return(sem[e.key]||0)>0;});
+
+  const docFormats=surfaces.docFormats||[];
+  const fs=surfaces.filesystem||{};
+
+  let codeRows="";
+  semEntries.forEach(function(e){
+    codeRows+=`<div class="surf-row"><span class="surf-dot" style="background:${e.color}"></span>${e.label}<span class="surf-val" style="margin-left:auto">${(sem[e.key]||0).toLocaleString()} files</span></div>`;
+  });
+  if(!semEntries.length){
+    codeRows=`<div class="surf-row" style="color:var(--faint)">no backend detected</div>`;
+  }
+  const tsLangs=surfaces.syntacticLangs||17;
+  codeRows+=`<div class="surf-row"><span class="surf-dot" style="background:#38BDF8"></span>tree-sitter<span class="surf-val" style="margin-left:auto">${tsLangs} langs</span></div>`;
+
+  let docRows="";
+  if(docFormats.length){
+    docRows=docFormats.map(function(f){
+      return`<div class="surf-row"><span class="surf-dot" style="background:#34D399"></span>${f}</div>`;
+    }).join("");
+  }else{
+    docRows=`<div class="surf-row" style="color:var(--faint)">md · toml · yaml · json · txt</div>`;
+  }
+
+  let fsHtml="";
+  if((fs.runs||0)>0){
+    fsHtml=`<div class="surf-row"><span class="surf-dot" style="background:#FACC15"></span>find_files / search_text<span class="surf-val" style="margin-left:auto">${fmtTok(fs.saved||0)} tok · ${(fs.runs||0).toLocaleString()} runs</span></div>`;
+  }else{
+    fsHtml=`<div class="surf-row"><span class="surf-dot" style="background:#FACC15"></span>find_files / search_text<span class="surf-val" style="color:var(--faint);margin-left:auto">sanctioned grep replacement</span></div>`;
+  }
+
+  content.innerHTML=`<div class="surf-grid">
+    <div>
+      <div class="surf-section-label">Code (semantic + syntactic)</div>
+      ${codeRows}
+    </div>
+    <div>
+      <div class="surf-section-label">Docs &amp; Config (section-level)</div>
+      ${docRows}
+      <div style="margin-top:10px">
+        <div class="surf-section-label">Filesystem</div>
+        ${fsHtml}
+      </div>
+    </div>
+  </div>`;
+}
+
+/* ── Completeness Certs legend ───────────────────────────────────────── */
+function renderCerts(certs){
+  const panel=document.getElementById("certsPanel");
+  const content=document.getElementById("certsContent");
+  if(!certs||!certs.length){return;}
+  panel.style.display="";
+
+  let html="";
+  certs.forEach(function(c){
+    html+=`<div class="cert-row">
+      ${certBadgeHtml(c.key)}
+      <span class="cert-desc">${c.desc||""}</span>
+    </div>`;
+  });
+  content.innerHTML=html;
+}
+
 /* ── Resize re-render (2D panels only) ───────────────────────────────── */
 let _resizeTimer=null;
 let _lastData=null;
@@ -654,6 +905,10 @@ fetch("/data")
     renderBars(s.days||[]);
     renderDonut(data.census||{});
     renderTools(s.tools||[]);
+
+    if(data.tiers) renderLadder(data.tiers);
+    if(data.surfaces) renderSurfaces(data.surfaces);
+    if(data.certs) renderCerts(data.certs);
 
     const g=data.graph||{nodes:[],links:[]};
     if(window.__dashDispatch) window.__dashDispatch(g);

--- a/server/viz.js
+++ b/server/viz.js
@@ -71,6 +71,47 @@ export function buildVizData(root) {
   let census = { clangd: 0, roslyn: 0, typescript: 0, pyright: 0, total: 0 };
   try { if (root) census = languageCensus(root); } catch { /* best-effort */ }
 
+  // PRECISION LADDER (the paper's identity made visible): vts answers at the highest precision it can reach
+  // and labels which rung. Each rung carries its engine, WHEN it applies, the completeness-certificate label
+  // it stamps, and — where the per-tool ledger attributes UNAMBIGUOUSLY — live saved/runs.
+  // ATTRIBUTION HONESTY (the per-tool ledger has no per-tier tag): the exact rung sums ONLY tools that are
+  // never anything but semantic-code — search_symbol/find_references/goto/hover/rename/diagnostics. The five
+  // DUAL-USE tools (read_symbol/document_symbols/replace_symbol_body/insert_symbol/safe_delete) also serve
+  // the SECTION tier (structTool runs them on .md/.toml/.yaml), so their savings can't be split code-vs-doc
+  // from the ledger alone — they are deliberately LEFT OUT of every rung's `saved` (they still count in the
+  // headline total + the per-tool bars). So a rung's `saved` is a clean lower bound, never cross-attributed.
+  // Syntactic activity flows through the exact tools as a documented fallback; its own saved stays 0 (reach
+  // shown instead). Section/syntactic show `reach`, not `saved` — no rung claims another's tokens.
+  const toolStat = (names) => names.reduce((a, n) => {
+    const v = (s.tools || {})[n];
+    if (v) { a.saved += Math.max(0, (v.rawTok || 0) - (v.outTok || 0)); a.runs += v.runs || 0; }
+    return a;
+  }, { saved: 0, runs: 0 });
+  const EXACT_TOOLS = ["search_symbol", "find_references", "goto_definition", "hover", "rename", "diagnostics"];
+  const exactStat = toolStat(EXACT_TOOLS), fuzzyStat = toolStat(["concept_search"]), fsStat = toolStat(["find_files", "search_text"]);
+  const tiers = [
+    { key: "exact", rung: 1, name: "Exact", engine: "Language server — clangd · Roslyn · tsserver · pyright", when: "you know the name and a toolchain is present", cert: "COMPLETE", tools: EXACT_TOOLS, saved: exactStat.saved, runs: exactStat.runs },
+    { key: "syntactic", rung: 2, name: "Syntactic", engine: "tree-sitter — 17 languages, zero setup", when: "no toolchain — declarations + tag-query references", cert: "SYNTACTIC", tools: [], reach: "17 languages", saved: 0, runs: 0 },
+    { key: "fuzzy", rung: 3, name: "Fuzzy", engine: "concept dictionary mined from the repo's own naming — no embeddings", when: "you only know the intent, not the symbol name", cert: "SYNTACTIC", tools: ["concept_search"], saved: fuzzyStat.saved, runs: fuzzyStat.runs },
+    { key: "section", rung: 4, name: "Section", engine: "Markdown · TOML · YAML · JSON · … addressed by heading", when: "it's a doc or config, not code", cert: "COMPLETE", tools: [], reach: "md · mdx · adoc · rst · toml · ini · yaml · json · txt", saved: 0, runs: 0 },
+  ];
+  // SURFACE COVERAGE (the "whole repo an agent sees" pillar): semantic backends detected in this root + the
+  // syntactic language reach + the document formats. filesystem (find_files/search_text) is the non-tiered
+  // sanctioned grep replacement.
+  const surfaces = {
+    semantic: census, // per-backend file counts in this root
+    syntacticLangs: 17, // tree-sitter: 10 hand-tuned + 7 tags-query
+    docFormats: ["markdown", "mdx", "asciidoc", "rst", "toml", "ini", "yaml", "json", "txt"],
+    filesystem: { saved: fsStat.saved, runs: fsStat.runs },
+  };
+  // Completeness-certificate legend (the precision-honesty pillar) — the labels vts stamps on every answer.
+  const certs = [
+    { key: "COMPLETE", desc: "semantic, every match returned (within the indexed/scoped set)" },
+    { key: "SYNTACTIC", desc: "tree-sitter declarations, zero setup — does not resolve refs/overloads/types" },
+    { key: "PARTIAL", desc: "capped or time-boxed — more exists, recoverable via the tee / a higher cap" },
+    { key: "INCONCLUSIVE", desc: "index still building or a 0 from a truncated walk — not a true zero" },
+  ];
+
   // include-graph → force-graph: nodes = cached files, edges = include relationships (basename match), node
   // weight = include fan-in (how many files include it). Capped to the highest-weight VTS_VIZ_MAX_NODES so the
   // browser sim stays smooth; links to dropped nodes are pruned.
@@ -101,6 +142,9 @@ export function buildVizData(root) {
     root: root || "",
     savings: { totalSaved, rawTok: rawCombined, outTok: outCombined, ratio, runs: runsCombined, usd: +((totalSaved / 1e6) * usdRate).toFixed(2), days, tools, sources },
     census,
+    tiers,
+    surfaces,
+    certs,
     graph,
   };
 }


### PR DESCRIPTION
Makes the tool's paper IDENTITY — the precision ladder — the visual centerpiece of the local dashboard, and sharpens one routing steer the work exposed. Designer + critic agents in the loop; screenshots verified via headless Chrome.

## Dashboard
- `viz.js`: `buildVizData` emits `tiers` (4 rungs — exact LSP → syntactic tree-sitter → fuzzy concept dictionary → section docs; each with engine, when-it-applies, the completeness-cert it stamps, live saved/runs), `surfaces` (semantic backends + 17 syntactic langs + 9 doc formats + filesystem), and `certs` (COMPLETE/SYNTACTIC/PARTIAL/INCONCLUSIVE legend).
- `dashboard.html`: a staircase PRECISION LADDER panel (tier-colored rung cards), SURFACE COVERAGE card, COMPLETENESS CERTIFICATES legend — between the stat strip and the chart. Self-contained (inline CSS/JS, no CDN; only external asset is the already-vendored same-origin Three.js). 3D graph untouched.

## Attribution honesty (critic finding, fixed)
The per-tool ledger has no per-tier tag, and 5 symbol tools (read_symbol/document_symbols/replace_symbol_body/insert_symbol/safe_delete) are DUAL-USE — structTool runs them on docs (section tier) too. So a rung's `saved` now sums ONLY unambiguous semantic-code tools (search_symbol/find_references/goto/hover/rename/diagnostics); dual-use tools are excluded from every rung (still in the headline total + per-tool bars). A rung's `saved` is a clean lower bound, never cross-tier.

## search_text symbol steer
A bare-identifier text query (the case the model keeps using instead of the semantic tool) now triggers the steer even when not truncated, and the steer LEADS the output instead of trailing under 60 matches. Regression-free: same hits, only the text reordered.

## Review points
- charter: zero-transmission intact (no external resource; verified no src=/href=/cdn). Output stays token-capped + precision-labeled. No embeddings.
- honesty: rung savings are a clean lower bound (no cross-tier double-count).
- Eval guard 72 extended (tiers/surfaces/certs + ladder panels present). EVAL PASSED, lint clean, CI green expected (incl. Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
