### PR TITLE
fix(concept,edit): sharpen fuzzy seed, gate cross-cutting noise, recency-window adoption

### DIFF
--- a/benchmarks/results/latest.json
+++ b/benchmarks/results/latest.json
@@ -21,20 +21,20 @@
             "grepTok": 439,
             "grepLines": 23,
             "grepCapped": false,
-            "vtsTok": 152,
+            "vtsTok": 193,
             "vtsMode": "semantic",
             "vtsOk": true,
-            "reduction": 0.6537585421412301
+            "reduction": 0.5603644646924829
           },
           {
             "scenario": "find all references",
             "grepTok": 439,
             "grepLines": 23,
             "grepCapped": false,
-            "vtsTok": 120,
+            "vtsTok": 123,
             "vtsMode": "semantic",
             "vtsOk": true,
-            "reduction": 0.7266514806378133
+            "reduction": 0.7198177676537585
           },
           {
             "scenario": "text search ('retry loop')",
@@ -63,20 +63,20 @@
             "grepTok": 1999,
             "grepLines": 103,
             "grepCapped": false,
-            "vtsTok": 152,
+            "vtsTok": 193,
             "vtsMode": "semantic",
             "vtsOk": true,
-            "reduction": 0.9239619809904952
+            "reduction": 0.9034517258629314
           },
           {
             "scenario": "find all references",
             "grepTok": 1999,
             "grepLines": 103,
             "grepCapped": false,
-            "vtsTok": 321,
+            "vtsTok": 375,
             "vtsMode": "semantic",
             "vtsOk": true,
-            "reduction": 0.8394197098549274
+            "reduction": 0.8124062031015508
           },
           {
             "scenario": "text search ('retry loop')",
@@ -105,20 +105,20 @@
             "grepTok": 4917,
             "grepLines": 303,
             "grepCapped": true,
-            "vtsTok": 168,
+            "vtsTok": 169,
             "vtsMode": "syntactic",
             "vtsOk": true,
-            "reduction": 0.9658328248932275
+            "reduction": 0.9656294488509254
           },
           {
             "scenario": "find all references",
             "grepTok": 4917,
             "grepLines": 303,
             "grepCapped": true,
-            "vtsTok": 433,
+            "vtsTok": 485,
             "vtsMode": "semantic",
             "vtsOk": true,
-            "reduction": 0.9119381736831401
+            "reduction": 0.9013626194834249
           },
           {
             "scenario": "text search ('retry loop')",
@@ -166,20 +166,20 @@
             "grepTok": 536,
             "grepLines": 33,
             "grepCapped": false,
-            "vtsTok": 168,
+            "vtsTok": 169,
             "vtsMode": "syntactic",
             "vtsOk": true,
-            "reduction": 0.6865671641791045
+            "reduction": 0.6847014925373134
           },
           {
             "scenario": "find all references",
             "grepTok": 536,
             "grepLines": 33,
             "grepCapped": false,
-            "vtsTok": 125,
+            "vtsTok": 128,
             "vtsMode": "semantic",
             "vtsOk": true,
-            "reduction": 0.7667910447761194
+            "reduction": 0.7611940298507462
           },
           {
             "scenario": "text search ('retry loop')",
@@ -208,20 +208,20 @@
             "grepTok": 2536,
             "grepLines": 153,
             "grepCapped": false,
-            "vtsTok": 168,
+            "vtsTok": 169,
             "vtsMode": "syntactic",
             "vtsOk": true,
-            "reduction": 0.9337539432176656
+            "reduction": 0.9333596214511041
           },
           {
             "scenario": "find all references",
             "grepTok": 2536,
             "grepLines": 153,
             "grepCapped": false,
-            "vtsTok": 346,
+            "vtsTok": 347,
             "vtsMode": "syntactic",
             "vtsOk": true,
-            "reduction": 0.863564668769716
+            "reduction": 0.8631703470031545
           },
           {
             "scenario": "text search ('retry loop')",
@@ -250,20 +250,20 @@
             "grepTok": 4221,
             "grepLines": 453,
             "grepCapped": true,
-            "vtsTok": 168,
+            "vtsTok": 169,
             "vtsMode": "syntactic",
             "vtsOk": true,
-            "reduction": 0.9601990049751243
+            "reduction": 0.9599620942904525
           },
           {
             "scenario": "find all references",
             "grepTok": 4221,
             "grepLines": 453,
             "grepCapped": true,
-            "vtsTok": 830,
+            "vtsTok": 831,
             "vtsMode": "syntactic",
             "vtsOk": true,
-            "reduction": 0.8033641317223407
+            "reduction": 0.8031272210376688
           },
           {
             "scenario": "text search ('retry loop')",
@@ -311,20 +311,20 @@
             "grepTok": 415,
             "grepLines": 23,
             "grepCapped": false,
-            "vtsTok": 155,
+            "vtsTok": 156,
             "vtsMode": "syntactic",
             "vtsOk": true,
-            "reduction": 0.6265060240963856
+            "reduction": 0.6240963855421686
           },
           {
             "scenario": "find all references",
             "grepTok": 415,
             "grepLines": 23,
             "grepCapped": false,
-            "vtsTok": 184,
+            "vtsTok": 185,
             "vtsMode": "syntactic",
             "vtsOk": true,
-            "reduction": 0.5566265060240965
+            "reduction": 0.5542168674698795
           },
           {
             "scenario": "text search ('retry loop')",
@@ -353,20 +353,20 @@
             "grepTok": 1895,
             "grepLines": 103,
             "grepCapped": false,
-            "vtsTok": 155,
+            "vtsTok": 156,
             "vtsMode": "syntactic",
             "vtsOk": true,
-            "reduction": 0.9182058047493403
+            "reduction": 0.9176781002638522
           },
           {
             "scenario": "find all references",
             "grepTok": 1895,
             "grepLines": 103,
             "grepCapped": false,
-            "vtsTok": 364,
+            "vtsTok": 365,
             "vtsMode": "syntactic",
             "vtsOk": true,
-            "reduction": 0.807915567282322
+            "reduction": 0.8073878627968338
           },
           {
             "scenario": "text search ('retry loop')",
@@ -395,20 +395,20 @@
             "grepTok": 4667,
             "grepLines": 303,
             "grepCapped": true,
-            "vtsTok": 156,
+            "vtsTok": 157,
             "vtsMode": "syntactic",
             "vtsOk": true,
-            "reduction": 0.9665738161559888
+            "reduction": 0.9663595457467323
           },
           {
             "scenario": "find all references",
             "grepTok": 4667,
             "grepLines": 303,
             "grepCapped": true,
-            "vtsTok": 848,
+            "vtsTok": 849,
             "vtsMode": "syntactic",
             "vtsOk": true,
-            "reduction": 0.8182986929505035
+            "reduction": 0.818084422541247
           },
           {
             "scenario": "text search ('retry loop')",
@@ -452,8 +452,8 @@
   "aggregateAtMax": {
     "files": 150,
     "grepTok": 47547,
-    "vtsTok": 6138,
-    "reduction": 0.8709066818095779
+    "vtsTok": 6195,
+    "reduction": 0.8697078680042905
   },
   "costAtMax": {
     "files": 150,
@@ -462,22 +462,22 @@
         "model": "Haiku 4.5",
         "price": 1,
         "grepCost": 0.047547,
-        "vtsCost": 0.006138,
-        "saved": 0.041409
+        "vtsCost": 0.006195,
+        "saved": 0.041352
       },
       {
         "model": "Sonnet 4.x",
         "price": 3,
         "grepCost": 0.142641,
-        "vtsCost": 0.018414,
-        "saved": 0.12422699999999999
+        "vtsCost": 0.018585,
+        "saved": 0.12405599999999999
       },
       {
         "model": "Opus 4.x",
         "price": 15,
         "grepCost": 0.713205,
-        "vtsCost": 0.09207,
-        "saved": 0.621135
+        "vtsCost": 0.092925,
+        "saved": 0.6202799999999999
       }
     ]
   },

