### PR TITLE
release: dead-code preview (dce) + promo gitignore - v0.34.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ paper/
 # committable symbol index — a FEATURE for users (commit it in YOUR repo to share cold-start symbols);
 # in THIS repo it's a dev/dogfood build artifact, so don't track it here.
 .vts-index/
+
+# promo / marketing assets (LinkedIn cards, generated images) — kept local, never shipped or tracked.
+# Drop any future promo material under promo/ and it stays out of git.
+promo/
+linkedin-card.*

--- a/commands/dce.md
+++ b/commands/dce.md
@@ -1,0 +1,38 @@
+---
+description: Preview-only dead-code analysis — from a seed symbol, walk the call graph to a fixpoint and list what is provably DEAD (and what cascades), without deleting anything.
+---
+
+# vs-token-safer — dead-code elimination (preview only)
+
+Use this when the user wants to know what code can be safely removed starting from one or more symbols
+("is `Foo` used anywhere?", "what becomes dead if I delete `Foo`?", "find unused code reachable from here").
+
+Run it with the seed symbol(s). Prefer the `vts_admin` MCP tool (server `vs-search`):
+
+```
+vts_admin { "op": "dce", "params": { "seed": "Foo", "projectPath": "<the project root>" } }
+```
+
+For several seeds use `"seeds": "Foo,Bar,Baz"`. If the `vs-search` server is unavailable, run the CLI instead:
+
+```
+vts dce --seed Foo --projectPath <root>
+# or:  vts dce --seeds Foo,Bar,Baz --projectPath <root> [--entry main,registerPlugin --maxNodes 120]
+```
+
+Then show the output **verbatim**. It classifies every symbol reachable from the seeds as:
+
+- **DEAD** — no live caller remains; listed in a safe deletion order (top is removable first).
+- **HELD** — still referenced; not dead (shows who calls it).
+- **ENTRY** — a root kept on purpose (main / public API / a name you passed via `--entry`).
+- **INCONCLUSIVE** — could not be resolved, or its caller set could not be proven complete.
+
+## Important — this NEVER deletes
+
+`dce` only proposes candidates from the **call graph**. To actually remove one, run `safe_delete`
+(`vts safe-delete --symbol <name> --apply`), which independently re-checks `find_references` and refuses while
+the symbol is still referenced. So even a wrong DEAD candidate cannot delete live code: **dce proposes, safe_delete disposes.**
+
+Always surface the CAVEAT in the output: the call graph does not see non-call references (a function used as a
+value/callback, reflection, string/dynamic dispatch, cross-language calls, or test-only usage). Delete DEAD
+candidates one at a time, top of the list first, and let `safe_delete`'s guard be the final gate.

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -2054,6 +2054,42 @@ if (tsAvailable()) {
 }
 const conceptOk = splitOk && expandOk && synOk && scoreOk && dfGateOk && conceptToolOk;
 
