### PR TITLE
feat: more surfaces (css/scss + html injection) + unified precision label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,17 +126,30 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   whole file), `replace_symbol_body`/`insert_symbol`/`safe_delete` → edit a section BY ITS HEADING/KEY (no
   whole-file Read + line-count). EXTENSIBLE provider registry (`PROVIDERS`: ext→parser): markdown/mdx (ATX+
   setext, fence-aware), asciidoc, reStructuredText, toml/ini (`[section]`), yaml (indent-nested keys), json
-  (pretty-printed keys), txt (heuristic), **html/htm/xhtml** (`parseHtml`: `<h1-6>` + `<style>`/`<script>` blocks +
-  id-landmarks at L1, and WITHIN style/script the top-level CSS selectors / JS FUNCTIONS at L2 via a brace-depth
-  scan `htmlNetBraces`/`htmlJsDecl` — so read/replace_symbol target a rule or function BY NAME; dogfooded on
-  dashboard.html, a function read at ~124×. Heuristic not a sub-language parse [degrades to block on minified];
-  tree-sitter INJECTION for exact JS/CSS ranges is the deferred robustness upgrade). Each provider emits `[{level,title,line}]`; shared `computeSpans` sets
-  the section span (to the next heading of level ≤ this), `resolveSection` (exact-then-substring, `line` disambig)
-  + `fmtOutline` are format-agnostic — add a format = add one parser. core.js: `STRUCT_TOOLS` + `structTool`
-  (synthesises an LSP-shaped range from a section span → reuses `symbolEditResult`/`applyEditsToText`); an
-  `isStructFile(a.path)` SHORT-CIRCUIT runs BEFORE backend resolution (a .md/.toml has no language server). NO
-  new MCP tools (the 5 existing symbol tools just work on text files — zero tool-budget cost). Zero-dep, PURE,
-  local, token-capped. Eval guard 84. `vts symbols/read-symbol/replace-symbol/insert/safe-delete --path X.md`.
+  (pretty-printed keys), txt (heuristic), **css/scss/less** (`parseCss`: top-level selectors / at-rules
+  (`@media`/`@keyframes`) at L1, SCSS-nested rules deeper, each with an EXACT brace-matched span via the shared
+  `htmlNetBraces` scan — a stylesheet's "symbol tree" is its RULE hierarchy, so read/replace_symbol target ONE
+  rule), **html/htm/xhtml** (`parseHtml`: `<h1-6>` + `<style>`/`<script>` blocks + id-landmarks at L1, and WITHIN
+  style/script the top-level CSS selectors / JS FUNCTIONS at L2 via a brace-depth scan `htmlNetBraces`/
+  `htmlJsDecl` — so read/replace_symbol target a rule or function BY NAME; dogfooded on dashboard.html, a
+  function read at ~153×). The heuristic embedded JS/CSS decls are tagged `embedded` so they can be REPLACED by
+  exact tree-sitter ranges: **tree-sitter INJECTION is DONE** (was the deferred robustness upgrade) — `treesitter.js
+  htmlEmbeddedDecls(text)` re-parses each `<script>`/`<style>` with the real javascript/css grammar for EXACT
+  decl ranges, recovering decls the heuristic misses (a MINIFIED one-line script, two CSS rules on one line, and
+  — crucially — a function inside a top-level **IIFE** `(function(){…})()`, the dashboard.html pattern: the
+  heuristic's depth-0 brace scan misses it, the injection's `maxBlockDepth≤1` walk recovers it). textstruct stays
+  PURE (no fs/async/tree-sitter) — `structOutlineInjected(file,text,injector)` takes the parser from core.js
+  (which owns tree-sitter) and falls back to the heuristic when it returns null (deps absent); `resolveInOutline`
+  resolves against the already-computed (refined) outline. Each provider emits `[{level,title,line[,endLine]}]`;
+  shared `computeSpans` sets the section span (a provider `endLine` — brace-matched — wins over the to-next-heading
+  heuristic), `resolveSection`/`resolveInOutline` (exact-then-substring, `line` disambig) + `fmtOutline` are
+  format-agnostic — add a format = add one parser. core.js: `STRUCT_TOOLS` + `structTool` (synthesises an
+  LSP-shaped range from a section span → reuses `symbolEditResult`/`applyEditsToText`; computes the injected
+  outline ONCE, then resolves against it); an `isStructFile(a.path)` SHORT-CIRCUIT runs BEFORE backend resolution
+  (a .md/.toml/.css has no language server); document_symbols + read_symbol carry a `completenessCert({section})`
+  (the SECTION rung). NO new MCP tools (the 5 existing symbol tools just work on text files — zero tool-budget
+  cost). Zero-dep core, PURE, local, token-capped. Eval guards 84 (CSS provider) + 81 (HTML injection, under the
+  tree-sitter block). `vts symbols/read-symbol/replace-symbol/insert/safe-delete --path X.{md,css,html}`.
 - `server/backends/index.js` — clangd/roslyn/typescript/pyright spawn configs + `pickBackend(root)`
   (detect order: compile_commands→clangd > .sln/.csproj→roslyn > tsconfig/package.json→typescript >
   pyproject/*.py→pyright; strongest build-artifact first). MIXED-REPO FIX: a query that TARGETS a file uses
@@ -500,7 +513,15 @@ it's on:
 - **exact** when the name is known and a toolchain is present → the language server (semantic, ground truth);
 - **syntactic** when there's no toolchain → tree-sitter (zero setup, 36 langs);
 - **fuzzy** when only the intent is known → a concept dictionary mined from the repo's own naming (no embeddings);
-- **section-level** when it's a doc/config, not code → Markdown/TOML/YAML/… addressed by heading.
+- **section-level** when it's a doc/config, not code → Markdown/TOML/YAML/CSS/HTML/… addressed by heading/selector.
+
+UNIFIED PRECISION LABEL: every answer carries ONE `completenessCert(...)` line that names the RUNG it came from —
+`EXACT rung` (semantic), `SYNTACTIC rung`, `FUZZY rung`, `SECTION rung` — plus the coverage state a capped/
+timed-out answer of any rung falls through to (`PARTIAL` / `INCONCLUSIVE`). So the model always sees exactly which
+rung answered, never a fuzzy result mislabeled syntactic. The `INCONCLUSIVE` advisory is ACTIONABLE — it names the
+auto-scope commands (`vts setup --scope <module>`, then `vts preindex`) because a bounded walk on a big tree is
+exactly the case a scoped index fixes. `core.js completenessCert({semantic|syntactic|fuzzy|section|scoped})`; the
+viz tiers/certs legend mirrors the 4 rungs + 2 coverage states (`server/viz.js`). `VTS_CERT=0` hides it. Eval guard 76.
 
 Three things make it ours, and none of them is a backend: (1) it covers the WHOLE repo an agent sees — code,
 the "I don't know the name" case, and documents; (2) every answer is capped to `file:line`, labeled with its

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1591,15 +1591,18 @@ const htmlSelfContainedOk =
 // + find_references (36k saved) → exact tier = 90k / 5 runs; syntactic/section = 0 saved + a reach string.
 const exactT = vd.tiers.find((t) => t.key === "exact");
 const synT = vd.tiers.find((t) => t.key === "syntactic");
+const fuzzyT = vd.tiers.find((t) => t.key === "fuzzy");
+const sectionT = vd.tiers.find((t) => t.key === "section");
 const tiersOk =
   vd.tiers.length === 4 &&
   vd.tiers.map((t) => t.rung).join("") === "1234" &&
   vd.tiers.map((t) => t.name).join(",") === "Exact,Syntactic,Fuzzy,Section" &&
   !!exactT && exactT.saved === 90000 && exactT.runs === 5 && exactT.cert === "COMPLETE" && // attributed, no double-count
   !!synT && synT.saved === 0 && /17 languages/.test(synT.reach || "") &&                   // syntactic: reach, not saved
-  vd.surfaces.syntacticLangs === 17 && Array.isArray(vd.surfaces.docFormats) && vd.surfaces.docFormats.length === 9 && vd.surfaces.docFormats.includes("markdown") &&
+  !!fuzzyT && fuzzyT.cert === "FUZZY" && !!sectionT && sectionT.cert === "SECTION" &&       // each rung labels its OWN precision (no fuzzy↦SYNTACTIC mislabel)
+  vd.surfaces.syntacticLangs === 17 && Array.isArray(vd.surfaces.docFormats) && vd.surfaces.docFormats.length === 12 && vd.surfaces.docFormats.includes("markdown") && vd.surfaces.docFormats.includes("css") &&
   vd.surfaces.semantic && vd.surfaces.semantic.clangd === 3 &&
-  vd.certs.length === 4 && vd.certs.map((c) => c.key).join(",") === "COMPLETE,SYNTACTIC,PARTIAL,INCONCLUSIVE";
+  vd.certs.length === 6 && vd.certs.map((c) => c.key).join(",") === "COMPLETE,SYNTACTIC,FUZZY,SECTION,PARTIAL,INCONCLUSIVE";
 const { startServer } = await import("../server/serve.js");
 const { server, port, url } = await startServer(vizRoot, 0); // port 0 → OS-assigned ephemeral
 const httpGet = (p) => new Promise((res, rej) => { http.get({ host: "127.0.0.1", port, path: p }, (r) => { let b = ""; r.on("data", (d) => (b += d)); r.on("end", () => res({ status: r.statusCode, body: b, ct: r.headers["content-type"] })); }).on("error", rej); });
@@ -1721,7 +1724,17 @@ const certWired = /\[completeness: COMPLETE/.test(certScan.text || "");
 const certScopedOk = completenessCert({ shown: 3, total: 3, semantic: true, scoped: true }).includes("within the configured indexing scope")
   && !completenessCert({ shown: 3, total: 3, semantic: true, scoped: false }).includes("within the configured");
 try { fs.rmSync(certDir, { recursive: true, force: true }); } catch { /* ignore */ }