--- a/benchmarks/results/latest.md
+++ b/benchmarks/results/latest.md
@@ -9,10 +9,10 @@ Reproduce: `npm run bench`.
 
 | Language | grep tokens | vts tokens | reduction |
 |---|--:|--:|--:|
-| TypeScript | 16634 | 2216 | **86.7%** |
-| Python | 14929 | 2508 | **83.2%** |
-| Go | 15984 | 1414 | **91.2%** |
-| **All languages** | **47547** | **6138** | **87.1%** |
+| TypeScript | 16634 | 2269 | **86.4%** |
+| Python | 14929 | 2510 | **83.2%** |
+| Go | 15984 | 1416 | **91.1%** |
+| **All languages** | **47547** | **6195** | **87.0%** |
 
 The win holds across languages vts has a language server for (TypeScript, Python — the SEMANTIC tier)
 and one it has no wired backend for (Go — tree-sitter answers symbol queries and a bounded literal scan
@@ -26,25 +26,25 @@ is shown in the per-scenario tables below — the token reduction itself is dete
 
 | caller files | grep tokens | vts tokens | reduction |
 |--:|--:|--:|--:|
-| 10 | 1409 | 786 | **44.2%** |
-| 50 | 6639 | 1949 | **70.6%** |
-| 150 | 16634 | 2216 | **86.7%** |
+| 10 | 1409 | 830 | **41.1%** |
+| 50 | 6639 | 2044 | **69.2%** |
+| 150 | 16634 | 2269 | **86.4%** |
 
 ### Python
 
 | caller files | grep tokens | vts tokens | reduction |
 |--:|--:|--:|--:|
-| 10 | 1577 | 770 | **51.2%** |
-| 50 | 7587 | 1865 | **75.4%** |
-| 150 | 14929 | 2508 | **83.2%** |
+| 10 | 1577 | 774 | **50.9%** |
+| 50 | 7587 | 1867 | **75.4%** |
+| 150 | 14929 | 2510 | **83.2%** |
 
 ### Go
 
 | caller files | grep tokens | vts tokens | reduction |
 |--:|--:|--:|--:|
-| 10 | 1350 | 496 | **63.3%** |
-| 50 | 6380 | 816 | **87.2%** |
-| 150 | 15984 | 1414 | **91.2%** |
+| 10 | 1350 | 498 | **63.1%** |
+| 50 | 6380 | 818 | **87.2%** |
+| 150 | 15984 | 1416 | **91.1%** |
 
 Grep grows with the match count; vts stays capped — so the reduction climbs with repo size in every
 language. On a tiny corpus a narrow text/file search is a wash (vts's header overhead ≈ grep); the
@@ -56,31 +56,31 @@ semantic scenarios (symbol/refs) win even there because grep over-reports commen
 
 | Scenario | grep tokens | vts tokens | reduction | vts mode |
 |---|--:|--:|--:|---|
-| find symbol declaration | 4917 (capped) | 168 | **96.6%** | syntactic |
-| find all references | 4917 (capped) | 433 | **91.2%** | semantic |
+| find symbol declaration | 4917 (capped) | 169 | **96.6%** | syntactic |
+| find all references | 4917 (capped) | 485 | **90.1%** | semantic |
 | text search ('retry loop') | 4917 (capped) | 1287 | **73.8%** | filesystem |
 | find file by name ('caller') | 1883 (capped) | 328 | **82.6%** | filesystem |
-| **TOTAL** | **16634** | **2216** | **86.7%** | |
+| **TOTAL** | **16634** | **2269** | **86.4%** | |
 
 ### Python
 
 | Scenario | grep tokens | vts tokens | reduction | vts mode |
 |---|--:|--:|--:|---|
-| find symbol declaration | 4221 (capped) | 168 | **96.0%** | syntactic |
-| find all references | 4221 (capped) | 830 | **80.3%** | syntactic |
+| find symbol declaration | 4221 (capped) | 169 | **96.0%** | syntactic |
+| find all references | 4221 (capped) | 831 | **80.3%** | syntactic |
 | text search ('retry loop') | 4604 (capped) | 1182 | **74.3%** | filesystem |
 | find file by name ('caller') | 1883 (capped) | 328 | **82.6%** | filesystem |
-| **TOTAL** | **14929** | **2508** | **83.2%** | |
+| **TOTAL** | **14929** | **2510** | **83.2%** | |
 
 ### Go
 
 | Scenario | grep tokens | vts tokens | reduction | vts mode |
 |---|--:|--:|--:|---|
-| find symbol declaration | 4667 (capped) | 156 | **96.7%** | syntactic |
-| find all references | 4667 (capped) | 848 | **81.8%** | syntactic |
+| find symbol declaration | 4667 (capped) | 157 | **96.6%** | syntactic |
+| find all references | 4667 (capped) | 849 | **81.8%** | syntactic |
 | text search ('retry loop') | 4667 (capped) | 81 | **98.3%** | filesystem |
 | find file by name ('caller') | 1983 (capped) | 329 | **83.4%** | filesystem |
-| **TOTAL** | **15984** | **1414** | **91.2%** | |
+| **TOTAL** | **15984** | **1416** | **91.1%** | |
 
 ## Zero-setup symbol search: grep vs tree-sitter (no toolchain) vs vts tier, per language
 
@@ -89,15 +89,15 @@ returns the same token-capped `file:line` shape, so toolchain-free costs no more
 
 | Language | caller files | grep tokens | tree-sitter (no setup) | vts tier | grep→tree-sitter |
 |---|--:|--:|--:|--:|--:|
-| TypeScript | 10 | 439 | 50 | 152 | **88.6%** |
-| TypeScript | 50 | 1999 | 50 | 152 | **97.5%** |
-| TypeScript | 150 | 4917 | 51 | 168 | **99.0%** |
-| Python | 10 | 536 | 51 | 168 | **90.5%** |
-| Python | 50 | 2536 | 51 | 168 | **98.0%** |
-| Python | 150 | 4221 | 52 | 168 | **98.8%** |
-| Go | 10 | 415 | 53 | 155 | **87.2%** |
-| Go | 50 | 1895 | 53 | 155 | **97.2%** |
-| Go | 150 | 4667 | 53 | 156 | **98.9%** |
+| TypeScript | 10 | 439 | 50 | 193 | **88.6%** |
+| TypeScript | 50 | 1999 | 50 | 193 | **97.5%** |
+| TypeScript | 150 | 4917 | 51 | 169 | **99.0%** |
+| Python | 10 | 536 | 51 | 169 | **90.5%** |
+| Python | 50 | 2536 | 51 | 169 | **98.0%** |
+| Python | 150 | 4221 | 52 | 169 | **98.8%** |
+| Go | 10 | 415 | 53 | 156 | **87.2%** |
+| Go | 50 | 1895 | 53 | 156 | **97.2%** |
+| Go | 150 | 4667 | 53 | 157 | **98.9%** |
 
 Both vts tiers stay flat while grep grows; the tree-sitter tier is the cold-start / no-toolchain path,
 the LSP tier adds reference/overload/type resolution on top. Build a committable index with `vts index`.
@@ -108,9 +108,9 @@ Saved = (grep − vts) input tokens × list input price. List prices, verify at 
 
 | Model | $/Mtok (in) | grep cost | vts cost | saved | cheaper |
 |---|--:|--:|--:|--:|--:|
-| Haiku 4.5 | $1.00 | $0.047547 | $0.006138 | $0.041409 | 87.1% |
-| Sonnet 4.x | $3.00 | $0.142641 | $0.018414 | $0.124227 | 87.1% |
-| Opus 4.x | $15.00 | $0.713205 | $0.092070 | $0.621135 | 87.1% |
+| Haiku 4.5 | $1.00 | $0.047547 | $0.006195 | $0.041352 | 87.0% |
+| Sonnet 4.x | $3.00 | $0.142641 | $0.018585 | $0.124056 | 87.0% |
+| Opus 4.x | $15.00 | $0.713205 | $0.092925 | $0.620280 | 87.0% |
 
 > Absolute $ per query is tiny — the win compounds across the many searches in a real session and
 > grows with repo size. On a real Unreal Engine project the same A/B is ~282k → ~2k tokens (~138×);

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1806,9 +1806,22 @@ const ctrlCreditOk =
   elAfterConv.symbol === 1 && elAfterConv.mod.warn.converted === 1 && elAfterConv.pending === null &&
   elAfterMiss.mod.block.shown === 1 && elAfterMiss.mod.block.converted === 0 && elAfterMiss.builtin === 1;
 const ctrlReportOk = ELc.controllerReport(elAfterMiss).includes("warn 1/1") && ELc.controllerReport(elAfterMiss).includes("block 0/1");
+// RECENCY WINDOW (#c): the rolling adoption rate must reflect CURRENT behavior, not the all-time tail, and
+// stay bounded. So far recent = [s, b] (one switch, one miss). With the window at its floor (5) push four
+// more built-in edits: the window keeps only the last 5 (all "b") → recent 0%, while the all-time ratio is
+// 1/6 = 17%. The divergence is the whole point — a stale all-time number can't tell the model the steer
+// stopped converting now.
+const rwPrev = process.env.VTS_EDIT_RECENT_WINDOW;
+process.env.VTS_EDIT_RECENT_WINDOW = "5";
+ELc.recordEditEvent("builtin-warn"); ELc.recordEditEvent("builtin-warn"); ELc.recordEditEvent("builtin-warn"); ELc.recordEditEvent("builtin-warn");
+const elRecent = ELc.readEditLedger();
+const recencyOk = Array.isArray(elRecent.recent) && elRecent.recent.length === 5 && elRecent.recent.join("") === "bbbbb" &&
+  ELc.adoptionPctRecent(elRecent) === 0 && ELc.adoptionPct(elRecent) === 17 &&     // recent diverges from all-time
+  ELc.adoptionPctRecent({ recent: [] }) === null;                                  // empty window → null
+if (rwPrev === undefined) delete process.env.VTS_EDIT_RECENT_WINDOW; else process.env.VTS_EDIT_RECENT_WINDOW = rwPrev;
 if (elPrev === undefined) delete process.env.VTS_EDIT_LEDGER; else process.env.VTS_EDIT_LEDGER = elPrev;
 try { fs.rmSync(elFresh, { force: true }); } catch { /* ignore */ }
-const adaptiveCtrlOk = escPolicyOk && ctrlCreditOk && ctrlReportOk;
+const adaptiveCtrlOk = escPolicyOk && ctrlCreditOk && ctrlReportOk && recencyOk;
 
 // 79) indexing SCOPE — the cold-index accelerator: index a subtree, not the whole monorepo. scopeDirs
 // resolves the config/env scope; inScope tests membership; scopedCdb writes a filtered compile_commands.json
@@ -1860,7 +1873,11 @@ const supOff = shouldSuppressSteer("/p/Intermediate/Build/Foo.gen.cpp") === fals
 if (supTogglePrev === undefined) delete process.env.VTS_SUPPRESS; else process.env.VTS_SUPPRESS = supTogglePrev;
 const dig = routingDigest({ builtin: 8, symbol: 2, mod: { warn: { shown: 0, converted: 0 }, block: { shown: 0, converted: 0 } } });
 const digOk = /Tool routing/.test(dig) && /COMPLEMENTARY/.test(dig) && /--scope/.test(dig) && /adoption 20% \(2\/10\)/.test(dig); // tree + posture
-const policyOk = supGen && supDotGen && supNodeMod && supReal && supOff && digOk;
+// the rolling recent rate is surfaced alongside the all-time ratio when it diverges (#c): here recent 4/5=80%
+// vs all-time 2/10=20% — the live signal the steer loop can actually move.
+const dig2 = routingDigest({ builtin: 8, symbol: 2, recent: ["s", "s", "s", "s", "b"], mod: { warn: { shown: 0, converted: 0 }, block: { shown: 0, converted: 0 } } });
+const digRecentOk = /adoption 20% \(2\/10\), recent 80%/.test(dig2);
+const policyOk = supGen && supDotGen && supNodeMod && supReal && supOff && digOk && digRecentOk;
 
 // 81) SYNTACTIC tier: tree-sitter declaration extraction (treesitter.js) + the committable symbol index
 // (symindex.js). The zero-setup fallback that works on any repo with no toolchain — a real AST decl, not a
@@ -1991,6 +2008,20 @@ const synOk = !!cSyn && JSON.stringify(cSyn.get("payment")) === JSON.stringify([
   cExpand(cModel, ["payment"], { synonyms: cSyn }).get("billing") === 0.95 &&  // synonym injected at 0.95
   cExpand(cModel, ["payment"]).get("billing") === undefined;                   // without the file: not bridged
 const scoreOk = cScore(cModel, cEnr, ["session", "auth"], []) > cScore(cModel, cEnr, ["render", "button"], []);
+// CROSS-CUTTING-GENERIC gate (#b): a query token present in a large fraction of decls is too generic to
+// expand THROUGH — its co-occurrence neighbours are cross-cutting noise. Build N=30 with `core` in 15 decls
+// (a "moderately common" token the PMI test alone still lets through) co-occurring with `flush` (df 4) above
+// the assoc bar. Default (maxDfRatio 0) expands `core`→`flush`; with the gate (0.25, df 15/30=0.5 > 0.25) it
+// does not. The gate only suppresses the noisy neighbour; the token itself is still weighted 1.
+const dfUnits = [];
+for (let i = 0; i < 11; i++) dfUnits.push(["core", "m" + i]);   // core alone (+ unique noise → df 1, dropped)
+for (let i = 0; i < 4; i++) dfUnits.push(["core", "flush"]);    // core+flush ×4 → assoc(core,flush)=2.0 ≥ 1.5
+for (let i = 0; i < 15; i++) dfUnits.push(["other", "t" + i]);  // pad N to 30; df(core)=15, df(flush)=4
+const dfModel = cBuild(dfUnits);
+const dfGateOff = cExpand(dfModel, ["core"]);                       // no cap → flush expanded
+const dfGateOn = cExpand(dfModel, ["core"], { maxDfRatio: 0.25 }); // core too generic → not expanded through
+const dfGateOk = dfGateOff.has("flush") && !dfGateOn.has("flush") && dfGateOn.get("core") === 1 &&
+  cExpand(dfModel, ["core"], { maxDfRatio: 0 }).has("flush"); // 0 ratio = gate off (back-compat)
 let conceptToolOk = true;
 if (tsAvailable()) {
   const cdir = path.join(os.tmpdir(), `vts-eval-${process.pid}-concept`);
@@ -2013,11 +2044,15 @@ if (tsAvailable()) {
   const pathLocalityOk = !cp.isError && /billing\.ts/.test(cp.text) && !/unrelated\.ts/.test(cp.text);
   // near.ts (imports core.ts, the top hit) must outrank far.ts (same symbol, no import edge) — the boost.
   const importBoostOk = !ci.isError && /near\.ts/.test(ci.text) && /far\.ts/.test(ci.text) && ci.text.indexOf("near.ts") < ci.text.indexOf("far.ts");
+  // CLIMB/FLOW SEED (#a): the ladder steer must climb on the strongest INTRINSIC match, not a proximity-
+  // boosted one. For "authenticate", core.ts `authenticate` is the exact-name hit (base 1.0); near.ts
+  // `authHelper` (base 0.7) is only lifted into view by the import boost, so it must NOT be the climb seed.
+  const seedOk = !ci.isError && /find_references symbol="authenticate"/.test(ci.text);
   conceptToolOk = !cr.isError && /validateSession/.test(cr.text) && /refreshToken/.test(cr.text) && !/renderWidget/.test(cr.text) && /no embeddings/.test(cr.text) &&
-    /ladder.*[Cc]limb/.test(cr.text) && pathLocalityOk && importBoostOk; // ladder nav + path-locality + import-graph proximity
+    /ladder.*[Cc]limb/.test(cr.text) && pathLocalityOk && importBoostOk && seedOk; // ladder nav + path-locality + import-graph proximity + intrinsic-best climb seed
   try { fs.rmSync(cdir, { recursive: true, force: true }); } catch { /* ignore */ }
 }
-const conceptOk = splitOk && expandOk && synOk && scoreOk && conceptToolOk;
+const conceptOk = splitOk && expandOk && synOk && scoreOk && dfGateOk && conceptToolOk;
 
 // 84) STRUCTURE tier (textstruct.js): prose/config files (markdown/toml/yaml/rst/…) get a SECTION tree, and
 // the existing symbol tools (document_symbols / read_symbol / replace_symbol_body / …) edit a section BY NAME

--- a/server/concept.js
+++ b/server/concept.js
@@ -219,7 +219,17 @@ export function idf(model, t) {
 // inspectable expansion with NO drift (vs a self-learning click loop). A curated synonym is injected JUST
 // BELOW an exact match (0.95) and above any mined co-occurrence neighbour, so a hand-declared bridge
 // (auth → login/session) reliably beats the noisy mined ones without ever outranking a literal hit.
-export function expandQuery(model, qTokens, { k = 6, minAssoc = 1.5, minCooc = 2, neighborMax = 0.85, synonyms = null } = {}) {
+// `maxDfRatio` (0 = off) is the CROSS-CUTTING-GENERIC gate. A token present in a large fraction of all
+// declarations (a "manager", "data", "handle" that names nothing in particular) carries no discriminative
+// concept signal, yet it can still clear the PMI bar against a moderately-common neighbour — and its
+// expansion is exactly the documented noise on cross-cutting queries. So when the corpus is large enough to
+// make a frequency estimate meaningful (N >= 20), we refuse to expand THROUGH such a token and refuse to
+// expand INTO one. It is still scored directly (its idf is already low, so it barely moves the rank); we
+// only suppress the noisy second-order neighbours it would otherwise pull in. Deterministic and inspectable
+// — a frequency threshold mined from the repo itself, not a learned cutoff. (A maximally ubiquitous token,
+// df == N, can never reach assoc >= minAssoc anyway; this gate catches the MODERATELY common middle band the
+// PMI test alone lets through.)
+export function expandQuery(model, qTokens, { k = 6, minAssoc = 1.5, minCooc = 2, neighborMax = 0.85, synonyms = null, maxDfRatio = 0 } = {}) {
   const weights = new Map();
   for (const t of qTokens) weights.set(t, 1);
   if (synonyms) {
@@ -228,15 +238,20 @@ export function expandQuery(model, qTokens, { k = 6, minAssoc = 1.5, minCooc = 2
       if (ex) for (const s of ex) { const st = String(s).toLowerCase(); if ((weights.get(st) || 0) < 0.95) weights.set(st, 0.95); }
     }
   }
+  const dfCap = maxDfRatio > 0 && model.N >= 20 ? maxDfRatio * model.N : Infinity;
   for (const t of qTokens) {
+    // a ubiquitous query token's co-occurrence neighbours are cross-cutting noise — don't expand THROUGH it
+    // (it's still scored directly, damped by its own low idf).
+    if ((model.df.get(t) || 0) > dfCap) continue;
     const m = model.cooc.get(t);
     if (!m) continue;
     const scored = [];
     for (const [n, c] of m) {
       if (weights.has(n)) continue;
       // a real synonym RECURS — gate on raw co-occurrence count (kills single-shot noise from a shared comment)
-      // AND on a neighbour seen in at least two declarations, before the association (PMI) threshold.
-      if (c < minCooc || (model.df.get(n) || 0) < 2) continue;
+      // AND on a neighbour seen in at least two declarations, before the association (PMI) threshold; and never
+      // expand INTO a cross-cutting-generic neighbour (df above the ratio cap).
+      if (c < minCooc || (model.df.get(n) || 0) < 2 || (model.df.get(n) || 0) > dfCap) continue;
       const a = assoc(model, t, n);
       if (a >= minAssoc) scored.push([n, a]);
     }

--- a/server/core.js
+++ b/server/core.js
@@ -2039,7 +2039,10 @@ export async function runTool(name, a = {}) {
       // deterministic, no drift. Purely additive: absent/malformed → the mined model runs alone.
       let synonyms = null;
       try { synonyms = parseSynonyms(fs.readFileSync(path.join(root, ".vts-index", "concept-synonyms.json"), "utf8")); } catch { /* no committed synonyms */ }
-      const enriched = expandQuery(model, qToks, synonyms ? { synonyms } : {});
+      // VTS_CONCEPT_MAX_DF (default 0.25): suppress expansion through/into a cross-cutting-generic token (one
+      // present in > this fraction of decls) — the documented noise source on cross-cutting fuzzy queries.
+      const maxDfRatio = Number(process.env.VTS_CONCEPT_MAX_DF ?? 0.25);
+      const enriched = expandQuery(model, qToks, { ...(synonyms ? { synonyms } : {}), maxDfRatio });
       // Kind weight: a fuzzy "how does X work" wants the function/class/type that EMBODIES the concept, not a
       // throwaway local const/var that merely mentions a word — demote those so the real declarations rank up.
       const kindW = (k) => (/^(const|var|local|decl|field|member)$/.test(k) ? 0.35 : 1);
@@ -2058,7 +2061,7 @@ export async function runTool(name, a = {}) {
           let nb = 0;
           const ns = nf && neighbors && neighbors.get(r.s.file);
           if (ns) for (const g of ns) { const fb = fileBase.get(g) || 0; if (fb > nb) nb = fb; }
-          return { s: r.s, sc: r.base + nb * nf };
+          return { s: r.s, sc: r.base + nb * nf, base: r.base };
         })
         .sort((a2, b2) => b2.sc - a2.sc);
       // Fuzzy results have a long low-relevance tail (a trivial local matching one weak expansion term). Cap
@@ -2068,6 +2071,11 @@ export async function runTool(name, a = {}) {
       const conceptMax = Math.min(max, envInt("VTS_CONCEPT_MAX", 15));
       const ranked = scoredAll.filter((r) => r.sc >= floor).slice(0, conceptMax);
       if (!ranked.length) return finishOut([], `No concept matches for "${a.q}" under ${root} (the repo's own naming may not bridge those words — try search_text, or a synonym).` + EMPTY_HINT + completenessCert({ shown: 0, total: 0, fuzzy: true }));
+      // Climb/flow SEED = the entry with the strongest INTRINSIC match (name/path/comment `base`), NOT the
+      // proximity-boosted total `sc`. The seed is handed to find_references/goto_definition for ground truth,
+      // so it must be the most confident exact-name candidate — an import-graph neighbour can lift a weak-base
+      // symbol to the top of the shown list, but it should never become the thing we tell the model to climb on.
+      const seed = ranked.reduce((best, r) => (r.base > best.base ? r : best), ranked[0]);
       const expTerms = [...enriched].filter(([t]) => !qToks.includes(t)).slice(0, 8).map(([t]) => t);
       const rows = ranked.map((r) => `${r.s.file}:${r.s.line}: ${r.s.kind} ${r.s.name}`);
       const expLine = expTerms.length ? `\n  concept-expanded with: ${expTerms.join(", ")} (mined from this repo's own naming, not a model)` : "";
@@ -2075,13 +2083,13 @@ export async function runTool(name, a = {}) {
       let flow = "";
       if (a.flow === true || a.flow === "true") {
         try {
-          const fr = await runTool("find_references", { symbol: ranked[0].s.name, direction: a.direction || "callees", depth: Number(a.depth) || 2, projectPath: root });
-          if (fr && !fr.isError) flow = `\n\nflow of the top seed (${ranked[0].s.name}) along the call graph:\n${fr.text}`;
+          const fr = await runTool("find_references", { symbol: seed.s.name, direction: a.direction || "callees", depth: Number(a.depth) || 2, projectPath: root });
+          if (fr && !fr.isError) flow = `\n\nflow of the top seed (${seed.s.name}) along the call graph:\n${fr.text}`;
         } catch { /* flow is best-effort */ }
       }
       // Precision-ladder navigation: concept_search is the FUZZY rung (related, not exact). Once a seed looks
       // right, climb to the exact rung for ground-truth — name the hit to find_references / goto_definition.
-      const climb = process.env.VTS_CONCEPT_STEER !== "0" ? `\n[ladder: this is the fuzzy rung. Climb to exact on a hit — find_references symbol="${ranked[0].s.name}" or goto_definition for ground-truth refs/def.]` : "";
+      const climb = process.env.VTS_CONCEPT_STEER !== "0" ? `\n[ladder: this is the fuzzy rung. Climb to exact on a hit — find_references symbol="${seed.s.name}" or goto_definition for ground-truth refs/def.]` : "";
       return finishOut(rows, `${ranked.length} concept match(es) for "${a.q}" (fuzzy — local concept dictionary, no embeddings, file:line):${expLine}\n` + rows.join("\n") + cert + climb + flow);
     }
     if (name === "find_files") {

--- a/server/edit-ledger.js
+++ b/server/edit-ledger.js
@@ -11,6 +11,11 @@ import path from "node:path";
 
 const LEDGER = () => process.env.VTS_EDIT_LEDGER || path.join(os.homedir(), ".vs-token-safer", "edit-adoption.json");
 const freshMod = () => ({ warn: { shown: 0, converted: 0 }, block: { shown: 0, converted: 0 } });
+// The recency window for the rolling adoption rate. The all-time ratio is dragged down forever by the long
+// historical tail of built-in edits, so it can never show whether the steer is working NOW — exactly the
+// signal the SessionStart re-inject loop needs. A bounded ring of the last N whole-decl edits ("s" = a vts
+// symbol-edit, "b" = a built-in edit we warned on) gives a metric that actually tracks current behavior.
+const RECENT_WINDOW = () => Math.max(5, parseInt(process.env.VTS_EDIT_RECENT_WINDOW || "50", 10) || 50);
 
 export function readEditLedger() {
   try {
@@ -19,8 +24,9 @@ export function readEditLedger() {
     o.mod.warn = o.mod.warn || { shown: 0, converted: 0 };
     o.mod.block = o.mod.block || { shown: 0, converted: 0 };
     if (!("pending" in o)) o.pending = null;
+    if (!Array.isArray(o.recent)) o.recent = [];
     return o;
-  } catch { return { builtin: 0, symbol: 0, streak: 0, mod: freshMod(), pending: null }; }
+  } catch { return { builtin: 0, symbol: 0, streak: 0, mod: freshMod(), pending: null, recent: [] }; }
 }
 function write(o) {
   try { const p = LEDGER(); fs.mkdirSync(path.dirname(p), { recursive: true }); fs.writeFileSync(p, JSON.stringify(o)); } catch { /* best-effort */ }
@@ -41,6 +47,11 @@ export function recordEditEvent(kind) {
     // A whole-decl edit went to the built-in tool: the previously-shown modality (still pending) did NOT
     // convert. Leave it shown-not-converted; recordSteerShown sets the next pending modality.
   }
+  // Append to the rolling recency window (kept bounded) so the live adoption rate tracks current behavior.
+  if (!Array.isArray(o.recent)) o.recent = [];
+  o.recent.push(kind === "symbol-edit" ? "s" : "b");
+  const w = RECENT_WINDOW();
+  if (o.recent.length > w) o.recent = o.recent.slice(-w);
   write(o);
   return o;
 }
@@ -56,6 +67,16 @@ export function recordSteerShown(modality) {
 export function adoptionPct(o = readEditLedger()) {
   const total = (o.builtin || 0) + (o.symbol || 0);
   return total ? Math.round((100 * (o.symbol || 0)) / total) : null;
+}
+// Rolling adoption % over the recency window — the live signal that tracks CURRENT behavior (the all-time
+// ratio is permanently dragged down by the historical tail and can't show whether the steer is converting
+// now). null when the window is empty. This is the safe lever the steer loop actually has: measure→re-inject
+// a metric that can move, rather than force adoption (a hard block traps the agent — documented).
+export function adoptionPctRecent(o = readEditLedger()) {
+  const r = Array.isArray(o.recent) ? o.recent : [];
+  if (!r.length) return null;
+  const s = r.filter((x) => x === "s").length;
+  return Math.round((100 * s) / r.length);
 }
 // Clear the ignore-streak without touching the counts — used after an L2 block FIRES so it backs off
 // (fire-once, not a persistent wall: a permanent block trapped the agent, which fought it with Edit retries

--- a/server/policy.js
+++ b/server/policy.js
@@ -11,7 +11,7 @@
 //      adoption posture (edit-adoption % + the adaptive controller state), so the model reads a single policy
 //      instead of N scattered reflexive nudges. This is the "integrative" half — vts and CC-native each named
 //      for what they're best at.
-import { readEditLedger, adoptionPct, controllerReport } from "./edit-ledger.js";
+import { readEditLedger, adoptionPct, adoptionPctRecent, controllerReport } from "./edit-ledger.js";
 
 // Generated code / build output / vendored deps — a semantic index adds nothing here; CC-native is fine.
 const SUPPRESS_DIR = /(^|[/\\])(Intermediate|Binaries|Saved|DerivedDataCache|node_modules|build|dist|out|obj|\.git)([/\\]|$)/i;
@@ -38,7 +38,11 @@ export function routingDigest(o = readEditLedger()) {
   ];
   if (pct !== null && total >= 3) {
     const hasSteer = (((o.mod || {}).warn || {}).shown || 0) + (((o.mod || {}).block || {}).shown || 0) > 0;
-    lines.push(`  posture: symbol-edit adoption ${pct}% (${o.symbol || 0}/${total})${hasSteer ? " · " + controllerReport(o) : ""}`);
+    // Lead with the ROLLING rate (current behavior) and keep the all-time ratio as context — the recent
+    // number is what tells the model whether the steer is converting now, the lever the loop can actually move.
+    const recent = adoptionPctRecent(o);
+    const recentStr = recent !== null && recent !== pct ? `, recent ${recent}%` : "";
+    lines.push(`  posture: symbol-edit adoption ${pct}% (${o.symbol || 0}/${total})${recentStr}${hasSteer ? " · " + controllerReport(o) : ""}`);
   }
   return lines.join("\n");
 }


### PR DESCRIPTION
Fixes the three known weaknesses logged for v0.34.1. Charter-pure: local-only, no embeddings, token-capped file:line, official parser.

## Changes

**(a) concept_search climb/flow seed = best intrinsic match, not `ranked[0]`** (`core.js`)
The ladder steer and `flow=` seed used the top entry by total score (`base` + import-graph proximity boost). A neighbour boost can lift a weak-base symbol to the top of the shown list, but the seed is handed to find_references/goto_definition for ground truth, so it must be the most confident exact-name candidate. Carry `base` into the ranked set; `seed = max base`.

**(b) cross-cutting-generic expansion gate** (`concept.js expandQuery`)
A moderately-common token clears the PMI bar while its co-occurrence neighbours are cross-cutting noise (the documented limit on cross-cutting fuzzy queries). New `maxDfRatio` (0 = off; `core.js` passes `VTS_CONCEPT_MAX_DF` default 0.25, active only when N>=20): refuse to expand through/into a token in > that fraction of decls. The token is still scored directly via its low idf; only the noisy second-order neighbours are suppressed.

**(c) recency-windowed adoption** (`edit-ledger.js` + `policy.js`)
The all-time adoption ratio is dragged down forever by the historical built-in-edit tail, so it cannot show whether the steer converts now — the exact signal the SessionStart re-inject loop needs. Bounded `recent[]` ring (`VTS_EDIT_RECENT_WINDOW` default 50, floor 5) + `adoptionPctRecent`; the routing digest surfaces `recent X%` alongside the all-time ratio when they diverge. The safe lever (measure -> re-inject a metric that can move), not forcing (a hard block traps the agent).

## Review points
- All three are reranking / metric-honesty changes — they never invent a match, never transmit, output stays capped.
- New env knobs default to the active-but-safe value; `VTS_CONCEPT_MAX_DF=0` and the recency window are back-compat.

## Verification
- `node eval/run.mjs` -> 86 checks PASS (added guards: 83 seedOk + dfGateOk, 78 recencyOk, 80 digRecentOk).
- `npm run lint` clean.
- benchmarks/results refreshed (3-language run; the paper's Evaluation section now cites these — paper lives in its own gitignored tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
