### PR TITLE
feat(concept,steer): committable synonym file + search_symbol uses-steer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,11 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   a strongly-matching file is lifted by `VTS_CONCEPT_IMPORT_FACTOR` 0.3 × the neighbour's score — reranks the
   matched set, never invents a match). A **click-feedback loop was CRITIC-REJECTED** (self-confirming via
   position bias, non-deterministic, unmeasurable, erodes inspectability); the charter-pure adaptation paths are
-  these code-mined structural signals + (future) an explicit committable synonym file. PRECISION-LADDER NAV
+  these code-mined structural signals + a **committable synonym file** (DONE): a team-curated, git-committable
+  `<root>/.vts-index/concept-synonyms.json` (`{ "term": ["syn", …] }`) — `concept.js parseSynonyms` (tokenises
+  keys+values) feeds `expandQuery({synonyms})`, injecting a curated bridge at weight 0.95 (below an exact 1.0,
+  above a mined neighbour); additive (absent/malformed → mined model alone), inspectable, deterministic, no
+  drift. Eval guard 83. PRECISION-LADDER NAV
   (`VTS_CONCEPT_STEER`): search_symbol(exact)+multi-word-miss → steers DOWN to concept_search; concept_search →
   points UP to find_references/goto. See [[identity-and-roadmap]].
 - `server/textstruct.js` — STRUCTURE tier for prose/config files (the naming-umbrella extension: token-safer

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -44,7 +44,8 @@ const lspOk = syms.length === 2 && syms[0].name === "SpawnHandler";
 const r1 = await runTool("search_symbol", { q: "Spawn", projectPath: process.cwd(), backend: "clangd" });
 // (search_symbol now factors the common dir prefix across rows, so the path may be relative under an
 // `under <prefix>/` header — assert the symbol + its file:line without requiring a contiguous absolute path.)
-const fmtOk = !r1.isError && /class SpawnHandler {2}@ /.test(r1.text) && /Foo\.cpp:42/.test(r1.text) && !/character|range|"kind"/.test(r1.text);
+const fmtOk = !r1.isError && /class SpawnHandler {2}@ /.test(r1.text) && /Foo\.cpp:42/.test(r1.text) && !/character|range|"kind"/.test(r1.text) &&
+  /find_references symbol="Spawn"/.test(r1.text) && /USED/.test(r1.text); // #2 uses-steer on a focused result (find call sites)
 
 // 3) token cap — a 1000-symbol index response collapses to a capped file:line list.
 const big = await runTool("search_symbol", { q: "ALL", projectPath: process.cwd(), backend: "clangd", maxResults: 60 });
@@ -1943,12 +1944,21 @@ const roslynOsPathOk =
 // 83) FUZZY concept retrieval (approach B): concept.js pure functions + the concept_search tool. The local
 // concept dictionary (identifier+comment co-occurrence) answers a concept query with no embeddings. Pure-fn
 // checks always run; the tool integration self-skips if the tree-sitter deps are absent.
-const { splitIdent: cSplit, tokenize: cTok, tokMatch: cMatch, buildConceptModel: cBuild, expandQuery: cExpand, scoreSymbol: cScore } = await import("../server/concept.js");
+const { splitIdent: cSplit, tokenize: cTok, tokMatch: cMatch, buildConceptModel: cBuild, expandQuery: cExpand, scoreSymbol: cScore, parseSynonyms: cParseSyn } = await import("../server/concept.js");
 const splitOk = JSON.stringify(cSplit("authenticateUser")) === JSON.stringify(["authenticate", "user"]) && cMatch("auth", "authenticate") === 0.7 && cTok("How does the auth flow?").includes("auth");
 // co-occurrence: auth co-occurs with login twice (>= minCooc) → expansion surfaces it; ui never co-occurs.
 const cModel = cBuild([["auth", "login", "session"], ["auth", "login", "token"], ["render", "button", "ui"]]);
 const cEnr = cExpand(cModel, ["auth"]);
 const expandOk = cEnr.has("login") && cEnr.get("auth") === 1 && cEnr.get("login") < 1 && !cEnr.has("ui");
+// COMMITTABLE SYNONYMS (#4): parseSynonyms tokenises keys+values (CamelCase/snake split, lowercased); a
+// curated synonym is injected at 0.95 (below an exact 1.0, above a mined neighbour) and is additive — a term
+// the mined model would NOT bridge (here `payment`→`billing`, never co-occurring) now expands.
+const cSyn = cParseSyn(JSON.stringify({ payment: ["billing", "invoice"], AuthFlow: "credential" }));
+const synOk = !!cSyn && JSON.stringify(cSyn.get("payment")) === JSON.stringify(["billing", "invoice"]) &&
+  cSyn.has("auth") && cSyn.has("flow") &&                                       // multi-token key split
+  cParseSyn("not json") === null && cParseSyn("[]") === null &&                // malformed/non-object → null
+  cExpand(cModel, ["payment"], { synonyms: cSyn }).get("billing") === 0.95 &&  // synonym injected at 0.95
+  cExpand(cModel, ["payment"]).get("billing") === undefined;                   // without the file: not bridged
 const scoreOk = cScore(cModel, cEnr, ["session", "auth"], []) > cScore(cModel, cEnr, ["render", "button"], []);
 let conceptToolOk = true;
 if (tsAvailable()) {
@@ -1976,7 +1986,7 @@ if (tsAvailable()) {
     /ladder.*[Cc]limb/.test(cr.text) && pathLocalityOk && importBoostOk; // ladder nav + path-locality + import-graph proximity
   try { fs.rmSync(cdir, { recursive: true, force: true }); } catch { /* ignore */ }
 }
-const conceptOk = splitOk && expandOk && scoreOk && conceptToolOk;
+const conceptOk = splitOk && expandOk && synOk && scoreOk && conceptToolOk;
 
 // 84) STRUCTURE tier (textstruct.js): prose/config files (markdown/toml/yaml/rst/…) get a SECTION tree, and
 // the existing symbol tools (document_symbols / read_symbol / replace_symbol_body / …) edit a section BY NAME

--- a/server/concept.js
+++ b/server/concept.js
@@ -214,9 +214,20 @@ export function idf(model, t) {
 // Expand a query's tokens through the local concept dictionary. Returns a Map<token, weight>: the query's own
 // tokens at weight 1, plus up to `k` neighbours per query token weighted by a saturating function of their
 // association (capped below 1 so an expanded term never outranks an exact one). minAssoc filters weak links.
-export function expandQuery(model, qTokens, { k = 6, minAssoc = 1.5, minCooc = 2, neighborMax = 0.85 } = {}) {
+// `synonyms` (optional Map<token, string[]>, from parseSynonyms over a committable .vts-index/concept-
+// synonyms.json) is the critic-approved charter-pure adaptation path: a human-curated, version-controlled,
+// inspectable expansion with NO drift (vs a self-learning click loop). A curated synonym is injected JUST
+// BELOW an exact match (0.95) and above any mined co-occurrence neighbour, so a hand-declared bridge
+// (auth → login/session) reliably beats the noisy mined ones without ever outranking a literal hit.
+export function expandQuery(model, qTokens, { k = 6, minAssoc = 1.5, minCooc = 2, neighborMax = 0.85, synonyms = null } = {}) {
   const weights = new Map();
   for (const t of qTokens) weights.set(t, 1);
+  if (synonyms) {
+    for (const t of qTokens) {
+      const ex = synonyms.get(t);
+      if (ex) for (const s of ex) { const st = String(s).toLowerCase(); if ((weights.get(st) || 0) < 0.95) weights.set(st, 0.95); }
+    }
+  }
   for (const t of qTokens) {
     const m = model.cooc.get(t);
     if (!m) continue;
@@ -275,4 +286,32 @@ export function scoreSymbol(
     }
   }
   return score;
+}
+
+// Parse a committable synonym file (JSON `{ "term": ["syn", …], … }`) into a Map<token, string[]> for
+// expandQuery. PURE (text → Map, no fs — the caller reads the file). Keys and values are tokenised the same
+// way identifiers are (CamelCase/snake split, lowercased), so a key `auth` or `AuthFlow` and a value
+// `login_session` all normalise to the same concept tokens the model uses. Returns null on a malformed /
+// empty file (the fuzzy rung then runs on the mined dictionary alone — the synonym file is purely additive).
+export function parseSynonyms(text) {
+  let obj;
+  try {
+    obj = JSON.parse(String(text));
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== "object" || Array.isArray(obj)) return null;
+  const m = new Map();
+  for (const [k, v] of Object.entries(obj)) {
+    const arr = Array.isArray(v) ? v : [v];
+    const terms = [];
+    for (const x of arr) for (const t of splitIdent(String(x))) terms.push(t);
+    const keys = splitIdent(String(k)); // a multi-token key (e.g. "auth flow") maps each of its tokens
+    for (const key of keys.length ? keys : [String(k).toLowerCase()]) {
+      const cur = m.get(key) || [];
+      for (const t of terms) if (!cur.includes(t)) cur.push(t);
+      if (cur.length) m.set(key, cur);
+    }
+  }
+  return m.size ? m : null;
 }

--- a/server/core.js
+++ b/server/core.js
@@ -21,7 +21,7 @@ import { recordEditEvent } from "./edit-ledger.js";
 import { compactGit, compactP4 } from "./compact.js";
 import { tsSearchSymbols, tsSearchReferences, tsFileDeclDocs, tsSupports, tsAvailable } from "./treesitter.js";
 import { searchSymIndex, buildSymIndex, symIndexPath, loadSymIndex } from "./symindex.js";
-import { splitIdent, tokenize, buildConceptModel, expandQuery, scoreSymbol, importSpecifiers } from "./concept.js";
+import { splitIdent, tokenize, buildConceptModel, expandQuery, scoreSymbol, importSpecifiers, parseSynonyms } from "./concept.js";
 import { isStructFile, structOutline, resolveSection, fmtOutline } from "./textstruct.js";
 
 const CONFIG_DIR = path.join(os.homedir(), ".vs-token-safer");
@@ -224,6 +224,7 @@ const EDIT_STEER =
   "(position=after|before) / safe_delete (preview by default, apply=true writes). It skips reading the file into " +
   "context. (VTS_EDIT_STEER=0 to hide.)";
 const editSteerOn = () => process.env.VTS_EDIT_STEER !== "0" && process.env.VTS_EDIT_STEER !== "false";
+const usesSteerOn = () => process.env.VTS_USES_STEER !== "0" && process.env.VTS_USES_STEER !== "false";
 const refNavOn = () => process.env.VTS_REF_NAV !== "0" && process.env.VTS_REF_NAV !== "false";
 // Appended to a LARGE flat find_references result: the same dependents can be read far cheaper as a per-file
 // blast-radius SUMMARY (detail=file) or navigated as the transitive caller TREE (direction=callers) — point
@@ -2015,7 +2016,12 @@ export async function runTool(name, a = {}) {
       if (!symbols.length) return finishOut([], `No indexable declarations under ${root} for concept search (no tree-sitter-supported files in scope?).` + EMPTY_HINT);
       const qToks = tokenize(String(a.q));
       if (!qToks.length) return err(`"${a.q}" has no usable concept tokens (too short / all stop-words). Try concrete nouns: "auth session token".`);
-      const enriched = expandQuery(model, qToks);
+      // COMMITTABLE synonyms (the critic-approved adaptation): a team-curated, git-committable
+      // .vts-index/concept-synonyms.json ({ "term": ["syn", …] }) augments the mined dictionary — inspectable,
+      // deterministic, no drift. Purely additive: absent/malformed → the mined model runs alone.
+      let synonyms = null;
+      try { synonyms = parseSynonyms(fs.readFileSync(path.join(root, ".vts-index", "concept-synonyms.json"), "utf8")); } catch { /* no committed synonyms */ }
+      const enriched = expandQuery(model, qToks, synonyms ? { synonyms } : {});
       // Kind weight: a fuzzy "how does X work" wants the function/class/type that EMBODIES the concept, not a
       // throwaway local const/var that merely mentions a word — demote those so the real declarations rank up.
       const kindW = (k) => (/^(const|var|local|decl|field|member)$/.test(k) ? 0.35 : 1);
@@ -2261,9 +2267,14 @@ export async function runTool(name, a = {}) {
       const focusN = focusCap(String(a.q), syms, max);
       const symTee = teeOverflow("search_symbol", a.q, syms.map((s) => `${s.name} @ ${locLine(s.location.uri, s.location.range)}`), focusN);
       const symEdit = editSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10) ? EDIT_STEER : ""; // focused lookup → likely an edit precursor
+      // Found the declaration(s); the other natural next step is "where is it USED?" — point at find_references
+      // by NAME (semantic call sites) so the model doesn't fall back to a grep for usages. Focused result only.
+      const symUses = usesSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10)
+        ? `\n↪ Where is "${a.q}" USED? find_references symbol="${a.q}" (all call sites, semantic) — add direction=callers for the caller tree.`
+        : "";
       const focusNote = focusN < max && focusN < syms.length ? ` — showing the ${focusN} best for an exact-name hit (raise maxResults or VTS_FOCUS=0 for all ${syms.length})` : "";
       const symCert = completenessCert({ shown: Math.min(focusN, syms.length), total: syms.length, truncated: focusN < syms.length ? "cap" : null, semantic: true, scoped: scopeDirsFor(root).length > 0 });
-      const symBody = adv + `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root})${focusNote}${symTee}:\n` + fmtSymbols(syms, focusN) + symEdit + symCert;
+      const symBody = adv + `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root})${focusNote}${symTee}:\n` + fmtSymbols(syms, focusN) + symEdit + symUses + symCert;
       maybeCounterfactual("search_symbol", String(a.q), root, syms.map((s) => s.location), symBody);
       return finishOut(syms, symBody);
     }


### PR DESCRIPTION
feat(concept,steer): committable synonym file for the fuzzy rung + search_symbol "uses?" steer

#4 COMMITTABLE SYNONYMS (the critic-approved charter-pure adaptation for concept_search): a
team-curated, git-committable <root>/.vts-index/concept-synonyms.json ({ "term": ["syn", ...] })
augments the mined co-occurrence dictionary. concept.js parseSynonyms tokenises keys+values
(CamelCase/snake split, lowercased) into a Map; expandQuery({synonyms}) injects a curated bridge
at weight 0.95 - just below an exact match (1.0) and above any mined neighbour - so a hand-declared
link (auth -> login/session) reliably beats the noisy mined ones without ever outranking a literal
hit. Purely additive: absent/malformed file -> the mined model runs alone. Inspectable,
deterministic, version-controlled, NO drift - the opposite of the rejected click-feedback loop.
core.js concept_search reads the file per query (best-effort) and passes it to expandQuery.

#2 search_symbol "uses?" steer: after locating a declaration (a focused result, <= VTS_EDIT_STEER_MAX),
append a one-line nudge to find_references symbol="X" (semantic call sites; direction=callers for
the caller tree) so the model doesn't fall back to a grep for usages - complements the existing
edit steer ("going to CHANGE one of these?"). VTS_USES_STEER=0 hides.

Eval: guard 83 extended (parseSynonyms tokenisation + malformed->null + a synonym bridges a term
the mined model would NOT, at 0.95); guard 2 asserts the uses-steer on a focused search_symbol.
EVAL PASSED, lint clean. Both verified live. CLAUDE.md concept bullet updated (synonym file DONE).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