+// 85) PREVIEW-ONLY DCE (dce.js): topological dead-code analysis over an INJECTED call-graph query — pure +
+// deterministic with a mock graph. DEAD cascades to a fixpoint (a callee dies only once ALL its callers are
+// removed), HELD when a live caller remains, ENTRY roots are kept, INCONCLUSIVE on unresolved / non-COMPLETE
+// cert. It never deletes — the real removal is safe_delete's reference-guarded job (guard 52), not tested here.
+const { analyzeDeadCode: dceAnalyze, formatDce: dceFmt } = await import("../server/dce.js");
+const dceG = {
+  main: { callers: [], callees: ["a", "b"] },
+  a: { callers: ["main"], callees: ["c"] },
+  b: { callers: ["main"], callees: ["c"] },
+  c: { callers: ["a", "b"], callees: [] },
+  d: { callers: [], callees: ["e"] },             // uncalled seed
+  f: { callers: [], callees: ["e"] },             // also uncalled
+  e: { callers: ["d", "f"], callees: [] },        // dead ONLY if both d and f are removed (the cascade test)
+  partialSym: { callers: [], callees: [], cert: "PARTIAL" },
+};
+const dceQuery = async (nm) => {
+  const g = dceG[nm];
+  if (!g) return { resolved: false };
+  return { resolved: true, cert: g.cert || "COMPLETE", file: nm + ".js", line: 1,
+    callers: (g.callers || []).map((n) => ({ name: n, file: n + ".js" })),
+    callees: (g.callees || []).map((n) => ({ name: n, file: n + ".js" })) };
+};
+const dceNames = (arr) => arr.map((x) => x.name);
+const dr1 = await dceAnalyze(dceQuery, ["d"], {});            // d dead; e HELD (f still calls it)
+const dr1ok = JSON.stringify(dceNames(dr1.dead)) === JSON.stringify(["d"]) && dr1.held.some((h) => h.name === "e" && h.callers.includes("f"));
+const dr2 = await dceAnalyze(dceQuery, ["d", "f"], {});       // remove both → e cascades dead, in order
+const dr2ok = dceNames(dr2.dead).join(",") === "d,f,e" && dr2.held.length === 0;
+const dr3 = await dceAnalyze(dceQuery, ["main"], { isEntry: (n) => n === "main" }); // ENTRY held, no cascade
+const dr3ok = dr3.dead.length === 0 && dr3.entry.some((e) => e.name === "main");
+const dr4 = await dceAnalyze(dceQuery, ["partialSym"], {});   // PARTIAL cert → INCONCLUSIVE, not dead
+const dr4ok = dr4.dead.length === 0 && dr4.inconclusive.some((x) => x.name === "partialSym");
+const dr5 = await dceAnalyze(dceQuery, ["ghost"], {});        // unresolved → INCONCLUSIVE
+const dr5ok = dr5.dead.length === 0 && dr5.inconclusive.some((x) => x.name === "ghost");
+const dceFmtOk = /DEAD/.test(dceFmt(dr2)) && /safe_delete symbol="e"/.test(dceFmt(dr2)) && /CAVEAT/.test(dceFmt(dr2));
+const dceOk = dr1ok && dr2ok && dr3ok && dr4ok && dr5ok && dceFmtOk;
+
 // 84) STRUCTURE tier (textstruct.js): prose/config files (markdown/toml/yaml/rst/…) get a SECTION tree, and
 // the existing symbol tools (document_symbols / read_symbol / replace_symbol_body / …) edit a section BY NAME
 // — no backend, no whole-file Read. Multi-format outline + resolve (pure) + the tool integration on disk.
