### PR TITLE
release: dce warm-index safety gate - v0.34.4

### DIFF
--- a/commands/dce.md
+++ b/commands/dce.md
@@ -13,12 +13,27 @@ Run it with the seed symbol(s). Prefer the `vts_admin` MCP tool (server `vs-sear
 vts_admin { "op": "dce", "params": { "seed": "Foo", "projectPath": "<the project root>" } }
 ```
 
-For several seeds use `"seeds": "Foo,Bar,Baz"`. If the `vs-search` server is unavailable, run the CLI instead:
+For several seeds use `"seeds": "Foo,Bar,Baz"`. Prefer the MCP tool — it runs in the warm server process, and
+`vts` is often not on PATH in Bash. If the `vs-search` server is unavailable, run the bundled CLI:
 
 ```
-vts dce --seed Foo --projectPath <root>
-# or:  vts dce --seeds Foo,Bar,Baz --projectPath <root> [--entry main,registerPlugin --maxNodes 120]
+node "$CLAUDE_PLUGIN_ROOT/server/cli.js" dce --seed Foo --projectPath <root>
+# (if vts is on PATH:  vts dce --seeds Foo,Bar,Baz --projectPath <root> [--entry main,registerPlugin --maxNodes 120])
 ```
+
+## Warm-index requirement (C++/clangd)
+
+For a clangd (C/C++) project the call graph must be **warm** — a cold or large tree (e.g. an Unreal monorepo,
+~26k TUs) under-reports callers, so a live symbol could look DEAD. `dce` therefore **refuses on a cold clangd
+index** and tells you to build one. Indexing the whole tree is heavy, so scope it first:
+
+```
+vts setup --scope Source --projectPath <root>   # narrow to the module subtree, not the whole monorepo
+vts preindex --projectPath <root>               # build the scoped index (or keep the MCP server warm)
+```
+
+Then re-run `dce`. To inspect the structure on a cold index anyway, pass `allowCold=true` — every verdict is
+then forced to INCONCLUSIVE (nothing is ever marked DEAD). TypeScript/Python/C# index on open and are not gated.
 
 Then show the output **verbatim**. It classifies every symbol reachable from the seeds as:
 

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -2058,7 +2058,15 @@ const conceptOk = splitOk && expandOk && synOk && scoreOk && dfGateOk && concept
 // deterministic with a mock graph. DEAD cascades to a fixpoint (a callee dies only once ALL its callers are
 // removed), HELD when a live caller remains, ENTRY roots are kept, INCONCLUSIVE on unresolved / non-COMPLETE
 // cert. It never deletes — the real removal is safe_delete's reference-guarded job (guard 52), not tested here.
-const { analyzeDeadCode: dceAnalyze, formatDce: dceFmt } = await import("../server/dce.js");
+const { analyzeDeadCode: dceAnalyze, formatDce: dceFmt, dceWarmGate: dceGate } = await import("../server/dce.js");
+// WARM GATE: clangd on a cold/large tree under-reports callers → a live symbol can look DEAD. So a cold clangd
+// (no persisted index) REFUSES by default; allowCold proceeds but forces every verdict to INCONCLUSIVE. Other
+// backends index on open → not gated. (The false-DEAD-on-cold-UE hardening; safe_delete is still the backstop.)
+const dceGateOk =
+  JSON.stringify(dceGate("clangd", false, false)) === JSON.stringify({ refuse: true, forceInconclusive: true }) &&   // cold clangd → refuse
+  JSON.stringify(dceGate("clangd", false, true)) === JSON.stringify({ refuse: false, forceInconclusive: true }) &&   // allowCold → proceed, all INCONCLUSIVE
+  JSON.stringify(dceGate("clangd", true, false)) === JSON.stringify({ refuse: false, forceInconclusive: false }) &&  // warm clangd → normal
+  JSON.stringify(dceGate("typescript", false, false)) === JSON.stringify({ refuse: false, forceInconclusive: false }); // non-clangd → not gated
 const dceG = {
   main: { callers: [], callees: ["a", "b"] },
   a: { callers: ["main"], callees: ["c"] },
@@ -2088,7 +2096,7 @@ const dr4ok = dr4.dead.length === 0 && dr4.inconclusive.some((x) => x.name === "
 const dr5 = await dceAnalyze(dceQuery, ["ghost"], {});        // unresolved → INCONCLUSIVE
 const dr5ok = dr5.dead.length === 0 && dr5.inconclusive.some((x) => x.name === "ghost");
 const dceFmtOk = /DEAD/.test(dceFmt(dr2)) && /safe_delete symbol="e"/.test(dceFmt(dr2)) && /CAVEAT/.test(dceFmt(dr2));
-const dceOk = dr1ok && dr2ok && dr3ok && dr4ok && dr5ok && dceFmtOk;
+const dceOk = dr1ok && dr2ok && dr3ok && dr4ok && dr5ok && dceFmtOk && dceGateOk;
 
 // 84) STRUCTURE tier (textstruct.js): prose/config files (markdown/toml/yaml/rst/…) get a SECTION tree, and
 // the existing symbol tools (document_symbols / read_symbol / replace_symbol_body / …) edit a section BY NAME

--- a/server/cli.js
+++ b/server/cli.js
@@ -42,8 +42,10 @@ Commands:
                  [--symbol <name> [--path <file> --line N --force --apply]]
   dce            Preview-only dead-code analysis. From seed symbol(s), walk the call graph to a fixpoint and
                  list DEAD / HELD / ENTRY / INCONCLUSIVE candidates + a safe deletion order. NEVER deletes —
-                 each DEAD candidate still goes through safe-delete's own reference guard.
-                 [--seed <name> | --seeds A,B,C --projectPath <dir> [--entry main,init --maxNodes N]]
+                 each DEAD candidate still goes through safe-delete's own reference guard. clangd needs a WARM
+                 (persisted) index — a cold/large tree under-reports callers, so it refuses unless warm; run
+                 'vts preindex' first (or --allowCold to inspect with every verdict forced to INCONCLUSIVE).
+                 [--seed <name> | --seeds A,B,C --projectPath <dir> [--entry main,init --maxNodes N --allowCold]]
   files          Find files by name (substring or glob). [--q <pattern> --projectPath <dir>]
   text           Raw text/regex search (token-capped). [--q <pattern> --projectPath <dir> --path <file> --glob <pat> --docs]
                  --path <file> / --glob <pat> target a file/glob and auto-include its extension (e.g. a .md);
@@ -90,7 +92,7 @@ Backends (auto-detected from the root, or set --backend / VTS_BACKEND):
 Settings precedence: env (VTS_*) > ~/.vs-token-safer/config.json > default.`;
 
 const LIST_FLAGS = new Set(["seeds", "entry"]);
-const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open", "static", "docs", "status", "flow"]);
+const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open", "static", "docs", "status", "flow", "allowCold"]);
 
 function parseArgs(argv) {
   const a = {};

--- a/server/core.js
+++ b/server/core.js
@@ -23,7 +23,7 @@ import { tsSearchSymbols, tsSearchReferences, tsFileDeclDocs, tsSupports, tsAvai
 import { searchSymIndex, buildSymIndex, symIndexPath, loadSymIndex } from "./symindex.js";
 import { splitIdent, tokenize, buildConceptModel, expandQuery, scoreSymbol, importSpecifiers, parseSynonyms } from "./concept.js";
 import { isStructFile, structOutlineInjected, resolveInOutline, fmtOutline } from "./textstruct.js";
-import { analyzeDeadCode, formatDce } from "./dce.js";
+import { analyzeDeadCode, formatDce, dceWarmGate } from "./dce.js";
 
 const CONFIG_DIR = path.join(os.homedir(), ".vs-token-safer");
 export const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(CONFIG_DIR, "config.json");
@@ -2107,6 +2107,15 @@ export async function runTool(name, a = {}) {
       if (!seeds.length) return err('vts_dce needs seed symbol(s): seed="Foo" or seeds="Foo,Bar" (the declaration(s) you suspect are dead).');
       const backendName = preferBackend(a.backend, backendForPath(a.path), BACKEND) || pickBackend(root);
       if (!backendName) return err(`dead-code analysis needs a language-server backend (clangd/roslyn/typescript/pyright) for ${root}; none resolved. It walks the call graph, which the syntactic/text tiers can't provide.`);
+      // WARM GATE — the safety preflight (cheap fs check, no clangd spawn). On a cold/large clangd tree the call
+      // graph under-reports callers (callers in not-yet-indexed TUs are absent) → a LIVE symbol can look DEAD.
+      // Refuse by default rather than hand back unsafe DEAD candidates; allowCold proceeds with every verdict
+      // forced to INCONCLUSIVE. (search_symbol etc. still resolve fine cold — only the call-graph completeness
+      // that DCE's correctness hinges on is unsafe.)
+      const allowCold = a.allowCold === true || a.allowCold === "true";
+      const persisted = backendName === "clangd" ? hasPersistedIndex(root) : true;
+      const gate = dceWarmGate(backendName, persisted, allowCold);
+      if (gate.refuse) return err(`dead-code analysis needs a built clangd index for ${root}, and none is persisted yet. On a cold or large (e.g. Unreal, ~26k TUs) tree the call graph UNDER-REPORTS callers — a symbol whose callers live in not-yet-indexed translation units would look DEAD when it is actually live, which is unsafe to feed safe_delete. Indexing the WHOLE tree is heavy, so SCOPE it to the module under analysis first, then build:\n  vts setup --scope Source --projectPath "${root}"   (narrow to the game/module subtree — not the whole monorepo)\n  vts preindex --projectPath "${root}"               (build the scoped index; or keep the MCP server running so clangd stays warm)\nThen re-run. Refusing rather than returning unsafe DEAD candidates. To inspect the structure anyway (every verdict forced to INCONCLUSIVE, nothing marked DEAD), pass allowCold=true.`);
       // Entry-point roots — never dead even with zero callers (they're invoked externally). A small built-in
       // set + user-supplied `entry` patterns (comma list, matched as case-insensitive name substrings).
       const userPats = (typeof a.entry === "string" && a.entry ? a.entry.split(",") : Array.isArray(a.entry) ? a.entry : [])
@@ -2127,11 +2136,13 @@ export async function runTool(name, a = {}) {
           if (l.target === focus.id && l.source !== focus.id) { const n = byId.get(l.source); if (n && !seenC.has(n.label)) { seenC.add(n.label); callers.push({ name: n.label, file: n.file }); } }
           if (l.source === focus.id && l.target !== focus.id) { const n = byId.get(l.target); if (n && !seenE.has(n.label)) { seenE.add(n.label); callees.push({ name: n.label, file: n.file }); } }
         }
-        return { resolved: true, callers, callees, cert: cg.truncated ? "PARTIAL" : "COMPLETE", file: focus.file, line: focus.line };
+        const cert = gate.forceInconclusive ? "INCONCLUSIVE" : cg.truncated ? "PARTIAL" : "COMPLETE";
+        return { resolved: true, callers, callees, cert, file: focus.file, line: focus.line };
       };
       const envCap = envInt("VTS_DCE_MAX_NODES", 120);
       const maxNodes = Math.min(Number(a.maxNodes) || envCap, envCap);
       const result = await analyzeDeadCode(query, seeds, { maxNodes, isEntry });
+      if (gate.forceInconclusive) result.coldNote = `clangd index not warm for ${root} — running in allowCold mode: every verdict is forced to INCONCLUSIVE (nothing is marked DEAD). Build the index (vts preindex) for real DEAD/HELD verdicts.`;
       const rows = result.dead.map((dd) => `${dd.file}:${dd.line}`);
       return finishOut(rows, formatDce(result, { cap: MAX_RESULTS }));
     }

--- a/server/dce.js
+++ b/server/dce.js
@@ -20,6 +20,18 @@
 //     file, line                    // where `name` is declared
 //   }
 
+// WARM GATE — the safety preflight. clangd's call graph on a cold or large (e.g. Unreal) tree UNDER-REPORTS
+// callers: a caller living in a translation unit clangd has not indexed yet is simply absent, so a LIVE symbol
+// looks like it has no callers → a false DEAD. For a workflow that feeds `safe_delete`, that is the worst
+// failure mode, so unless a persisted index exists we REFUSE by default. `allowCold` lets the caller proceed
+// anyway, but then every verdict is forced to INCONCLUSIVE (never DEAD) — the structure is shown, no deletion
+// is ever implied. Non-clangd backends index on open and carry no persisted-index notion, so they are not
+// gated here (their per-symbol cert still reflects truncation). PURE — the caller supplies `persisted`.
+export function dceWarmGate(backendName, persisted, allowCold) {
+  if (backendName === "clangd" && !persisted) return { refuse: !allowCold, forceInconclusive: true };
+  return { refuse: false, forceInconclusive: false };
+}
+
 export async function analyzeDeadCode(query, seeds, opts = {}) {
   const maxNodes = Math.max(1, opts.maxNodes || 200);
   const isEntry = opts.isEntry || (() => false);
@@ -74,8 +86,10 @@ export async function analyzeDeadCode(query, seeds, opts = {}) {
 // Token-capped, sectioned preview. Never prints source bodies — names + file:line + ready safe_delete calls.
 export function formatDce(result, opts = {}) {
   const cap = opts.cap || 60;
-  const { dead, held, entry, inconclusive, truncated, seeds } = result;
-  const L = [`dead-code analysis from seed(s): ${seeds.join(", ")} — PREVIEW ONLY, nothing was deleted.`, ""];
+  const { dead, held, entry, inconclusive, truncated, seeds, coldNote } = result;
+  const L = [`dead-code analysis from seed(s): ${seeds.join(", ")} — PREVIEW ONLY, nothing was deleted.`];
+  if (coldNote) L.push(`⚠ ${coldNote}`);
+  L.push("");
 
   if (dead.length) {
     L.push(`DEAD — ${dead.length} candidate(s), in a safe deletion order (each is unreferenced once the ones above it are removed):`);

--- a/skills/vs-dce/SKILL.md
+++ b/skills/vs-dce/SKILL.md
@@ -10,13 +10,20 @@ symbol. The output is token-capped (names + `file:line`, no source bodies). Noth
 
 ## How to run
 
-Prefer the `vts_admin` MCP tool (server `vs-search`); fall back to the `vts` CLI:
+Prefer the `vts_admin` MCP tool (it runs in the warm server process; `vts` is often not on PATH in Bash). Fall
+back to the bundled CLI via node:
 
 ```
 vts_admin { "op": "dce", "params": { "seed": "Foo", "projectPath": "<root>" } }
 # several seeds:  "params": { "seeds": "Foo,Bar", "projectPath": "<root>", "entry": "main,registerPlugin" }
-# CLI:            vts dce --seed Foo --projectPath <root>
+# CLI fallback:   node "$CLAUDE_PLUGIN_ROOT/server/cli.js" dce --seed Foo --projectPath <root>
 ```
+
+**Warm-index requirement (C++/clangd).** The call graph must be warm. A cold or large clangd tree (e.g. an
+Unreal monorepo, ~26k TUs) under-reports callers, so a live symbol could look DEAD — `dce` therefore REFUSES on
+a cold clangd index. Scope + build first: `vts setup --scope Source` then `vts preindex` (or keep the MCP server
+warm), then re-run. `allowCold=true` inspects a cold index with every verdict forced to INCONCLUSIVE (never
+DEAD). TypeScript/Python/C# index on open and are not gated.
 
 Show the result verbatim. Buckets: **DEAD** (no live caller, in safe deletion order) · **HELD** (still called) ·
 **ENTRY** (kept root: main / public API / a name passed via `entry`) · **INCONCLUSIVE** (unresolved or the


### PR DESCRIPTION
Patch: hardens v0.34.3's `vts dce` against a false-DEAD on a cold/large clangd tree.

Closes #162

## What
clangd's call graph under-reports callers on a cold or large (Unreal, ~26k TU) tree — a live symbol could look DEAD. `dce` now **refuses on a cold clangd index** with an actionable advisory (`vts setup --scope Source` → `vts preindex`), or `allowCold=true` proceeds with every verdict forced to INCONCLUSIVE (never DEAD). Non-clangd backends are not gated. Docs/CLI lead with the MCP tool + node-cli fallback (vts often not on PATH).

## Review points
- Cheap fs preflight (`hasPersistedIndex`) — never spawns clangd or triggers the heavy cold build.
- Second line of defense; safe_delete's reference guard is still the disposal backstop.
- 87-check eval green (guard 85 extended with `dceWarmGate`), lint clean, CI green on #162.

Follow-up (separate): a "thorough/slow-but-complete" DCE mode — build-and-wait for the full index + per-candidate find_references reference-count verification to eliminate the call-graph non-call blind spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