-const certOk = certComplete && certPartial && certTime && certIndex && certOff && certWired && certScopedOk;
+// UNIFIED PRECISION LABEL (#6): the cert names WHICH RUNG answered — exact / syntactic / fuzzy / section — so
+// each tier is honestly labeled (fuzzy is NOT mislabeled SYNTACTIC, section carries its own label), and the
+// INCONCLUSIVE advisory is ACTIONABLE (the concrete vts setup --scope / vts preindex auto-scope commands).
+const certExactRung = completenessCert({ shown: 3, total: 3, semantic: true }).includes("EXACT rung");
+const certFuzzy = (() => { const s = completenessCert({ shown: 5, total: 5, fuzzy: true }); return s.includes("FUZZY rung") && !s.includes("SYNTACTIC"); })();
+const certSection = completenessCert({ shown: 4, section: true }).includes("SECTION rung");
+const certSyntacticRung = completenessCert({ shown: 2, total: 2, syntactic: true }).includes("SYNTACTIC rung");
+const certAutoScope = completenessCert({ shown: 0, truncated: "time" }).includes("vts setup --scope")
+  && completenessCert({ truncated: "index" }).includes("vts preindex");
+const certOk = certComplete && certPartial && certTime && certIndex && certOff && certWired && certScopedOk &&
+  certExactRung && certFuzzy && certSection && certSyntacticRung && certAutoScope;
 
 // 77) counterfactual shadow measurement — the quasi-controlled answer to "did vts reach the same answer as
 // grep?". relateSets classifies vts's answer set against grep's; maybeCounterfactual (opt-in
