### PR TITLE
feat(steer): general alternation steer — route A|B|C of symbols to per-symbol semantic lookup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -463,12 +463,17 @@ repo while config pinned clangd for a UE tree) > forced `VTS_BACKEND`/config `ba
   TEXT query that is really a symbol/class usage hunt — a `Foo<Bar>` template arg (the `<Type>` wins), a `::`
   scope, or the longest CamelCase/snake identifier; null for `TODO|FIXME`/prose. `textSymbolSteer(q,truncated)`
   appends a one-line nudge to `find_references symbol="X"` / `search_symbol q="X"` (semantic, COMPLETE, no 4s
-  time-box, ~10–20× smaller) — fires only on a CODE scan (`!docs && !path`) when the result was TRUNCATED or the
-  query carries a `<>`/`::` cue (low-noise: a bare-CamelCase text search that completed isn't nagged). The
-  EMPTY-but-timed-out branch also steers AND flags that a `0` from a truncated walk is NOT conclusive (a real 0
-  and an unreached-in-time 0 are indistinguishable — `find_references` resolves which). `VTS_TEXT_STEER=0` off.
-  Born from a live case: the model used `search_text "FindComponentByClass<UMyComp>"` → 8-of-49 time-boxed slice;
-  `find_references` returned all 49 at 19×. Eval guard 58 (`symbolHuntInText` unit + integration).
+  time-box, ~10–20× smaller). The steer now LEADS the output (top, not trailing under 60 matches — the model
+  acts on the first lines it reads) and fires on a TRUNCATED scan, a `<>`/`::` cue, OR a BARE identifier (the
+  whole query is one symbol — the case the model keeps reaching for instead of the semantic tool). ALTERNATION
+  (`altSymbols(q)`, GENERAL over `|`, any N): `A|B|C` of CamelCase/snake identifiers → steers to `find_references`
+  PER symbol (find_references can't take a regex; search_text matched the whole alternation as full line text) —
+  lists each (cap 6 shown + "+N more"); a keyword/ALL-CAPS alternation (`TODO|FIXME`, `GET|POST`) is NOT a symbol
+  list → spared. The EMPTY-but-timed-out branch also steers AND flags that a `0` from a truncated walk is NOT
+  conclusive. `VTS_TEXT_STEER=0` off. Born live: `search_text "FindComponentByClass<UMyComp>"` → 8-of-49 slice,
+  `find_references` all 49 at 19×; and a UE `search_text "GetSyncModeComponent|GetSmoothSyncComponent"` that a
+  single search_symbol can't answer (regex) → per-symbol find_references. Eval guard 58 (`symbolHuntInText` +
+  `altSymbols` unit + integration).
 
 ## Identity (what we are) — and the roadmap rule it implies
 vs-token-safer is not "a code search tool." It is the layer an agent talks to instead of reading the

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1182,23 +1182,34 @@ const setupClangdOk =
 // 58) search_text → symbol steer — a TEXT query that is really a symbol/class usage hunt (a `Foo<Bar>`
 // template arg, `::` scope, or CamelCase/snake identifier) gets a one-line nudge toward find_references /
 // search_symbol (semantic, complete, no time-box) appended to the result; freeform/keyword text does NOT.
-const { symbolHuntInText } = await import("../server/core.js");
+const { symbolHuntInText, altSymbols } = await import("../server/core.js");
 const huntUnitOk =
   symbolHuntInText("FindComponentByClass<UMyComp>") === "UMyComp" &&   // template arg is the hunted type
   symbolHuntInText("MaxWalkSpeed") === "MaxWalkSpeed" &&               // dominant CamelCase identifier
   !!symbolHuntInText("get_value|set_value") &&                        // snake_case alternation → truthy
   symbolHuntInText("TODO|FIXME") === null &&                          // ALL-CAPS keyword → no symbol shape
   symbolHuntInText("just some plain words") === null;                 // prose → null
+// altSymbols: a symbol ALTERNATION (any N) → the full identifier list, for a per-symbol find_references
+// steer; a keyword/content alternation → null (not symbols). General over `|`, not just two branches.
+const altUnitOk =
+  JSON.stringify(altSymbols("getFoo|setBar|resetBaz")) === JSON.stringify(["getFoo", "setBar", "resetBaz"]) && // N=3, general
+  JSON.stringify(altSymbols("get_value|set_value")) === JSON.stringify(["get_value", "set_value"]) &&           // snake, deduped
+  altSymbols("TODO|FIXME") === null && altSymbols("GET|POST|HEAD") === null &&                                  // keyword/ALL-CAPS → not symbols
+  altSymbols("FooBar") === null && altSymbols("a|b") === null;                                                  // no `|` / no CamelCase cue → null
 // integration: a code scan whose q is a `<Type>` hunt steers; a plain-word q does not.
 const stDir = path.join(os.tmpdir(), `vts-eval-textsteer-${process.pid}`);
 fs.mkdirSync(stDir, { recursive: true });
 fs.writeFileSync(path.join(stDir, "use.cpp"), "auto* w = Owner->Helper<UMyWidget>();\nint plainword = 1;\n");
+fs.writeFileSync(path.join(stDir, "two.cpp"), "auto a = MakeWidgetAlpha();\nauto b = MakeWidgetBeta();\n");
 const stHunt = await runTool("search_text", { q: "Helper<UMyWidget>", projectPath: stDir });
 const stPlain = await runTool("search_text", { q: "plainword", projectPath: stDir });
+const stAlt = await runTool("search_text", { q: "MakeWidgetAlpha|MakeWidgetBeta", projectPath: stDir }); // 2-symbol alternation
 const textSteerOk =
-  huntUnitOk &&
+  huntUnitOk && altUnitOk &&
   /find_references symbol="UMyWidget"/.test(stHunt.text) &&   // symbol hunt → steer with the right name
-  !/find_references/.test(stPlain.text);                       // plain word → no steer
+  !/find_references/.test(stPlain.text) &&                     // plain word → no steer
+  /ALTERNATION of 2 symbols/.test(stAlt.text) &&               // alternation → per-symbol steer
+  /find_references symbol="MakeWidgetAlpha"/.test(stAlt.text) && /find_references symbol="MakeWidgetBeta"/.test(stAlt.text); // BOTH listed
 try { fs.rmSync(stDir, { recursive: true, force: true }); } catch { /* ignore */ }
 
 // 59) edit-warn control-flow exclusion — a multi-line `if (…) {` / `for (…) {` block edited INSIDE a

--- a/server/core.js
+++ b/server/core.js
@@ -174,12 +174,36 @@ export function symbolHuntInText(q) {
   if (!cand.length) return null;
   return cand.sort((a, b) => b.length - a.length)[0];
 }
+// An ALTERNATION of symbols (`A|B|C`, any N) — the model reaches for search_text because find_references
+// takes ONE name, not a regex. Pull every identifier branch so the steer can point at find_references PER
+// symbol (the general `|` case, not just two). Returns the deduped identifier list, or null when it isn't a
+// symbol alternation: every `|`-separated branch must be a bare identifier AND at least one must carry a
+// CamelCase/snake cue (so a keyword/content alternation — `TODO|FIXME`, `GET|POST|HEAD` — is NOT steered;
+// those are real text filters, not symbols, exactly as the grep-block hook classifies them).
+export function altSymbols(q) {
+  const s = String(q || "");
+  if (!s.includes("|") || s.length > 200) return null;
+  const branches = s.split("|").map((b) => b.trim()).filter(Boolean);
+  if (branches.length < 2) return null;
+  if (!branches.every((b) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(b))) return null; // any non-identifier branch → a regex, not a symbol list
+  if (!branches.some((b) => /[a-z][A-Z]|[a-z0-9]_[a-z]/.test(b))) return null;  // no CamelCase/snake cue → keyword alternation, leave it
+  return [...new Set(branches)];
+}
 const textSteerOn = () => !/^(0|false|off|no)$/i.test(String(process.env.VTS_TEXT_STEER ?? "1"));
 // Build the one-line steer, or "" — fires only on a clear symbol hunt that would actually benefit: the
 // scan was TRUNCATED (completeness now matters) OR the query carries a `<>`/`::` code cue. A bare CamelCase
 // text search that completed fine isn't nagged.
 function textSymbolSteer(q, truncated) {
   if (!textSteerOn()) return "";
+  // Alternation of symbols (A|B|C, any N) → steer to find_references on EACH (find_references can't take a
+  // regex; search_text matched the whole alternation as full line text). Fires regardless of truncation —
+  // an alternation of symbols always has a strictly better per-symbol semantic path.
+  const alts = altSymbols(q);
+  if (alts && alts.length >= 2) {
+    const list = alts.slice(0, 6).map((a) => `find_references symbol="${a}"`).join(" · ");
+    const more = alts.length > 6 ? ` (+${alts.length - 6} more)` : "";
+    return `\n↪ "${q}" is an ALTERNATION of ${alts.length} symbols — search_text matched it as one regex (full line text). find_references can't take A|B in one call; for semantic, COMPLETE results run ONE call per symbol: ${list}${more}.`;
+  }
   const sym = symbolHuntInText(q);
   if (!sym) return "";
   // "strong" cue = a code expression (`::`/`<>`) OR a BARE identifier (the whole query is one symbol name,


### PR DESCRIPTION
feat(steer): general alternation steer — route A|B|C of symbols to per-symbol semantic lookup

Live-found in a UE session: the model kept running a text scan on an alternation of symbols
(e.g. an A-or-B of two CamelCase names) because the semantic per-symbol tool takes ONE name, not
a regex - so a single semantic call can't answer A|B, and the model fell back to the text scan.

altSymbols(q) (core.js, exported) parses a `|` alternation GENERALLY (any N branches, not just
two): it returns the deduped identifier list when every branch is a bare identifier AND at least
one carries a CamelCase/snake cue; null otherwise - so a keyword/content alternation (TODO|FIXME,
GET|POST|HEAD - real text filters, ALL-CAPS, no symbol shape) is left alone, matching how the
grep-block hook already classifies these.

textSymbolSteer now leads with a per-symbol steer for such an alternation: it lists one semantic
per-symbol lookup per branch (cap 6 shown + "+N more"), explaining the regex can't go to the
single-name semantic tool. Fires regardless of truncation - an alternation of symbols always has
a strictly better per-symbol path. Single-symbol and template/`::` steers are unchanged.

Eval guard 58 extended: altSymbols over N=3 / snake / keyword / ALL-CAPS / no-`|` / no-cue cases,
plus an integration that a 2-symbol alternation scan lists BOTH per-symbol lookups. EVAL PASSED,
lint clean. CLAUDE.md steer bullet updated (lead + bare-identifier + general alternation).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