@@ -2194,6 +2230,7 @@ const rows = [
   ["syntactic tier: tree-sitter decl extraction (36 langs, zero setup) + committable .vts-index symbol index + HTML <script>/<style> exact-range injection", tsTierOk, "true", tsTierOk],
   ["Roslyn dotnet-host path OS-aware (macOS/Linux C# regression: win32/darwin/linux globalStorage)", roslynOsPathOk, "true", roslynOsPathOk],
   ["fuzzy concept retrieval (B): repo co-occurrence dictionary + concept_search (no embeddings, ranked decls)", conceptOk, "true", conceptOk],
+  ["preview-only DCE: topological dead-code candidates via call-graph cascade to a fixpoint (safe_delete backstop)", dceOk, "true", dceOk],
   ["structure tier: section outline/read/edit for md/toml/yaml/html/css/scss/… via the symbol tools (no backend, by heading/selector/rule/function)", structOk, "true", structOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);

--- a/server/cli.js
+++ b/server/cli.js
@@ -40,6 +40,10 @@ Commands:
                  [--symbol <name> --text <text> [--path <file> --line N --apply]]
   safe-delete    Delete a named declaration; refuses while referenced unless --force. Preview; --apply.
                  [--symbol <name> [--path <file> --line N --force --apply]]
+  dce            Preview-only dead-code analysis. From seed symbol(s), walk the call graph to a fixpoint and
+                 list DEAD / HELD / ENTRY / INCONCLUSIVE candidates + a safe deletion order. NEVER deletes —
+                 each DEAD candidate still goes through safe-delete's own reference guard.
+                 [--seed <name> | --seeds A,B,C --projectPath <dir> [--entry main,init --maxNodes N]]
   files          Find files by name (substring or glob). [--q <pattern> --projectPath <dir>]
   text           Raw text/regex search (token-capped). [--q <pattern> --projectPath <dir> --path <file> --glob <pat> --docs]
                  --path <file> / --glob <pat> target a file/glob and auto-include its extension (e.g. a .md);
@@ -85,7 +89,7 @@ Backends (auto-detected from the root, or set --backend / VTS_BACKEND):
   pyright     — Python (pyproject/setup.py/requirements or *.py; bundled pyright-langserver)
 Settings precedence: env (VTS_*) > ~/.vs-token-safer/config.json > default.`;
 
-const LIST_FLAGS = new Set([]);
+const LIST_FLAGS = new Set(["seeds", "entry"]);
 const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open", "static", "docs", "status", "flow"]);
 
 function parseArgs(argv) {
@@ -102,7 +106,7 @@ function parseArgs(argv) {
   }
   return a;
 }
-const COMMANDS = { symbol: "search_symbol", references: "find_references", definition: "goto_definition", "trace-calls": "find_references", hover: "hover", symbols: "document_symbols", "read-symbol": "read_symbol", diagnostics: "diagnostics", rename: "rename", "replace-symbol": "replace_symbol_body", insert: "insert_symbol", "insert-after": "insert_symbol", "insert-before": "insert_symbol", "safe-delete": "safe_delete", files: "find_files", text: "search_text", git: "vts_git", p4: "vts_p4", setup: "vts_setup", config: "vts_config", savings: "vts_savings", "savings-reset": "vts_savings_reset", discover: "vts_discover", warmup: "vts_warmup", preindex: "vts_preindex", scope: "vts_scope", index: "vts_index", concept: "concept_search", "gen-compile-db": "vts_gen_compile_db" };
+const COMMANDS = { symbol: "search_symbol", references: "find_references", definition: "goto_definition", "trace-calls": "find_references", hover: "hover", symbols: "document_symbols", "read-symbol": "read_symbol", diagnostics: "diagnostics", rename: "rename", "replace-symbol": "replace_symbol_body", insert: "insert_symbol", "insert-after": "insert_symbol", "insert-before": "insert_symbol", "safe-delete": "safe_delete", dce: "vts_dce", files: "find_files", text: "search_text", git: "vts_git", p4: "vts_p4", setup: "vts_setup", config: "vts_config", savings: "vts_savings", "savings-reset": "vts_savings_reset", discover: "vts_discover", warmup: "vts_warmup", preindex: "vts_preindex", scope: "vts_scope", index: "vts_index", concept: "concept_search", "gen-compile-db": "vts_gen_compile_db" };
 
 const [, , rawCmd, ...rest] = process.argv;
 if (!rawCmd || rawCmd === "-h" || rawCmd === "--help" || rawCmd === "help") { console.log(HELP); process.exit(rawCmd ? 0 : 1); }

--- a/server/core.js
+++ b/server/core.js
@@ -23,6 +23,7 @@ import { tsSearchSymbols, tsSearchReferences, tsFileDeclDocs, tsSupports, tsAvai
 import { searchSymIndex, buildSymIndex, symIndexPath, loadSymIndex } from "./symindex.js";
 import { splitIdent, tokenize, buildConceptModel, expandQuery, scoreSymbol, importSpecifiers, parseSynonyms } from "./concept.js";
 import { isStructFile, structOutlineInjected, resolveInOutline, fmtOutline } from "./textstruct.js";
+import { analyzeDeadCode, formatDce } from "./dce.js";
 
 const CONFIG_DIR = path.join(os.homedir(), ".vs-token-safer");
 export const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(CONFIG_DIR, "config.json");
@@ -2091,6 +2092,48 @@ export async function runTool(name, a = {}) {
       // right, climb to the exact rung for ground-truth — name the hit to find_references / goto_definition.
       const climb = process.env.VTS_CONCEPT_STEER !== "0" ? `\n[ladder: this is the fuzzy rung. Climb to exact on a hit — find_references symbol="${seed.s.name}" or goto_definition for ground-truth refs/def.]` : "";
       return finishOut(rows, `${ranked.length} concept match(es) for "${a.q}" (fuzzy — local concept dictionary, no embeddings, file:line):${expLine}\n` + rows.join("\n") + cert + climb + flow);
+    }
+    if (name === "vts_dce") {
+      // TOPOLOGICAL dead-code ANALYSIS (preview-only) — see dce.js. Seed symbol(s) → walk the call graph to a
+      // fixpoint → DEAD / HELD / ENTRY / INCONCLUSIVE candidates + a safe deletion order. It NEVER deletes;
+      // the real removal goes through safe_delete (whose find_references guard is the independent backstop, so
+      // a false DEAD here cannot delete live code). DCE proposes (call graph), safe_delete disposes (refs guard).
+      const root = resolveRoot(a);
+      let seeds = [];
+      if (Array.isArray(a.seeds)) seeds = a.seeds.slice();
+      else if (typeof a.seeds === "string" && a.seeds) seeds = a.seeds.split(",");
+      if (a.seed) seeds.push(String(a.seed));
+      seeds = [...new Set(seeds.map((s) => String(s).trim()).filter(Boolean))];
+      if (!seeds.length) return err('vts_dce needs seed symbol(s): seed="Foo" or seeds="Foo,Bar" (the declaration(s) you suspect are dead).');
+      const backendName = preferBackend(a.backend, backendForPath(a.path), BACKEND) || pickBackend(root);
+      if (!backendName) return err(`dead-code analysis needs a language-server backend (clangd/roslyn/typescript/pyright) for ${root}; none resolved. It walks the call graph, which the syntactic/text tiers can't provide.`);
+      // Entry-point roots — never dead even with zero callers (they're invoked externally). A small built-in
+      // set + user-supplied `entry` patterns (comma list, matched as case-insensitive name substrings).
+      const userPats = (typeof a.entry === "string" && a.entry ? a.entry.split(",") : Array.isArray(a.entry) ? a.entry : [])
+        .map((s) => String(s).trim().toLowerCase()).filter(Boolean);
+      const DEFAULT_ENTRY = /^(main|winmain|_?start|run)$/i;
+      const isEntry = (nm) => DEFAULT_ENTRY.test(nm) || userPats.some((p) => nm.toLowerCase().includes(p));
+      // query(name): one call-hierarchy probe (both directions, 1 hop) → caller + callee NAMES with files.
+      const query = async (nm) => {
+        let cg;
+        try { cg = await buildCallGraph({ symbol: nm, direction: "both", depth: 1, projectPath: root, backend: backendName }); }
+        catch { return { resolved: false }; }
+        if (!cg || cg.error) return { resolved: false };
+        const focus = cg.nodes.find((n) => n.focus) || cg.nodes[0];
+        if (!focus) return { resolved: false };
+        const byId = new Map(cg.nodes.map((n) => [n.id, n]));
+        const callers = [], callees = [], seenC = new Set(), seenE = new Set();
+        for (const l of cg.links || []) {
+          if (l.target === focus.id && l.source !== focus.id) { const n = byId.get(l.source); if (n && !seenC.has(n.label)) { seenC.add(n.label); callers.push({ name: n.label, file: n.file }); } }
+          if (l.source === focus.id && l.target !== focus.id) { const n = byId.get(l.target); if (n && !seenE.has(n.label)) { seenE.add(n.label); callees.push({ name: n.label, file: n.file }); } }
+        }
+        return { resolved: true, callers, callees, cert: cg.truncated ? "PARTIAL" : "COMPLETE", file: focus.file, line: focus.line };
+      };
+      const envCap = envInt("VTS_DCE_MAX_NODES", 120);
+      const maxNodes = Math.min(Number(a.maxNodes) || envCap, envCap);
+      const result = await analyzeDeadCode(query, seeds, { maxNodes, isEntry });
+      const rows = result.dead.map((dd) => `${dd.file}:${dd.line}`);
+      return finishOut(rows, formatDce(result, { cap: MAX_RESULTS }));
     }
     if (name === "find_files") {
       if (!a.q) return err("find_files needs q (a filename substring or glob like *Manager.cpp).");

--- a/server/dce.js
+++ b/server/dce.js
@@ -1,0 +1,110 @@
+// dce.js — TOPOLOGICAL dead-code ANALYSIS (preview-only).
+//
+// Given seed symbols, walk the call graph to a fixpoint and classify every reachable symbol as
+//   DEAD          — no live caller remains (all its callers are themselves slated for removal), OR
+//   HELD          — still called by something outside the removal set, OR
+//   ENTRY         — a root we must keep (main / public API / user-named entry pattern), OR
+//   INCONCLUSIVE  — could not be resolved, or its caller set could not be proven COMPLETE.
+//
+// It NEVER deletes. It emits a candidate list + a suggested deletion order. The actual removal still goes
+// through `safe_delete`, whose independent find_references guard refuses a symbol that is still referenced —
+// so a false "DEAD" here cannot delete live code. The layering is the safety model:
+//   DCE proposes (the call graph)  ·  safe_delete disposes (the reference guard).
+//
+// PURE: the graph query is INJECTED, so this module touches no fs/LSP and is fully unit-testable.
+//   query(name) -> {
+//     resolved: bool,
+//     callers:  [{ name, file }],   // immediate callers (who calls `name`)
+//     callees:  [{ name, file }],   // immediate callees (whom `name` calls) — the cascade frontier
+//     cert:     "COMPLETE" | "PARTIAL" | "INCONCLUSIVE" | ...,   // confidence in the CALLER set
+//     file, line                    // where `name` is declared
+//   }
+
+export async function analyzeDeadCode(query, seeds, opts = {}) {
+  const maxNodes = Math.max(1, opts.maxNodes || 200);
+  const isEntry = opts.isEntry || (() => false);
+  const seedList = [...new Set(seeds.filter(Boolean))];
+
+  const info = new Map();
+  const q = async (name) => { if (!info.has(name)) info.set(name, await query(name)); return info.get(name); };
+
+  const removal = new Set();   // confirmed DEAD
+  const order = [];            // discovery order = a safe deletion order (each is unreferenced once the ones above it are gone)
+  const entry = new Map();     // name -> reason
+  const incon = new Map();     // name -> reason
+  const candidates = new Set(seedList);
+
+  // Fixpoint: a symbol with a still-live caller is NOT finalized — a later pass may remove that caller and
+  // free it. Only ENTRY and INCONCLUSIVE are terminal classifications; "has a live caller" is re-checked.
+  let changed = true;
+  while (changed && removal.size < maxNodes) {
+    changed = false;
+    for (const name of [...candidates]) {
+      if (removal.has(name) || entry.has(name) || incon.has(name)) continue;
+      const r = await q(name);
+      if (!r || !r.resolved) { incon.set(name, "could not resolve to a callable symbol (no backend, or not a function/method)"); continue; }
+      if (isEntry(name, r)) { entry.set(name, "entry point / public API — kept as a root"); continue; }
+      if (r.cert !== "COMPLETE") { incon.set(name, `caller set is ${r.cert || "unverified"} — cannot prove it is unused`); continue; }
+      const live = (r.callers || []).filter((c) => c.name !== name && !removal.has(c.name));
+      if (live.length === 0) {
+        removal.add(name); order.push(name); changed = true;
+        for (const ce of r.callees || []) if (ce.name !== name) candidates.add(ce.name);
+      }
+    }
+  }
+  const truncated = removal.size >= maxNodes;
+
+  const held = [];
+  for (const name of candidates) {
+    if (removal.has(name) || entry.has(name) || incon.has(name)) continue;
+    const r = info.get(name);
+    const live = (r && r.callers ? r.callers : []).filter((c) => c.name !== name && !removal.has(c.name));
+    held.push({ name, callers: [...new Set(live.map((c) => c.name))].slice(0, 8) });
+  }
+  const dead = order.map((name) => { const r = info.get(name); return { name, file: r && r.file, line: r && r.line }; });
+  return {
+    dead, order,
+    held,
+    entry: [...entry].map(([name, reason]) => ({ name, reason })),
+    inconclusive: [...incon].map(([name, reason]) => ({ name, reason })),
+    truncated, seeds: seedList,
+  };
+}
+
+// Token-capped, sectioned preview. Never prints source bodies — names + file:line + ready safe_delete calls.
+export function formatDce(result, opts = {}) {
+  const cap = opts.cap || 60;
+  const { dead, held, entry, inconclusive, truncated, seeds } = result;
+  const L = [`dead-code analysis from seed(s): ${seeds.join(", ")} — PREVIEW ONLY, nothing was deleted.`, ""];
+
+  if (dead.length) {
+    L.push(`DEAD — ${dead.length} candidate(s), in a safe deletion order (each is unreferenced once the ones above it are removed):`);
+    dead.slice(0, cap).forEach((d, i) => L.push(`  ${i + 1}. ${d.name}${d.file ? `  @ ${d.file}:${d.line}` : ""}`));
+    if (dead.length > cap) L.push(`  … ${dead.length - cap} more`);
+    L.push("");
+    L.push("  to remove (each still passes safe_delete's own reference guard, so it cannot delete live code):");
+    dead.slice(0, Math.min(cap, 12)).forEach((d) => L.push(`    safe_delete symbol="${d.name}" apply=true`));
+    if (dead.length > 12) L.push(`    … and ${dead.length - 12} more, top-to-bottom`);
+  } else {
+    L.push("DEAD — none. No seed is provably unreferenced (see HELD / INCONCLUSIVE below).");
+  }
+
+  if (held.length) {
+    L.push("", `HELD — ${held.length} still referenced (NOT dead):`);
+    held.slice(0, cap).forEach((h) => L.push(`  ${h.name}${h.callers.length ? `  ← called by ${h.callers.join(", ")}` : ""}`));
+  }
+  if (entry.length) L.push("", `ENTRY — ${entry.length} kept as root(s): ${entry.map((e) => e.name).join(", ")}`);
+  if (inconclusive.length) {
+    L.push("", `INCONCLUSIVE — ${inconclusive.length} (cannot prove dead — verify manually):`);
+    inconclusive.slice(0, cap).forEach((x) => L.push(`  ${x.name} — ${x.reason}`));
+  }
+  if (truncated) L.push("", "(node cap hit — more may cascade; raise maxNodes or re-run from the tail of the DEAD list.)");
+
+  L.push(
+    "",
+    "CAVEAT: candidates come from the CALL graph, which does not see non-call references — a function used as a",
+    "value/callback, reflection, string or dynamic dispatch, cross-language calls, or test-only usage. Treat DEAD",
+    "as CANDIDATES, not a verdict: safe_delete re-checks each with find_references and refuses while referenced.",
+  );
+  return L.join("\n");
+}

--- a/skills/vs-dce/SKILL.md
+++ b/skills/vs-dce/SKILL.md
@@ -1,0 +1,38 @@
+---
+description: Preview-only dead-code analysis for C/C++, C#/.NET, JS/TS, and Python via vs-token-safer. From one or more seed symbols, walk the official language server's call graph to a fixpoint and report what is provably DEAD (and what transitively becomes dead) — without deleting anything. Use whenever the user asks what code is unused/removable, whether a function is called anywhere, what becomes dead if a symbol is deleted, or for transitive dead-code cleanup. Not for a plain "who calls X" (use find_references) — this is the multi-hop cascade + safe deletion order.
+---
+
+# vs-token-safer — dead-code elimination (preview only)
+
+Topological dead-code analysis built on the OFFICIAL language-server call graph (clangd / Roslyn / tsserver /
+pyright). You name seed symbol(s); it walks callers/callees to a fixpoint and classifies every reachable
+symbol. The output is token-capped (names + `file:line`, no source bodies). Nothing leaves the machine.
+
+## How to run
+
+Prefer the `vts_admin` MCP tool (server `vs-search`); fall back to the `vts` CLI:
+
+```
+vts_admin { "op": "dce", "params": { "seed": "Foo", "projectPath": "<root>" } }
+# several seeds:  "params": { "seeds": "Foo,Bar", "projectPath": "<root>", "entry": "main,registerPlugin" }
+# CLI:            vts dce --seed Foo --projectPath <root>
+```
+
+Show the result verbatim. Buckets: **DEAD** (no live caller, in safe deletion order) · **HELD** (still called) ·
+**ENTRY** (kept root: main / public API / a name passed via `entry`) · **INCONCLUSIVE** (unresolved or the
+caller set couldn't be proven complete).
+
+## The safety model — it NEVER deletes
+
+`dce` only PROPOSES candidates from the call graph. The actual removal goes through `safe_delete`
+(`vts safe-delete --symbol <name> --apply`), which independently re-checks `find_references` and refuses while
+the symbol is still referenced. So a wrong DEAD candidate cannot delete live code: **dce proposes, safe_delete disposes.**
+
+Karpathy-style rules — do the listed thing, do not improvise:
+1. Run `dce` with the seed(s); show the buckets verbatim.
+2. To remove a DEAD candidate, run `safe_delete` on it, top of the list first, one at a time.
+3. Always surface the CAVEAT: the call graph does not see non-call references (function-as-value, reflection,
+   string/dynamic dispatch, cross-language, or test-only usage). Treat DEAD as candidates, not a verdict.
+4. Never bypass `safe_delete` (no `sed`/manual deletion of a DEAD candidate) — its reference guard is the backstop.
+
+Env: `VTS_DCE_MAX_NODES` (cascade node cap, default 120).


### PR DESCRIPTION
Patch release rolling up what's accumulated on dev.

Closes #159
Closes #160

## What
- **`vts dce`** — preview-only topological dead-code analysis (#159). From seed symbol(s), walk the language-server call graph to a fixpoint → DEAD / HELD / ENTRY / INCONCLUSIVE candidates + a safe deletion order. Never deletes; safe_delete's reference guard is the independent backstop.
- **gitignore** promo/marketing assets (#160).

## Review points
- DCE is additive — no new advertised MCP tool (reaches via `vts_admin{op:"dce"}`), reuses `buildCallGraph`; the only new logic is the pure fixpoint in `dce.js`.
- Released as a **patch** per maintainer's call (the dce change is `feat:`, which would normally be a minor).
- 87-check eval green, lint clean, CI green on both source PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