@@ -1920,7 +1933,25 @@ if (tsAvailable()) {
   const incrOk = ib1.reparsed === 2 && ib1.reused === 0 && ib2.reparsed === 0 && ib2.reused === 2
     && ib3.reparsed === 1 && ib3.reused === 1 && !!(incrHit && incrHit.length);
   try { fs.rmSync(incrDir, { recursive: true, force: true }); } catch { /* ignore */ }
-  tsTierOk = fileExtractOk && searchOk && rankOk && idxPresent && idxLoadOk && idxSearchOk && refOk && noBackendRefOk && tagsTierOk && incrOk;
+  // (h) HTML EMBEDDED-CODE INJECTION: re-parse `<script>`/`<style>` blocks with the real javascript/css
+  // grammar for EXACT decl ranges, robust where the textstruct heuristic brace-scan degrades — a MINIFIED
+  // script (`var z=1;function mini(a){...}class C{}` on one line) and TWO CSS rules on one line, both of
+  // which the heuristic misses. The injector replaces the heuristic embedded heads; non-embedded heads stay.
+  const { htmlEmbeddedDecls: hED } = await import("../server/treesitter.js");
+  const { structOutlineInjected: sInj } = await import("../server/textstruct.js");
+  const injHtml = "<html>\n<h1>T</h1>\n<style>\n.box{color:red}.b2{margin:0}\n</style>\n<script>\n(function(){\nfunction iifeFn(){ return 1; }\nconst k = 2;\n})();\n</script>\n<script>var z=1;function mini(a){return a}class C{}</script>\n</html>\n";
+  const injO = await sInj("p.html", injHtml, hED);
+  const injDirect = await hED(injHtml);
+  const iife = injO.find((s) => s.title === "iifeFn");
+  const htmlInjectOk =
+    Array.isArray(injDirect) &&
+    injO.some((s) => s.title === ".box" && s.level === 2) &&
+    injO.some((s) => s.title === ".b2" && s.level === 2) &&          // 2nd rule on the SAME line — heuristic misses, injection finds
+    !!iife && iife.level === 2 && iife.line === 8 && iife.endLine === 8 && // IIFE-WRAPPED fn — the heuristic (depth-0) misses it; depth≤1 injection recovers it (the dashboard.html pattern)
+    injO.some((s) => s.title === "mini" && s.level === 2) &&         // minified one-line script — injection recovers the decls
+    injO.some((s) => s.title === "C" && s.level === 2) &&
+    injO.some((s) => s.title === "T" && s.level === 1);              // non-embedded heading preserved
+  tsTierOk = fileExtractOk && searchOk && rankOk && idxPresent && idxLoadOk && idxSearchOk && refOk && noBackendRefOk && tagsTierOk && incrOk && htmlInjectOk;
   try { fs.rmSync(tsDir, { recursive: true, force: true }); } catch { /* ignore */ }
 } else {
   console.log("  (tree-sitter deps absent — syntactic tier guard skipped, treated as pass)");
@@ -2027,7 +2058,18 @@ const htmlStructOk = sIs("page.html") &&
   htmlO.some((s) => s.title === "helper" && s.level === 2) &&    // arrow-const inside <script>
   !!htmlFn && htmlFn.line === 7 && htmlFn.endLine === 7 &&        // resolve a function → its EXACT brace-matched span (no over-capture)
   htmlO.find((s) => s.title === "doThing").endLine === 7;        // single-line fn closes on its own line
-const structOk = outlineOk && resolveOk && structToolOk && htmlStructOk;
+// CSS / SCSS provider (surface extension): a stylesheet's rule hierarchy is its section tree — top-level
+// selectors / at-rules at level 1, SCSS-nested rules deeper, each with an EXACT brace-matched span. So
+// read_symbol returns ONE rule and replace_symbol_body splices exactly it (no whole-file Read).
+const cssTxt = ".box {\n  color: red;\n}\n#main { padding: 0; }\n@media screen {\n  .inner {\n    margin: 1px;\n  }\n}\n";
+const cssO = sOutline("style.css", cssTxt);
+const cssInner = sResolve("style.scss", cssTxt, ".inner");
+const cssStructOk = sIs("style.css") && sIs("a.scss") && sIs("b.less") &&
+  cssO.find((s) => s.title === ".box" && s.level === 1)?.endLine === 3 &&        // multi-line rule, exact span
+  cssO.find((s) => s.title === "#main" && s.level === 1)?.endLine === 4 &&       // single-line rule closes on its own line
+  cssO.find((s) => s.title === "@media screen" && s.level === 1)?.endLine === 9 &&
+  !!cssInner && cssInner.level === 2 && cssInner.line === 6 && cssInner.endLine === 8; // nested rule → level 2, exact span
+const structOk = outlineOk && resolveOk && structToolOk && htmlStructOk && cssStructOk;
 
 await disposeClients(); // guard 75's read_symbol spawned a backend AFTER the earlier teardown — dispose it so node exits
 
@@ -2109,15 +2151,15 @@ const rows = [
   ["on-demand call graph + symbol autocomplete: buildCallGraph/listSymbols + /callgraph + /symbols routes", callGraphAllOk, "true", callGraphAllOk],
   ["result rerank (Semble-inspired, charter-pure): lexical+kind+history, stable, before the cap", rerankOk, "true", rerankOk],
   ["effective cuts: focus (exact→few) + concept (multi-term rank) + read-avoidance ledger", effectiveCutsOk, "true", effectiveCutsOk],
-  ["completeness certificate: COMPLETE/PARTIAL/INCONCLUSIVE label + wired into search_text + toggle", certOk, "true", certOk],
+  ["completeness certificate: unified precision label (exact/syntactic/fuzzy/section rung) + PARTIAL/INCONCLUSIVE coverage + actionable auto-scope advisory + wired into search_text + toggle", certOk, "true", certOk],
   ["counterfactual shadow grep: relateSets algebra + maybeCounterfactual records (vts⊆grep) + report + toggle", counterfactualEvalOk, "true", counterfactualEvalOk],
   ["adaptive escalation controller: warn/block policy (soft/escalate/back-off) + conversion crediting + report", adaptiveCtrlOk, "true", adaptiveCtrlOk],
   ["indexing scope: scopeDirs/inScope + scopedCdb prune + stats + fallbacks + clangd-indexer kill switch", scopeOk, "true", scopeOk],
   ["tool-routing policy: suppress steer on generated/build paths (CC-native) + routing digest + toggle", policyOk, "true", policyOk],
-  ["syntactic tier: tree-sitter decl extraction (36 langs, zero setup) + committable .vts-index symbol index", tsTierOk, "true", tsTierOk],
+  ["syntactic tier: tree-sitter decl extraction (36 langs, zero setup) + committable .vts-index symbol index + HTML <script>/<style> exact-range injection", tsTierOk, "true", tsTierOk],
   ["Roslyn dotnet-host path OS-aware (macOS/Linux C# regression: win32/darwin/linux globalStorage)", roslynOsPathOk, "true", roslynOsPathOk],
   ["fuzzy concept retrieval (B): repo co-occurrence dictionary + concept_search (no embeddings, ranked decls)", conceptOk, "true", conceptOk],
-  ["structure tier: section outline/read/edit for md/toml/yaml/html/… via the symbol tools (no backend, by heading/selector/function)", structOk, "true", structOk],
+  ["structure tier: section outline/read/edit for md/toml/yaml/html/css/scss/… via the symbol tools (no backend, by heading/selector/rule/function)", structOk, "true", structOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/core.js
+++ b/server/core.js
@@ -19,10 +19,10 @@ import { classifyDeclEdit } from "./edit-detect.js";
 import { counterfactualOn, relateSets, recordCounterfactual, grepKey, locKey, counterfactualReport } from "./counterfactual.js";
 import { recordEditEvent } from "./edit-ledger.js";
 import { compactGit, compactP4 } from "./compact.js";
-import { tsSearchSymbols, tsSearchReferences, tsFileDeclDocs, tsSupports, tsAvailable } from "./treesitter.js";
+import { tsSearchSymbols, tsSearchReferences, tsFileDeclDocs, tsSupports, tsAvailable, htmlEmbeddedDecls } from "./treesitter.js";
 import { searchSymIndex, buildSymIndex, symIndexPath, loadSymIndex } from "./symindex.js";
 import { splitIdent, tokenize, buildConceptModel, expandQuery, scoreSymbol, importSpecifiers, parseSynonyms } from "./concept.js";
-import { isStructFile, structOutline, resolveSection, fmtOutline } from "./textstruct.js";
+import { isStructFile, structOutlineInjected, resolveInOutline, fmtOutline } from "./textstruct.js";
 
 const CONFIG_DIR = path.join(os.homedir(), ".vs-token-safer");
 export const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(CONFIG_DIR, "config.json");
@@ -1089,29 +1089,45 @@ function factorCommonPrefix(lines) {
 function certOn() { return !/^(0|false|off|no)$/i.test(String(process.env.VTS_CERT ?? "1")); }
 // truncated: falsy | "cap" | "time" | "scan". semantic=true → a language-server index answered (authoritative
 // 0); false → a bounded lexical scan. shown/total optional (total null = unknown upper bound).
-function completenessCert({ shown = 0, total = null, truncated = null, semantic = false, scoped = false, syntactic = false } = {}) {
+function completenessCert({ shown = 0, total = null, truncated = null, semantic = false, scoped = false, syntactic = false, fuzzy = false, section = false } = {}) {
   if (!certOn()) return "";
-  // The SYNTACTIC tier (tree-sitter / committed index) finds DECLARATIONS without a toolchain, but it does not
-  // resolve references, overloads, or types — so even a "complete" syntactic answer is not the semantic
-  // certainty the LSP gives. Label it as such so the agent knows a language server would tighten it.
+  // ONE label names BOTH which precision RUNG answered AND how complete the set is (the unified precision
+  // label). The four ladder rungs — exact (semantic LSP) / syntactic (tree-sitter) / fuzzy (concept dictionary)
+  // / section (structure tier) — each carry their own honesty caveat; a capped/timed-out result falls through
+  // to the PARTIAL / INCONCLUSIVE coverage states instead. So the agent always sees exactly which rung it's on.
+  //
+  // SECTION rung — the structure tier (docs/config) addressed by heading/selector/rule. Exact text spans, but
+  // document structure, not semantic code analysis.
+  if (section) {
+    return `\n[completeness: SECTION rung — the structure tier returned ${shown} section(s) addressed by heading/selector/rule (exact text spans, no language server); this is document structure, not semantic code.]`;
+  }
+  // FUZZY rung — the concept dictionary mined from the repo's own naming (no embeddings). Related, not exact.
+  if (fuzzy && truncated !== "cap" && !(total != null && shown < total)) {
+    return `\n[completeness: FUZZY rung — a concept dictionary mined from the repo's own naming matched ${shown} declaration(s) by co-occurrence (no embeddings); related, not exact. Climb to find_references/goto_definition on a hit for ground truth.]`;
+  }
+  // SYNTACTIC rung — tree-sitter / committed index finds DECLARATIONS without a toolchain, but does not resolve
+  // references, overloads, or types — so even a "complete" syntactic answer is not the semantic certainty the
+  // LSP gives. Label it as such so the agent knows a language server would tighten it.
   if (syntactic && truncated !== "cap" && !(total != null && shown < total)) {
-    return `\n[completeness: SYNTACTIC — tree-sitter found ${shown} declaration(s) with zero project setup; this tier locates decls but does NOT resolve references/overloads/types. Install a language server (or generate compile_commands.json) for semantic certainty.]`;
+    return `\n[completeness: SYNTACTIC rung — tree-sitter found ${shown} declaration(s) with zero project setup; this tier locates decls but does NOT resolve references/overloads/types. Install a language server (or generate compile_commands.json) for semantic certainty.]`;
   }
   // When an indexing scope is active, a semantic COMPLETE (or authoritative 0) is complete WITHIN THE SCOPE,
   // not across the whole project — qualify it so the agent doesn't read it as project-wide coverage.
   const within = scoped ? " within the configured indexing scope (not the whole project — widen or unset the scope for full coverage)" : "";
+  // INCONCLUSIVE walks are where AUTO-SCOPE pays off: a bounded scan on a big tree is exactly the case a scoped
+  // index fixes, so the advisory is actionable (the concrete `vts setup --scope` + `vts preindex` commands).
   if (truncated === "time" || truncated === "scan") {
     const how = truncated === "time" ? "time-boxed" : "scan-limited";
-    return `\n[completeness: INCONCLUSIVE — a bounded ${how} walk did not cover the whole tree, so this result (a 0 included) may be incomplete; narrow the scope or use a semantic tool (search_symbol/find_references) to certify.]`;
+    return `\n[completeness: INCONCLUSIVE — a bounded ${how} walk did not cover the whole tree, so this result (a 0 included) may be incomplete. Narrow the indexing scope (vts setup --scope <module>, then vts preindex) or use a semantic tool (search_symbol/find_references) to certify.]`;
   }
   if (truncated === "index") {
-    return `\n[completeness: INCONCLUSIVE — this backend answers from open/indexed files only, so a symbol whose file isn't indexed yet can be missed; this is not an authoritative 0.]`;
+    return `\n[completeness: INCONCLUSIVE — this backend answers from open/indexed files only, so a symbol whose file isn't indexed yet can be missed; this is not an authoritative 0. A big tree indexes far faster scoped (vts setup --scope <module>, then vts preindex).]`;
   }
   if (truncated === "cap" || (total != null && shown < total)) {
     const more = total != null ? `${shown} of ${total}` : `the top ${shown}`;
     return `\n[completeness: PARTIAL — showing ${more}; the remainder is known and recoverable (raise the cap or read the tee file).]`;
   }
-  return `\n[completeness: COMPLETE — ${semantic ? "the language-server index" : "the bounded scan"} returned every match${within} (${shown}).]`;
+  return `\n[completeness: ${semantic ? "EXACT rung, COMPLETE" : "COMPLETE"} — ${semantic ? "the language-server index" : "the bounded scan"} returned every match${within} (${shown}).]`;
 }
 export { completenessCert };
 function fmtLocations(locs, max, label) {
@@ -1706,16 +1722,18 @@ async function structTool(name, a, root, { finishOut, err, symbolEditResult }) {
   const file = (path.isAbsolute(String(a.path)) ? String(a.path) : path.join(root, String(a.path))).replace(/\\/g, "/");
   let text; try { text = fs.readFileSync(file, "utf8"); } catch { return err(`structure: cannot read ${a.path}.`); }
   const max = Number(a.maxResults) || MAX_RESULTS;
+  // Compute the outline once. For HTML the embedded `<script>`/`<style>` JS/CSS decls are REFINED to exact
+  // tree-sitter ranges (htmlEmbeddedDecls) when the grammars are present, else the heuristic brace-scan stands.
+  const o = await structOutlineInjected(file, text, htmlEmbeddedDecls);
   if (name === "document_symbols") {
-    const o = structOutline(file, text);
     if (!o.length) return finishOut([], `No sections found in ${file} (no headings/keys recognised).`);
     try { recordQueryResults(root, [file]); } catch { /* best-effort */ }
-    return finishOut(o, `outline of ${file} — ${o.length} section(s) (structure tier, no language server):\n` + fmtOutline(o, max));
+    return finishOut(o, `outline of ${file} — ${o.length} section(s) (structure tier, no language server):\n` + fmtOutline(o, max) + completenessCert({ shown: o.length, section: true }));
   }
   // the remaining tools target one named section (accept `symbol` — reuses the symbol tools — or `section`).
   const title = a.symbol != null ? a.symbol : a.section;
   if (title == null) return err(`${name} on a text file needs \`symbol\` (the section heading/key to target). Run document_symbols on it first to see the sections.`);
-  const sec = resolveSection(file, text, title, { line: a.line != null ? Number(a.line) + 1 : null });
+  const sec = resolveInOutline(o, title, { line: a.line != null ? Number(a.line) + 1 : null });
   if (!sec) return err(`No section titled "${title}" in ${file}. Run document_symbols to list the headings (match is exact-then-substring; pass line= to disambiguate repeats).`);
   const lines = text.split(/\r?\n/);
   // synthesise an LSP-shaped range that spans whole section lines: start of the heading line → start of the
@@ -1732,7 +1750,7 @@ async function structTool(name, a, root, { finishOut, err, symbolEditResult }) {
     const omitted = sec.endLine - end;
     const note = omitted > 0 ? `\n… ${omitted} more line(s)${sigOnly ? " (heading only — omit signatureOnly for the section)" : ` — raise VTS_SYMBOL_MAX_LINES (now ${cap})`}.` : "";
     try { recordQueryResults(root, [file]); } catch { /* best-effort */ }
-    return finishOut(text, `section "${sec.title}" @ ${file}:${sec.line}-${sec.endLine} (structure tier):\n` + body + note);
+    return finishOut(text, `section "${sec.title}" @ ${file}:${sec.line}-${sec.endLine} (structure tier):\n` + body + note + completenessCert({ shown: 1, section: true }));
   }
   const apply = a.apply === true || a.apply === "true";
   if (name === "replace_symbol_body") {
@@ -2049,11 +2067,11 @@ export async function runTool(name, a = {}) {
       const floor = (scoredAll[0]?.sc || 0) * Number(process.env.VTS_CONCEPT_FLOOR || 0.2);
       const conceptMax = Math.min(max, envInt("VTS_CONCEPT_MAX", 15));
       const ranked = scoredAll.filter((r) => r.sc >= floor).slice(0, conceptMax);
-      if (!ranked.length) return finishOut([], `No concept matches for "${a.q}" under ${root} (the repo's own naming may not bridge those words — try search_text, or a synonym).` + EMPTY_HINT + completenessCert({ shown: 0, total: 0, syntactic: true }));
+      if (!ranked.length) return finishOut([], `No concept matches for "${a.q}" under ${root} (the repo's own naming may not bridge those words — try search_text, or a synonym).` + EMPTY_HINT + completenessCert({ shown: 0, total: 0, fuzzy: true }));
       const expTerms = [...enriched].filter(([t]) => !qToks.includes(t)).slice(0, 8).map(([t]) => t);
       const rows = ranked.map((r) => `${r.s.file}:${r.s.line}: ${r.s.kind} ${r.s.name}`);
       const expLine = expTerms.length ? `\n  concept-expanded with: ${expTerms.join(", ")} (mined from this repo's own naming, not a model)` : "";
-      const cert = completenessCert({ shown: rows.length, total: ranked.length, truncated: null, syntactic: true });
+      const cert = completenessCert({ shown: rows.length, total: ranked.length, truncated: null, fuzzy: true });
       let flow = "";
       if (a.flow === true || a.flow === "true") {
         try {

--- a/server/dashboard.html
+++ b/server/dashboard.html
@@ -785,6 +785,8 @@ function renderTools(tools){
 const CERT_COLORS={
   COMPLETE:  {color:"#34D399",bg:"rgba(52,211,153,.12)"},
   SYNTACTIC: {color:"#38BDF8",bg:"rgba(56,189,248,.12)"},
+  FUZZY:     {color:"#A78BFA",bg:"rgba(167,139,250,.12)"},
+  SECTION:   {color:"#2DD4BF",bg:"rgba(45,212,191,.12)"},
   PARTIAL:   {color:"#FACC15",bg:"rgba(250,204,21,.12)"},
   INCONCLUSIVE:{color:"#737373",bg:"rgba(115,115,115,.12)"},
 };

--- a/server/textstruct.js
+++ b/server/textstruct.js
@@ -212,12 +212,12 @@ function parseHtml(lines) {
       if (depth <= 0 && openDecl == null) {
         if (mode === "script") {
           const nm = htmlJsDecl(ln);
-          if (nm) { heads.push({ level: 2, title: nm, line: i + 1 }); openDecl = heads.length - 1; }
+          if (nm) { heads.push({ level: 2, title: nm, line: i + 1, embedded: "script" }); openDecl = heads.length - 1; }
         } else {
           const at = /^\s*(@[\w-]+[^{]*?)\s*\{/.exec(ln);            // @media / @keyframes … (single- or multi-line)
           const sel = /^\s*([.#]?[^{}@/][^{}]*?)\s*\{/.exec(ln);    // a CSS rule opener (brace may not end the line)
-          if (at) { heads.push({ level: 2, title: at[1].trim().slice(0, 60), line: i + 1 }); openDecl = heads.length - 1; }
-          else if (sel) { heads.push({ level: 2, title: sel[1].trim().slice(0, 60), line: i + 1 }); openDecl = heads.length - 1; }
+          if (at) { heads.push({ level: 2, title: at[1].trim().slice(0, 60), line: i + 1, embedded: "style" }); openDecl = heads.length - 1; }
+          else if (sel) { heads.push({ level: 2, title: sel[1].trim().slice(0, 60), line: i + 1, embedded: "style" }); openDecl = heads.length - 1; }
         }
       }
       depth += htmlNetBraces(ln);
@@ -249,9 +249,44 @@ function parseHtml(lines) {
   return heads;
 }
 
+// CSS / SCSS / LESS: a stylesheet's "symbol tree" is its RULE hierarchy. Each top-level selector or at-rule
+// (`@media`, `@keyframes`, …) is a section; SCSS/LESS nesting falls out of brace depth (a rule inside a rule is
+// one level deeper). Same brace-depth scan + exact-endLine brace-match as the HTML `<style>` branch, reused
+// here for standalone stylesheets — so read_symbol returns ONE rule and replace_symbol_body splices exactly its
+// span (no whole-file Read + line-count). HONEST LIMIT (shared with HTML): heuristic brace depth, not a CSS
+// parse — a multi-line selector list (`.a,\n.b {`) is keyed by its first line, a minified file degrades to
+// fewer/coarser rules, and a `{`/`}` inside an unterminated string/comment the stripper misses can skew a span.
+function parseCss(lines) {
+  const heads = [];
+  let depth = 0;
+  const stack = []; // { idx, baseDepth } — a multi-line rule closes (exact endLine) when depth returns to base
+  for (let i = 0; i < lines.length; i++) {
+    const ln = lines[i];
+    const net = htmlNetBraces(ln);
+    // A line that OPENS a rule at the current nesting level: an at-rule (`@media … {`) or a selector (`.x {`,
+    // `#id {`, `&:hover {`, `div > p {`). The `{` may close on the same line (a complete one-line rule) or open
+    // a multi-line body. A bare declaration (`color: red;`) has no `{` so it never matches.
+    const at = /^\s*(@[\w-]+[^{]*?)\s*\{/.exec(ln);
+    const sel = /^\s*([.#&]?[^{}@/][^{}]*?)\s*\{/.exec(ln);
+    const title = at ? at[1].trim() : sel ? sel[1].trim() : null;
+    if (title) {
+      heads.push({ level: depth + 1, title: title.replace(/\s+/g, " ").slice(0, 60), line: i + 1 });
+      if (net > 0) stack.push({ idx: heads.length - 1, baseDepth: depth });
+      else heads[heads.length - 1].endLine = i + 1; // single-line complete rule
+    }
+    depth += net;
+    if (depth < 0) depth = 0;
+    while (stack.length && depth <= stack[stack.length - 1].baseDepth) {
+      heads[stack.pop().idx].endLine = i + 1; // body closed → exact span
+    }
+  }
+  return heads;
+}
+
 const PROVIDERS = [
   { exts: /\.(md|markdown|mdx|mkd|mdown)$/i, parse: parseMarkdown },
   { exts: /\.(html?|xhtml|htm)$/i, parse: parseHtml },
+  { exts: /\.(css|scss|less)$/i, parse: parseCss },
   { exts: /\.(adoc|asciidoc|asc)$/i, parse: parseAsciiDoc },
   { exts: /\.(rst|rest)$/i, parse: parseRst },
   { exts: /\.(toml|ini|cfg|conf|properties|editorconfig|gitconfig)$/i, parse: parseIni },
@@ -312,6 +347,28 @@ export function structOutline(file, text) {
   return computeSpans(p.parse(lines), lines.length);
 }
 
+// Async outline that lets a caller REFINE the HTML embedded-code sections (the `<script>`/`<style>` JS/CSS
+// decls) via an injected parser, while keeping this module pure — the parser (tree-sitter) is owned by core.js
+// and supplied as `embeddedDeclParser(text) → [{ level, title, line, endLine, embedded }] | null`. When it
+// returns decls, the heuristic embedded heads (tagged `embedded`) are dropped and replaced by the exact ones;
+// null / empty / throw → the heuristic outline stands. For any non-HTML file this is exactly structOutline.
+export async function structOutlineInjected(file, text, embeddedDeclParser) {
+  const p = providerFor(file);
+  if (!p) return [];
+  const lines = String(text).split(/\r?\n/);
+  let heads = p.parse(lines);
+  if (embeddedDeclParser && /\.(html?|xhtml)$/i.test(String(file))) {
+    try {
+      const injected = await embeddedDeclParser(text);
+      if (injected && injected.length)
+        heads = heads.filter((h) => !h.embedded).concat(injected).sort((a, b) => a.line - b.line);
+    } catch {
+      /* keep the heuristic heads */
+    }
+  }
+  return computeSpans(heads, lines.length);
+}
+
 // Back-compat alias (markdown was the first provider).
 export function mdOutline(text) {
   return computeSpans(parseMarkdown(String(text).split(/\r?\n/)), String(text).split(/\r?\n/).length);
@@ -320,8 +377,12 @@ export function mdOutline(text) {
 // Resolve ONE section by title for read/edit. Exact title (case-insensitive) beats a substring; a `line`
 // (1-based, inside the section) disambiguates repeats; a `level` filters by depth. → { level, title, line,
 // endLine } or null.
-export function resolveSection(file, text, title, { line = null, level = null } = {}) {
-  const outline = structOutline(file, text);
+export function resolveSection(file, text, title, opts = {}) {
+  return resolveInOutline(structOutline(file, text), title, opts);
+}
+// Resolve ONE section against an ALREADY-COMPUTED outline (so the injected/refined HTML outline is resolved
+// against, not recomputed). Same matching rules as resolveSection.
+export function resolveInOutline(outline, title, { line = null, level = null } = {}) {
   if (!outline.length || !title) return null;
   const want = String(title).trim().toLowerCase();
   const cands = outline.filter((s) => level == null || s.level === level);

--- a/server/treesitter.js
+++ b/server/treesitter.js
@@ -836,3 +836,155 @@ export async function tsFileDeclDocs(absPath, { maxBytes = 2_000_000, gap = 3 } 
   }
   return out;
 }
+
+// ── HTML EMBEDDED-CODE INJECTION (the robustness upgrade over the textstruct.js heuristic brace-scan). The
+// HTML structure provider locates `<script>`/`<style>` blocks and, WITHIN them, the top-level JS functions /
+// CSS rules by counting brace depth — exact for well-formatted code, but a minified or oddly-formatted block
+// degrades to the whole block. Tree-sitter is the official parser for those very languages, so here we re-parse
+// each embedded block with the real javascript / css grammar and hand back EXACT decl ranges. textstruct.js
+// stays pure (no fs/async/tree-sitter) — it tags its heuristic embedded heads with `embedded` and core.js
+// supplies THIS as the injector, which REPLACES those heads when tree-sitter is available. Returns null when
+// tree-sitter is unavailable (caller keeps the heuristic) — never throws.
+
+// Count of newlines before a string offset (= the 0-based line the offset sits on; added to a within-block
+// 1-based line to get the absolute 1-based line).
+function _newlinesBefore(s, idx) {
+  let n = 0;
+  for (let i = 0; i < idx && i < s.length; i++) if (s.charCodeAt(i) === 10) n++;
+  return n;
+}
+
+// Walk a raw source STRING with a hand-tuned cfg (decl set + kind map) and return declarations with EXACT
+// start+end lines (1-based, within the string). `maxBlockDepth` bounds how deeply nested a decl may be (depth =
+// the count of enclosing `{ }` scopes — statement_block / class_body): 0 = top-level only, 1 ALSO captures the
+// VERY common pattern of a script wrapped in one top-level IIFE (`(function(){ … })()`) and the methods of a
+// top-level class, while still skipping the inner helper closures (depth ≥ 2) that would clutter the outline.
+// This is the robustness win over the heuristic, which — like a depth-0 filter — misses an IIFE-wrapped decl
+// entirely. Best-effort → [].
+const _TS_BLOCK = new Set(["statement_block", "class_body"]);
+async function tsDeclsInString(wasmBase, src, cfg, maxBlockDepth = 1) {
+  const lang = await loadLanguage(wasmBase);
+  if (!lang || !_TS) return [];
+  let parser, tree;
+  try {
+    parser = new _TS.Parser();
+    parser.setLanguage(lang);
+    tree = parser.parse(src);
+  } catch {
+    return [];
+  }
+  const out = [];
+  const stack = [[tree.rootNode, 0]]; // [node, enclosing-block depth]
+  let guard = 0;
+  while (stack.length && out.length < 5000 && guard++ < 200000) {
+    const [node, bd] = stack.pop();
+    if (cfg.decl.has(node.type) && (maxBlockDepth == null || bd <= maxBlockDepth)) {
+      const nm = nameOf(node);
+      if (nm && /[A-Za-z_$]/.test(nm))
+        out.push({
+          name: nm.slice(0, 80),
+          kind: cfg.kind[node.type] || node.type,
+          line: node.startPosition.row + 1,
+          endLine: node.endPosition.row + 1,
+        });
+    }
+    const childBd = bd + (_TS_BLOCK.has(node.type) ? 1 : 0);
+    for (let i = node.namedChildCount - 1; i >= 0; i--) stack.push([node.namedChild(i), childBd]);
+  }
+  try {
+    tree.delete && tree.delete();
+    parser.delete && parser.delete();
+  } catch {
+    /* ignore */
+  }
+  return out;
+}
+
+// Top-level CSS rules / at-rules with EXACT ranges (the css grammar has its own node shapes, so a small
+// dedicated walk rather than the cfg-driven one). rule_set → its selector text; at-rules → the text up to `{`.
+const _CSS_AT = new Set(["media_statement", "keyframes_statement", "supports_statement", "at_rule"]);
+async function tsCssDeclsInString(src) {
+  const lang = await loadLanguage("css");
+  if (!lang || !_TS) return [];
+  let parser, tree;
+  try {
+    parser = new _TS.Parser();
+    parser.setLanguage(lang);
+    tree = parser.parse(src);
+  } catch {
+    return [];
+  }
+  const out = [];
+  const root = tree.rootNode;
+  for (let i = 0; i < root.namedChildCount; i++) {
+    const node = root.namedChild(i);
+    let name = null,
+      kind = null;
+    if (node.type === "rule_set") {
+      let sel = null;
+      for (let j = 0; j < node.namedChildCount; j++)
+        if (node.namedChild(j).type === "selectors") {
+          sel = node.namedChild(j);
+          break;
+        }
+      name = (sel ? sel.text : node.text.split("{")[0]).replace(/\s+/g, " ").trim();
+      kind = "rule";
+    } else if (_CSS_AT.has(node.type)) {
+      name = node.text.split("{")[0].replace(/\s+/g, " ").trim();
+      kind = "at-rule";
+    }
+    if (name && /\S/.test(name))
+      out.push({ name: name.slice(0, 80), kind, line: node.startPosition.row + 1, endLine: node.endPosition.row + 1 });
+  }
+  try {
+    tree.delete && tree.delete();
+    parser.delete && parser.delete();
+  } catch {
+    /* ignore */
+  }
+  return out;
+}
+
+// Re-parse every `<script>`/`<style>` block of an HTML document with the real javascript/css grammar and return
+// the embedded decls as flat heads [{ level:2, title, line, endLine, kind, embedded }] in ABSOLUTE 1-based
+// lines. core.js merges these over textstruct's heuristic embedded heads. null ⇒ tree-sitter unavailable.
+export async function htmlEmbeddedDecls(text) {
+  await ensureTS();
+  if (!_TS) return null;
+  const src = String(text);
+  const out = [];
+  let m;
+  const reScript = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+  while ((m = reScript.exec(src))) {
+    const attrs = m[1] || "";
+    const inner = m[2] || "";
+    // Skip non-JS scripts (JSON, importmap, text/template) — only real JS/module blocks carry decls.
+    const ty = /\btype\s*=\s*["']?([^"'\s>]+)/i.exec(attrs);
+    if (ty && !/^(text\/)?(javascript|ecmascript|babel|jsx)$|module/i.test(ty[1])) continue;
+    if (!inner.trim()) continue;
+    const offset = _newlinesBefore(src, m.index + (m[0].length - inner.length - 9)); // 9 = "</script>"
+    let decls;
+    try {
+      decls = await tsDeclsInString("javascript", inner, JSTS, 1); // depth ≤ 1 → top-level + one IIFE wrapper
+    } catch {
+      decls = [];
+    }
+    for (const d of decls)
+      out.push({ level: 2, title: d.name, line: d.line + offset, endLine: d.endLine + offset, kind: d.kind, embedded: "script" });
+  }
+  const reStyle = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+  while ((m = reStyle.exec(src))) {
+    const inner = m[1] || "";
+    if (!inner.trim()) continue;
+    const offset = _newlinesBefore(src, m.index + (m[0].length - inner.length - 8)); // 8 = "</style>"
+    let decls;
+    try {
+      decls = await tsCssDeclsInString(inner);
+    } catch {
+      decls = [];
+    }
+    for (const d of decls)
+      out.push({ level: 2, title: d.name, line: d.line + offset, endLine: d.endLine + offset, kind: d.kind, embedded: "style" });
+  }
+  return out;
+}

--- a/server/viz.js
+++ b/server/viz.js
@@ -135,8 +135,8 @@ export function buildVizData(root) {
   const tiers = [
     { key: "exact", rung: 1, name: "Exact", engine: "Language server — clangd · Roslyn · tsserver · pyright", when: "you know the name and a toolchain is present", cert: "COMPLETE", tools: EXACT_TOOLS, saved: exactStat.saved, runs: exactStat.runs },
     { key: "syntactic", rung: 2, name: "Syntactic", engine: "tree-sitter — 17 languages, zero setup", when: "no toolchain — declarations + tag-query references", cert: "SYNTACTIC", tools: [], reach: "17 languages", saved: 0, runs: 0 },
-    { key: "fuzzy", rung: 3, name: "Fuzzy", engine: "concept dictionary mined from the repo's own naming — no embeddings", when: "you only know the intent, not the symbol name", cert: "SYNTACTIC", tools: ["concept_search"], saved: fuzzyStat.saved, runs: fuzzyStat.runs },
-    { key: "section", rung: 4, name: "Section", engine: "Markdown · TOML · YAML · JSON · … addressed by heading", when: "it's a doc or config, not code", cert: "COMPLETE", tools: [], reach: "md · mdx · adoc · rst · toml · ini · yaml · json · txt", saved: 0, runs: 0 },
+    { key: "fuzzy", rung: 3, name: "Fuzzy", engine: "concept dictionary mined from the repo's own naming — no embeddings", when: "you only know the intent, not the symbol name", cert: "FUZZY", tools: ["concept_search"], saved: fuzzyStat.saved, runs: fuzzyStat.runs },
+    { key: "section", rung: 4, name: "Section", engine: "Markdown · TOML · YAML · JSON · HTML · CSS · … addressed by heading/selector/rule", when: "it's a doc or config, not code", cert: "SECTION", tools: [], reach: "md · mdx · adoc · rst · toml · ini · yaml · json · html · css · scss · txt", saved: 0, runs: 0 },
   ];
   // SURFACE COVERAGE (the "whole repo an agent sees" pillar): semantic backends detected in this root + the
   // syntactic language reach + the document formats. filesystem (find_files/search_text) is the non-tiered
@@ -144,13 +144,17 @@ export function buildVizData(root) {
   const surfaces = {
     semantic: census, // per-backend file counts in this root
     syntacticLangs: 17, // tree-sitter: 10 hand-tuned + 7 tags-query
-    docFormats: ["markdown", "mdx", "asciidoc", "rst", "toml", "ini", "yaml", "json", "txt"],
+    docFormats: ["markdown", "mdx", "asciidoc", "rst", "toml", "ini", "yaml", "json", "html", "css", "scss", "txt"],
     filesystem: { saved: fsStat.saved, runs: fsStat.runs },
   };
-  // Completeness-certificate legend (the precision-honesty pillar) — the labels vts stamps on every answer.
+  // Completeness-certificate legend (the precision-honesty pillar) — the labels vts stamps on every answer. The
+  // first four name a precision RUNG (exact → COMPLETE, syntactic, fuzzy, section); the last two are coverage
+  // states a capped/timed-out answer of ANY rung falls through to.
   const certs = [
-    { key: "COMPLETE", desc: "semantic, every match returned (within the indexed/scoped set)" },
-    { key: "SYNTACTIC", desc: "tree-sitter declarations, zero setup — does not resolve refs/overloads/types" },
+    { key: "COMPLETE", desc: "exact rung (semantic), every match returned (within the indexed/scoped set)" },
+    { key: "SYNTACTIC", desc: "syntactic rung — tree-sitter declarations, zero setup; does not resolve refs/overloads/types" },
+    { key: "FUZZY", desc: "fuzzy rung — concept dictionary mined from the repo's own naming (no embeddings); related, not exact" },
+    { key: "SECTION", desc: "section rung — doc/config structure by heading/selector/rule; exact spans, not semantic code" },
     { key: "PARTIAL", desc: "capped or time-boxed — more exists, recoverable via the tee / a higher cap" },
     { key: "INCONCLUSIVE", desc: "index still building or a 0 from a truncated walk — not a true zero" },
   ];


### PR DESCRIPTION
## Theme
More surfaces + precision honesty — three forward-backlog items, all charter-pure (local-only, no embeddings, output stays token-capped `file:line`, official parser).

## What's in it
- **CSS/SCSS/LESS structure provider** (`textstruct.js parseCss`) — a stylesheet's rule hierarchy is its section tree: top-level selectors / at-rules at L1, SCSS-nested rules deeper, each with an exact brace-matched span. The 5 symbol tools read/edit a rule by name. No new MCP tool, zero-dep, pure.
- **HTML embedded-code tree-sitter injection** (`treesitter.js htmlEmbeddedDecls`) — re-parse each `<script>`/`<style>` with the real javascript/css grammar for exact decl ranges, replacing the heuristic brace-scan. Recovers decls the heuristic misses: a minified one-line script, two CSS rules on one line, and a function inside a top-level IIFE (the dashboard.html pattern; `maxBlockDepth <= 1`). `textstruct` stays pure — `structOutlineInjected` takes the parser from `core.js` and falls back to the heuristic when grammars are absent. Dogfood: `renderCerts` (IIFE-nested) now read by name at ~153x.
- **Unified precision label** (`core.js completenessCert`) — one cert line names the rung it came from: `EXACT` / `SYNTACTIC` / `FUZZY` / `SECTION`, plus `PARTIAL` / `INCONCLUSIVE` coverage. Fixes `concept_search` being mislabeled SYNTACTIC (it is the FUZZY rung); adds the SECTION rung to the structure tier; the INCONCLUSIVE advisory is now actionable (names the `vts setup --scope` / `vts preindex` auto-scope commands). viz tiers/certs legend mirrors the 4 rungs + 2 coverage states.

## Review points
- `textstruct.js` purity preserved (no fs/async/tree-sitter import) — injection is dependency-injected from `core.js`.
- HTML injection degrades gracefully: grammars absent → `htmlEmbeddedDecls` returns null → heuristic outline stands.
- Bump level: PATCH (per maintainer call), `0.34.0 -> 0.34.1`.

## Verification
Eval guards 84 (CSS provider), 81 (HTML injection + IIFE), 72 (viz tiers/certs), 76 (unified label + auto-scope). All suites green: `eval` 86, edit-steer 18/18, skillopt 19/19, eslint clean, plugin validate ✔.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
