### PR TITLE
feat(steer): bash code-edit steer + find_references nav steer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,9 @@ repo while config pinned clangd for a UE tree) > forced `VTS_BACKEND`/config `ba
   file:line tree]; codebase-memory-mcp `trace_path` parity but on the OFFICIAL LSP [zero-transmission, real
   semantic edges] and folded INTO find_references — NOT a new tool [no fixed-surface cost, reuses the symbol→pos
   resolution]. `vts trace-calls` CLI = `references --direction callers`. Eval guard 70; live-verified on the vts
-  repo itself), `goto_definition` (a `kind` param folds in
+  repo itself. NAV STEER (`refNavSteer`): a LARGE flat ref result (> cap or ≥`VTS_REF_NAV_MIN` 25) with no
+  `detail=` appends a one-line nudge to the CHEAPER views of the same set — `detail=file`/`dir` (per-file
+  blast-radius summary) or `direction=callers` (transitive caller tree); `VTS_REF_NAV=0` hides), `goto_definition` (a `kind` param folds in
   `type_definition`/`implementation`/`declaration` via `lsp.js gotoByKind` → 3 more LSP nav requests, NO new
   MCP tools), `hover`, `document_symbols`, `diagnostics` (compiler/linter errors+warnings for a file as a
   token-capped `file:line:col severity [code]: msg` list, sorted error→hint + count summary — the compact
@@ -218,7 +220,13 @@ repo while config pinned clangd for a UE tree) > forced `VTS_BACKEND`/config `ba
   `search_symbol` (≤`VTS_EDIT_STEER_MAX` 10) / `goto_definition` result (`VTS_EDIT_STEER=0` hides); (L1) the
   grep-block hook now also matches `Edit|MultiEdit` — a whole-decl replace/insert gets a MODEL-VISIBLE
   `emitWarn` with a READY symbol-edit call (`replace_symbol_body`/`insert_symbol`, `declSymbolName`
-  best-effort names it), `VTS_EDIT_WARN=0` off; (L2) OPT-IN escalation, `VTS_EDIT_BLOCK_AFTER` DEFAULT 0=OFF — set ≥1 and once the
+  best-effort names it), `VTS_EDIT_WARN=0` off; (L1-Bash) the hook ALSO catches a code-file edit done via
+  BASH — `sed -i`, an `awk` inplace/redirect, or a `python`/`perl` heredoc that opens a code file for write
+  (`isBashCodeEdit`: a code-ext path AND an explicit write/in-place signal must BOTH be present, so a
+  read-only `sed` pipe or a `python build.py` isn't nagged) — warn-only toward replace_symbol_body/
+  insert_symbol; the Edit-tool steer alone MISSED this (a python brace-match splice bypasses it — live-found
+  on a large irregular-indent function), and Bash file-surgery is a big slice of the low symbol-edit adoption;
+  (L2) OPT-IN escalation, `VTS_EDIT_BLOCK_AFTER` DEFAULT 0=OFF — set ≥1 and once the
   adoption ledger's ignore-`streak` hits it, a SAFE insert (`insertDecl && !replaceDecl` — `insert_symbol`
   can't corrupt) is BLOCKED ONCE (exit 2) then `resetStreak()` (fire-once, NOT a wall — a permanent block
   TRAPPED the agent: it fought the wall with Edit retries / code contortions instead of switching, and each

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -296,6 +296,16 @@ const findFileOpsOk =
   hFindDuMulti.status === 0 && !parseRw(hFindDuMulti).updatedInput &&
   hFindXargs.status === 0 && !parseRw(hFindXargs).updatedInput &&
   hFindTypeD.status === 0 && !parseRw(hFindTypeD).updatedInput;
+// BASH-EDIT steer (#7): a Bash command EDITING a code file (sed -i / awk inplace / python-write heredoc)
+// bypasses the Edit-tool steer → WARN toward replace_symbol_body/insert_symbol (never block). A read-only
+// or generation command (python build.py) is NOT nagged. The warn rides emitWarn → stdout additionalContext.
+const hSedI = runHook({ tool_name: "Bash", tool_input: { command: "sed -i 's/foo/bar/' src/Thing.cpp" } });
+const hPyWrite = runHook({ tool_name: "Bash", tool_input: { command: "python - <<'PY'\nopen('App.ts','w').write(x)\nPY" } });
+const hPyBuild = runHook({ tool_name: "Bash", tool_input: { command: "python build.py --target Editor" } });
+const bashEditOk =
+  hSedI.status === 0 && /replace_symbol_body/.test(hSedI.out || "") &&        // sed -i a code file → warn
+  hPyWrite.status === 0 && /replace_symbol_body/.test(hPyWrite.out || "") &&  // python write-heredoc → warn
+  hPyBuild.status === 0 && !/replace_symbol_body/.test(hPyBuild.out || "");   // python build (no write) → silent
 const rewriteOk =
   /cli\.js" files --q "\*\.cpp"/.test(hFind.updatedInput?.command || "") &&
   /cli\.js" symbol --q "SpawnActor"/.test(hGitGrep.updatedInput?.command || "") &&  // git grep identifier → symbol
@@ -1182,7 +1192,13 @@ const setupClangdOk =
 // 58) search_text → symbol steer — a TEXT query that is really a symbol/class usage hunt (a `Foo<Bar>`
 // template arg, `::` scope, or CamelCase/snake identifier) gets a one-line nudge toward find_references /
 // search_symbol (semantic, complete, no time-box) appended to the result; freeform/keyword text does NOT.
-const { symbolHuntInText, altSymbols } = await import("../server/core.js");
+const { symbolHuntInText, altSymbols, refNavSteer } = await import("../server/core.js");
+// refNavSteer: a LARGE flat find_references result offers the cheaper views (detail=file / direction=callers);
+// a small set is left alone (no nag). Pure fn, env-gated (VTS_REF_NAV=0 hides — default on).
+const refNavOk =
+  /detail=file/.test(refNavSteer(40, 60)) && /direction=callers/.test(refNavSteer(40, 60)) && // big set → offer summary/tree
+  refNavSteer(70, 60) !== "" &&                                                                // over the cap → offer
+  refNavSteer(5, 60) === "";                                                                   // small set → silent
 const huntUnitOk =
   symbolHuntInText("FindComponentByClass<UMyComp>") === "UMyComp" &&   // template arg is the hunted type
   symbolHuntInText("MaxWalkSpeed") === "MaxWalkSpeed" &&               // dominant CamelCase identifier
@@ -1205,7 +1221,7 @@ const stHunt = await runTool("search_text", { q: "Helper<UMyWidget>", projectPat
 const stPlain = await runTool("search_text", { q: "plainword", projectPath: stDir });
 const stAlt = await runTool("search_text", { q: "MakeWidgetAlpha|MakeWidgetBeta", projectPath: stDir }); // 2-symbol alternation
 const textSteerOk =
-  huntUnitOk && altUnitOk &&
+  huntUnitOk && altUnitOk && refNavOk &&
   /find_references symbol="UMyWidget"/.test(stHunt.text) &&   // symbol hunt → steer with the right name
   !/find_references/.test(stPlain.text) &&                     // plain word → no steer
   /ALTERNATION of 2 symbols/.test(stAlt.text) &&               // alternation → per-symbol steer
@@ -2010,6 +2026,7 @@ const rows = [
   ["log steer + empty hint → gamedev-log", logSteerOk, "true", logSteerOk],
   ["hook: rewrite code-grep / warn log+grep", hookOk, "true", hookOk],
   ["hook: rewrite find/git-grep, block complex/pipe, exclude", rewriteOk, "true", rewriteOk],
+  ["hook: bash code-edit steer (sed -i / python-write → replace_symbol_body; build script spared)", bashEditOk, "true", bashEditOk],
   ["search_text JS/TS + symbol→text fallback", jsTextOk, "true", jsTextOk],
   ["language census + adaptive cap + multi-prewarm", warmRatioOk, "true", warmRatioOk],
   ["vts_setup language census auto-config", setupOk, "true", setupOk],

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -145,6 +145,29 @@ function hasFileOpsContext(segments) {
   return segments.some((s) => FILE_OPS_EXECS.has(execOf(s)));
 }
 
+// A Bash command that EDITS a code file in place — `sed -i`, an `awk` inplace/redirect, or a python/perl
+// heredoc (or -c) that opens a code file for write. The edit-steer hook only matches the Edit/MultiEdit
+// TOOLS, so a model doing file surgery via Bash/python BYPASSED it entirely (live: an agent brace-matched +
+// spliced a large irregular-indent function in python — exactly what replace_symbol_body does natively). A
+// warn-only nudge toward the symbol-edit tools (edit by NAME via the parser range — no brace-matching, no
+// exact-match hazard, no whole-file read). FP-careful: a code-file path AND an explicit write/in-place
+// signal must BOTH be present, so a read-only `sed`/`awk` in a pipeline or a `python build.py` isn't nagged.
+const CODE_FILE_TOKEN = /[\w./\\-]+\.(c|cc|cxx|cpp|h|hpp|hh|hxx|inl|ipp|tpp|cs|ts|tsx|mts|cts|js|jsx|mjs|cjs|py|pyi)\b/i;
+function isBashCodeEdit(cmd) {
+  const s = String(cmd);
+  if (!CODE_FILE_TOKEN.test(s)) return false;                       // no code-file path → not a code edit
+  if (/\bsed\b[^|]*\s-i\b/.test(s)) return true;                    // sed -i (in-place)
+  if (/\bawk\b/.test(s) && (/-i\s+inplace/.test(s) || /\bawk\b[^|]*>/.test(s))) return true; // awk inplace / redirect to a file
+  if (/\b(?:python3?|perl)\b/.test(s) && /(<<|-c\b)/.test(s) &&     // python/perl heredoc or -c that WRITES
+      (/open\s*\([^)]*["'][aw]b?["']/.test(s) || /\.write(?:_text|_bytes)?\s*\(/.test(s) || /Path\s*\([^)]*\)\s*\.write/.test(s))) return true;
+  return false;
+}
+function bashEditNudge() {
+  return KO
+    ? "[vs-token-safer] Bash로 코드 파일을 수정 중이에요. 선언을 통째로 교체/추가하는 거면 이름으로 편집하세요 — replace_symbol_body symbol=<이름> / insert_symbol symbol=<앵커> (파서 range로 span 잡아 splice — brace-matching·exact-match·파일 통째 Read 불필요; preview 기본, apply=true 기록). 부분 in-place 수정이면 그대로 OK. 끄기: VTS_EDIT_WARN=0."
+    : "[vs-token-safer] Editing a code file via Bash. If you're replacing/adding a WHOLE declaration, edit by NAME — replace_symbol_body symbol=<name> / insert_symbol symbol=<anchor> (resolves the span via the parser range and splices — no brace-matching, no exact-match hazard, no whole-file read; preview by default, apply=true writes). A partial in-place tweak? Carry on. Disable: VTS_EDIT_WARN=0.";
+}
+
 // The executable key used for excludeCommands matching (git grep → "git").
 const excludeKeyOf = (segment) => execOf(segment);
 
@@ -706,6 +729,13 @@ process.stdin.on("end", () => {
   if (segments.some(isLogSearchSegment)) {
     emitWarn(LOG_NUDGE + setup);
     process.exit(0); // logs were never blocked — just point at the right tool
+  }
+  // Bash-based code-file EDIT (sed -i / awk inplace / python-write heredoc) — the model doing file surgery
+  // that bypasses the Edit-tool steer. Warn-only (never block — blocking mid-refactor would strand it),
+  // gated by the same VTS_EDIT_WARN switch as the Edit-tool steer.
+  if (editWarnOn() && isBashCodeEdit(cmd)) {
+    emitWarn(bashEditNudge() + setup);
+    process.exit(0);
   }
   process.exit(0);
 });

--- a/server/core.js
+++ b/server/core.js
@@ -224,6 +224,16 @@ const EDIT_STEER =
   "(position=after|before) / safe_delete (preview by default, apply=true writes). It skips reading the file into " +
   "context. (VTS_EDIT_STEER=0 to hide.)";
 const editSteerOn = () => process.env.VTS_EDIT_STEER !== "0" && process.env.VTS_EDIT_STEER !== "false";
+const refNavOn = () => process.env.VTS_REF_NAV !== "0" && process.env.VTS_REF_NAV !== "false";
+// Appended to a LARGE flat find_references result: the same dependents can be read far cheaper as a per-file
+// blast-radius SUMMARY (detail=file) or navigated as the transitive caller TREE (direction=callers) — point
+// the model at those instead of scrolling a long flat list. Only when the set is big (a handful of refs
+// doesn't need a summary). `VTS_REF_NAV=0` hides it.
+export function refNavSteer(n, max) {
+  if (!refNavOn()) return "";
+  if (n <= max && n < envInt("VTS_REF_NAV_MIN", 25)) return "";
+  return `\n↪ ${n} references — smaller views of the same set: detail=file (per-file blast-radius summary) or detail=dir; direction=callers (the transitive caller tree, before you change it). (VTS_REF_NAV=0 to hide.)`;
+}
 
 // First-use setup nudge: if the plugin has never been configured (no config file), prepend a one-time
 // pointer to setup the FIRST time a search/nav tool runs in a process. Once per process (not per call) so
@@ -2340,7 +2350,8 @@ export async function runTool(name, a = {}) {
       const detail = String(a.detail || "").toLowerCase();
       const refBody = (detail === "file" || detail === "dir") ? fmtRefSummary(locList, detail, max) : fmtLocations(locs, max, "reference(s)");
       const refCert = completenessCert({ shown: Math.min(locList.length, max), total: locList.length, truncated: locList.length > max ? "cap" : null, semantic: true, scoped: scopeDirsFor(root).length > 0 });
-      const refBodyFull = backendAdvisory(backendName, root) + `references of ${originLabel} (backend: ${backendName})${refTee}:\n` + refBody + refCert;
+      const refNav = detail ? "" : refNavSteer(locList.length, max); // a flat list with no detail= → offer the cheaper views
+      const refBodyFull = backendAdvisory(backendName, root) + `references of ${originLabel} (backend: ${backendName})${refTee}:\n` + refBody + refNav + refCert;
       if (a.symbol) maybeCounterfactual("find_references", String(a.symbol), root, locList, refBodyFull); // by-name → a NAME to shadow-grep
       return finishOut(locs, refBodyFull);
     }


### PR DESCRIPTION
feat(steer): bash code-edit steer + find_references nav steer (2 preemptive-routing gaps)

Two more "a cheaper tool exists but the model picks a costlier path, and the steer was post-hoc
or missing" gaps, both user-found.

#7 BASH code-edit steer (hooks/block-code-grep.js): the edit-steer hook only matched the
Edit/MultiEdit TOOLS, so a model editing a code file via Bash - sed -i, an awk inplace/redirect,
or a python/perl heredoc that opens a code file for write - bypassed it entirely (live: an agent
brace-matched and spliced a large irregular-indent function in python, exactly what
replace_symbol_body does natively). isBashCodeEdit detects it (a code-ext path AND an explicit
write/in-place signal must both be present - a read-only sed pipe or a python build.py is NOT
nagged) and warns toward replace_symbol_body/insert_symbol. Warn-only (never block - blocking
mid-refactor would strand the agent), gated by VTS_EDIT_WARN. This is a big slice of the low
symbol-edit adoption: Bash file-surgery was neither measured nor steered.

#1 find_references NAV steer (core.js refNavSteer): a large flat reference result (over the cap
or >= VTS_REF_NAV_MIN, default 25) with no detail= now appends a one-line nudge to the cheaper
views of the SAME set - detail=file/dir (per-file blast-radius summary) or direction=callers (the
transitive caller tree). VTS_REF_NAV=0 hides. Token-cap and contract unchanged (one trailing line).

Eval: guard 17b adds bash code-edit cases (sed -i / python-write warn; build script spared);
guard 58 adds refNavSteer unit (big set offers the views, small set silent). EVAL PASSED, lint
clean. CLAUDE.md updated (hook L1-Bash layer + find_references nav steer).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
