### PR TITLE
feat(dce): thorough reference-verify + reachability (mark-sweep) mode + build-and-wait

### DIFF
--- a/commands/dce.md
+++ b/commands/dce.md
@@ -42,6 +42,20 @@ Then show the output **verbatim**. It classifies every symbol reachable from the
 - **ENTRY** — a root kept on purpose (main / public API / a name you passed via `--entry`).
 - **INCONCLUSIVE** — could not be resolved, or its caller set could not be proven complete.
 
+## Two modes
+
+- **Caller-cascade** (default): start from the seeds, follow callers; a seed with no live caller is dead, and
+  removing it can cascade. Thorough by default — each DEAD candidate is reference-verified.
+- **Reachability / mark-sweep** (pass `roots`): the Go-`deadcode`/RTA model — liveness is computed FORWARD from
+  the named entry points, so a *missing caller* can't cause a false DEAD; only an incomplete root set can (the
+  reference verify catches that). Roots are generic and **framework-agnostic** — name them yourself, or commit a
+  `.vts-index/dce-roots.json` (`["main","RunTests","StartupModule", …]`) that your team curates once. vts hard-
+  codes NO framework markers (no UFUNCTION / `@Route` / `[Test]`); you declare your own entry points.
+
+```
+vts dce --seeds Foo,Bar --roots "main,RunTests,StartupModule" --projectPath <root>
+```
+
 ## Important — this NEVER deletes
 
 `dce` only proposes candidates from the **call graph**. To actually remove one, run `safe_delete`

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -2058,7 +2058,15 @@ const conceptOk = splitOk && expandOk && synOk && scoreOk && dfGateOk && concept
 // deterministic with a mock graph. DEAD cascades to a fixpoint (a callee dies only once ALL its callers are
 // removed), HELD when a live caller remains, ENTRY roots are kept, INCONCLUSIVE on unresolved / non-COMPLETE
 // cert. It never deletes — the real removal is safe_delete's reference-guarded job (guard 52), not tested here.
-const { analyzeDeadCode: dceAnalyze, formatDce: dceFmt, dceWarmGate: dceGate } = await import("../server/dce.js");
+const { analyzeDeadCode: dceAnalyze, reachabilityDeadCode: dceReach, formatDce: dceFmt, dceWarmGate: dceGate, reconcileRefs: dceRecon, parseRootsFile: dceParseRoots } = await import("../server/dce.js");
+// THOROUGH reference reconciliation: the call graph sees CALLS; a symbol kept alive only by a NON-CALL ref
+// (function value / reflection) has more references than call sites → NOT dead. reconcileRefs gates that, and
+// analyzeDeadCode's `verify` hook applies it in the fixpoint so an unverified symbol is INCONCLUSIVE, not DEAD,
+// and never cascades false DEAD downstream.
+const dceReconOk =
+  dceRecon(2, 2).confirmed === true && dceRecon(0, 0).confirmed === true &&          // refs == call sites → dead
+  dceRecon(2, 3).confirmed === false && dceRecon(0, 1).confirmed === false &&        // refs > call sites → non-call use, not dead
+  dceRecon(2, null).confirmed === false;                                             // uncountable → cannot confirm (safe)
 // WARM GATE: clangd on a cold/large tree under-reports callers → a live symbol can look DEAD. So a cold clangd
 // (no persisted index) REFUSES by default; allowCold proceeds but forces every verdict to INCONCLUSIVE. Other
 // backends index on open → not gated. (The false-DEAD-on-cold-UE hardening; safe_delete is still the backstop.)
@@ -2096,7 +2104,30 @@ const dr4ok = dr4.dead.length === 0 && dr4.inconclusive.some((x) => x.name === "
 const dr5 = await dceAnalyze(dceQuery, ["ghost"], {});        // unresolved → INCONCLUSIVE
 const dr5ok = dr5.dead.length === 0 && dr5.inconclusive.some((x) => x.name === "ghost");
 const dceFmtOk = /DEAD/.test(dceFmt(dr2)) && /safe_delete symbol="e"/.test(dceFmt(dr2)) && /CAVEAT/.test(dceFmt(dr2));
-const dceOk = dr1ok && dr2ok && dr3ok && dr4ok && dr5ok && dceFmtOk && dceGateOk;
+// verify hook: a thorough verify that REJECTS `e` (a non-call ref) must keep d,f DEAD but move e to
+// INCONCLUSIVE (not DEAD), proving the gate blocks a false cascade. An all-confirm verify == no verify.
+const dceVerifyReject = async (nm) => (nm === "e" ? { confirmed: false, reason: "non-call reference" } : { confirmed: true });
+const dr6 = await dceAnalyze(dceQuery, ["d", "f"], { verify: dceVerifyReject });
+const dr6ok = dceNames(dr6.dead).join(",") === "d,f" && dr6.inconclusive.some((x) => x.name === "e");
+const dr7 = await dceAnalyze(dceQuery, ["d", "f"], { verify: async () => ({ confirmed: true }) });
+const dr7ok = dceNames(dr7.dead).join(",") === "d,f,e";
+// REACHABILITY (mark-sweep): liveness is computed FORWARD from roots. With root=main, {main,a,b,c} are reachable;
+// d/e/f are not. So a seed d is DEAD (and its callee e cascades dead); a seed a is HELD (reachable from main); a
+// verify that rejects e moves it to INCONCLUSIVE. A missing CALLER can't cause a false DEAD here (computed from
+// roots) — only incomplete roots can, which the verify catches.
+const reach1 = await dceReach(dceQuery, ["main"], ["d"], {});
+const reach1ok = dceNames(reach1.dead).includes("d") && dceNames(reach1.dead).includes("e") && reach1.roots.join() === "main";
+const reach2 = await dceReach(dceQuery, ["main"], ["a"], {});
+const reach2ok = reach2.dead.length === 0 && reach2.held.some((h) => h.name === "a" && /reachable/.test(h.note || ""));
+const reach3 = await dceReach(dceQuery, ["main"], ["d"], { verify: async (nm) => ({ confirmed: nm !== "e" }) });
+const reach3ok = dceNames(reach3.dead).includes("d") && !dceNames(reach3.dead).includes("e") && reach3.inconclusive.some((x) => x.name === "e");
+const reachOk = reach1ok && reach2ok && reach3ok;
+// committable, framework-agnostic roots file (mirrors concept-synonyms): array or {roots:[...]}, [] on malformed.
+const rootsFileOk =
+  JSON.stringify(dceParseRoots('["main","Foo"]')) === JSON.stringify(["main", "Foo"]) &&
+  JSON.stringify(dceParseRoots('{"roots":["a","b"]}')) === JSON.stringify(["a", "b"]) &&
+  dceParseRoots("not json").length === 0 && dceParseRoots("{}").length === 0;
+const dceOk = dr1ok && dr2ok && dr3ok && dr4ok && dr5ok && dceFmtOk && dceGateOk && dceReconOk && dr6ok && dr7ok && reachOk && rootsFileOk;
 
 // 84) STRUCTURE tier (textstruct.js): prose/config files (markdown/toml/yaml/rst/…) get a SECTION tree, and
 // the existing symbol tools (document_symbols / read_symbol / replace_symbol_body / …) edit a section BY NAME
@@ -2238,7 +2269,7 @@ const rows = [
   ["syntactic tier: tree-sitter decl extraction (36 langs, zero setup) + committable .vts-index symbol index + HTML <script>/<style> exact-range injection", tsTierOk, "true", tsTierOk],
   ["Roslyn dotnet-host path OS-aware (macOS/Linux C# regression: win32/darwin/linux globalStorage)", roslynOsPathOk, "true", roslynOsPathOk],
   ["fuzzy concept retrieval (B): repo co-occurrence dictionary + concept_search (no embeddings, ranked decls)", conceptOk, "true", conceptOk],
-  ["preview-only DCE: topological dead-code candidates via call-graph cascade to a fixpoint (safe_delete backstop)", dceOk, "true", dceOk],
+  ["preview-only DCE: caller-cascade + reachability(mark-sweep from roots) + reference-verify + warm gate (safe_delete backstop)", dceOk, "true", dceOk],
   ["structure tier: section outline/read/edit for md/toml/yaml/html/css/scss/… via the symbol tools (no backend, by heading/selector/rule/function)", structOk, "true", structOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);

--- a/server/cli.js
+++ b/server/cli.js
@@ -44,8 +44,13 @@ Commands:
                  list DEAD / HELD / ENTRY / INCONCLUSIVE candidates + a safe deletion order. NEVER deletes —
                  each DEAD candidate still goes through safe-delete's own reference guard. clangd needs a WARM
                  (persisted) index — a cold/large tree under-reports callers, so it refuses unless warm; run
-                 'vts preindex' first (or --allowCold to inspect with every verdict forced to INCONCLUSIVE).
-                 [--seed <name> | --seeds A,B,C --projectPath <dir> [--entry main,init --maxNodes N --allowCold]]
+                 'vts preindex' first, or --build to build-and-wait now (slow). Thorough by default: each DEAD
+                 candidate is reference-verified (full uses vs call sites) to catch non-call refs;
+                 --thorough=false for the fast call-graph-only mode. --allowCold inspects cold (all INCONCLUSIVE).
+                 --roots A,B (or a committable .vts-index/dce-roots.json) switches to REACHABILITY mode: liveness
+                 is computed forward from those entry points (Go-deadcode/RTA style), so a missing caller can't
+                 cause a false DEAD — only incomplete roots can (the reference verify catches that).
+                 [--seed <name> | --seeds A,B,C --projectPath <dir> [--entry main,init --roots main,RunTests --maxNodes N --build --allowCold]]
   files          Find files by name (substring or glob). [--q <pattern> --projectPath <dir>]
   text           Raw text/regex search (token-capped). [--q <pattern> --projectPath <dir> --path <file> --glob <pat> --docs]
                  --path <file> / --glob <pat> target a file/glob and auto-include its extension (e.g. a .md);
@@ -91,8 +96,8 @@ Backends (auto-detected from the root, or set --backend / VTS_BACKEND):
   pyright     — Python (pyproject/setup.py/requirements or *.py; bundled pyright-langserver)
 Settings precedence: env (VTS_*) > ~/.vs-token-safer/config.json > default.`;
 
-const LIST_FLAGS = new Set(["seeds", "entry"]);
-const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open", "static", "docs", "status", "flow", "allowCold"]);
+const LIST_FLAGS = new Set(["seeds", "entry", "roots"]);
+const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open", "static", "docs", "status", "flow", "allowCold", "build", "thorough", "reachability"]);
 
 function parseArgs(argv) {
   const a = {};

--- a/server/core.js
+++ b/server/core.js
@@ -23,7 +23,7 @@ import { tsSearchSymbols, tsSearchReferences, tsFileDeclDocs, tsSupports, tsAvai
 import { searchSymIndex, buildSymIndex, symIndexPath, loadSymIndex } from "./symindex.js";
 import { splitIdent, tokenize, buildConceptModel, expandQuery, scoreSymbol, importSpecifiers, parseSynonyms } from "./concept.js";
 import { isStructFile, structOutlineInjected, resolveInOutline, fmtOutline } from "./textstruct.js";
-import { analyzeDeadCode, formatDce, dceWarmGate } from "./dce.js";
+import { analyzeDeadCode, reachabilityDeadCode, formatDce, dceWarmGate, reconcileRefs, parseRootsFile } from "./dce.js";
 
 const CONFIG_DIR = path.join(os.homedir(), ".vs-token-safer");
 export const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(CONFIG_DIR, "config.json");
@@ -2105,6 +2105,17 @@ export async function runTool(name, a = {}) {
       if (a.seed) seeds.push(String(a.seed));
       seeds = [...new Set(seeds.map((s) => String(s).trim()).filter(Boolean))];
       if (!seeds.length) return err('vts_dce needs seed symbol(s): seed="Foo" or seeds="Foo,Bar" (the declaration(s) you suspect are dead).');
+      // Reachability (mark-sweep) roots: explicit `roots` ∪ the committable .vts-index/dce-roots.json (team-
+      // curated, framework-agnostic — vts hard-codes NO framework markers). Reachability mode activates when
+      // any root is supplied or reachability=true is set; it computes liveness FORWARD from these entry points.
+      let rootsArg = [];
+      if (Array.isArray(a.roots)) rootsArg = a.roots.slice();
+      else if (typeof a.roots === "string" && a.roots) rootsArg = a.roots.split(",");
+      let fileRoots = [];
+      try { fileRoots = parseRootsFile(fs.readFileSync(path.join(root, ".vts-index", "dce-roots.json"), "utf8")); } catch { /* no committed roots */ }
+      const dceRoots = [...new Set([...rootsArg, ...fileRoots].map((s) => String(s).trim()).filter(Boolean))];
+      const reachabilityMode = a.reachability === true || a.reachability === "true" || dceRoots.length > 0;
+      if (reachabilityMode && !dceRoots.length) return err('reachability mode needs roots: roots="main,StartupModule,RunTests" (the entry points liveness is computed from), or a committable .vts-index/dce-roots.json. Without roots, omit reachability to use the default caller-cascade mode.');
       const backendName = preferBackend(a.backend, backendForPath(a.path), BACKEND) || pickBackend(root);
       if (!backendName) return err(`dead-code analysis needs a language-server backend (clangd/roslyn/typescript/pyright) for ${root}; none resolved. It walks the call graph, which the syntactic/text tiers can't provide.`);
       // WARM GATE — the safety preflight (cheap fs check, no clangd spawn). On a cold/large clangd tree the call
@@ -2113,9 +2124,17 @@ export async function runTool(name, a = {}) {
       // forced to INCONCLUSIVE. (search_symbol etc. still resolve fine cold — only the call-graph completeness
       // that DCE's correctness hinges on is unsafe.)
       const allowCold = a.allowCold === true || a.allowCold === "true";
-      const persisted = backendName === "clangd" ? hasPersistedIndex(root) : true;
+      const build = a.build === true || a.build === "true";
+      const thorough = !(a.thorough === false || a.thorough === "false"); // default ON — the slow, complete mode
+      let persisted = backendName === "clangd" ? hasPersistedIndex(root) : true;
+      // build=true: don't refuse a cold clangd tree — kick off the (slow) full index build and WAIT, then
+      // proceed with a COMPLETE call graph. getClient's afterInit blocks on the cold build, so once it returns
+      // the whole index is ready. If the build can't complete, we stay cold and fall through to the gate.
+      if (backendName === "clangd" && !persisted && build) {
+        try { const cb = await getClient(root, backendName); persisted = hasPersistedIndex(root) || cb.indexLoaded === true; } catch { /* build failed → stays cold */ }
+      }
       const gate = dceWarmGate(backendName, persisted, allowCold);
-      if (gate.refuse) return err(`dead-code analysis needs a built clangd index for ${root}, and none is persisted yet. On a cold or large (e.g. Unreal, ~26k TUs) tree the call graph UNDER-REPORTS callers — a symbol whose callers live in not-yet-indexed translation units would look DEAD when it is actually live, which is unsafe to feed safe_delete. Indexing the WHOLE tree is heavy, so SCOPE it to the module under analysis first, then build:\n  vts setup --scope Source --projectPath "${root}"   (narrow to the game/module subtree — not the whole monorepo)\n  vts preindex --projectPath "${root}"               (build the scoped index; or keep the MCP server running so clangd stays warm)\nThen re-run. Refusing rather than returning unsafe DEAD candidates. To inspect the structure anyway (every verdict forced to INCONCLUSIVE, nothing marked DEAD), pass allowCold=true.`);
+      if (gate.refuse) return err(`dead-code analysis needs a built clangd index for ${root}, and none is persisted yet. On a cold or large (e.g. Unreal, ~26k TUs) tree the call graph UNDER-REPORTS callers — a symbol whose callers live in not-yet-indexed translation units would look DEAD when it is actually live, which is unsafe to feed safe_delete. Indexing the WHOLE tree is heavy, so SCOPE it to the module under analysis first, then build:\n  vts setup --scope Source --projectPath "${root}"   (narrow to the game/module subtree — not the whole monorepo)\n  vts preindex --projectPath "${root}"               (build the scoped index; or keep the MCP server running so clangd stays warm)\nOr re-run with build=true to build-and-wait now (slow — minutes on a big tree). Refusing rather than returning unsafe DEAD candidates; allowCold=true inspects the structure with every verdict forced to INCONCLUSIVE.`);
       // Entry-point roots — never dead even with zero callers (they're invoked externally). A small built-in
       // set + user-supplied `entry` patterns (comma list, matched as case-insensitive name substrings).
       const userPats = (typeof a.entry === "string" && a.entry ? a.entry.split(",") : Array.isArray(a.entry) ? a.entry : [])
@@ -2132,17 +2151,53 @@ export async function runTool(name, a = {}) {
         if (!focus) return { resolved: false };
         const byId = new Map(cg.nodes.map((n) => [n.id, n]));
         const callers = [], callees = [], seenC = new Set(), seenE = new Set();
+        let callSites = 0;
         for (const l of cg.links || []) {
-          if (l.target === focus.id && l.source !== focus.id) { const n = byId.get(l.source); if (n && !seenC.has(n.label)) { seenC.add(n.label); callers.push({ name: n.label, file: n.file }); } }
+          if (l.target === focus.id && l.source !== focus.id) {
+            callSites += Math.max(1, Number(l.count) || 1); // sum of call-site ranges feeding this symbol — the thorough verify reconciles this against the full reference count
+            const n = byId.get(l.source); if (n && !seenC.has(n.label)) { seenC.add(n.label); callers.push({ name: n.label, file: n.file }); }
+          }
           if (l.source === focus.id && l.target !== focus.id) { const n = byId.get(l.target); if (n && !seenE.has(n.label)) { seenE.add(n.label); callees.push({ name: n.label, file: n.file }); } }
         }
         const cert = gate.forceInconclusive ? "INCONCLUSIVE" : cg.truncated ? "PARTIAL" : "COMPLETE";
-        return { resolved: true, callers, callees, cert, file: focus.file, line: focus.line };
+        return { resolved: true, callers, callees, callSites, cert, file: focus.file, line: focus.line };
       };
-      const envCap = envInt("VTS_DCE_MAX_NODES", 120);
-      const maxNodes = Math.min(Number(a.maxNodes) || envCap, envCap);
-      const result = await analyzeDeadCode(query, seeds, { maxNodes, isEntry });
-      if (gate.forceInconclusive) result.coldNote = `clangd index not warm for ${root} — running in allowCold mode: every verdict is forced to INCONCLUSIVE (nothing is marked DEAD). Build the index (vts preindex) for real DEAD/HELD verdicts.`;
+      // THOROUGH verify (default on, slow): count the FULL semantic reference set (textDocument/references —
+      // every use, not just calls) and reconcile against the call-site count. A symbol kept alive ONLY by a
+      // non-call reference (function value/callback, reflection, dynamic dispatch) has more references than call
+      // sites → it is NOT marked DEAD. This closes the call graph's blind spot in preview, without mutating.
+      // Skipped in allowCold (all INCONCLUSIVE already) and when thorough=false (fast call-graph-only mode).
+      const dceClient = (thorough && !gate.forceInconclusive) ? await getClient(root, backendName) : null;
+      const refCountFor = async (nm) => {
+        if (!dceClient) return null;
+        try {
+          const persistedNow = backendName === "clangd" && hasPersistedIndex(root);
+          const syms = await symbolReady(dceClient, nm, persistedNow, envInt("VTS_CLANGD_PERSISTED_WAIT_MS", 60000));
+          const pick = (syms || []).slice().sort((x, y) => (x.name === nm ? 0 : 1) - (y.name === nm ? 0 : 1))[0];
+          if (!pick) return null;
+          const p = fromUri(pick.location.uri), line = pick.location.range.start.line;
+          const ch = anchorOnName(p, line, nm, pick.location.range.start.character);
+          dceClient.didOpen(p, langIdForPath(p, backendName));
+          const locs = (await dceClient.references(p, line, ch, false)) || [];
+          return locs.length;
+        } catch { return null; }
+      };
+      const verify = dceClient ? (async (nm, r) => reconcileRefs(r.callSites || 0, await refCountFor(nm))) : null;
+      const envCap = envInt("VTS_DCE_MAX_NODES", reachabilityMode ? 2000 : 120);
+      const maxNodes = Math.min(Number(a.maxNodes) || envCap, reachabilityMode ? envInt("VTS_DCE_MAX_NODES", 2000) : envCap);
+      let result;
+      if (reachabilityMode) {
+        // MARK-SWEEP (Go-deadcode/RTA model): liveness is computed FORWARD from the named ENTRY POINTS, so a
+        // missing *caller* edge can't make a live symbol look dead — only an incomplete ROOT set can, and the
+        // reference verify catches that. Roots come from the `roots` arg ∪ the committable .vts-index/dce-roots
+        // .json (team-curated, framework-agnostic — vts hard-codes NO framework markers).
+        result = await reachabilityDeadCode(query, dceRoots, seeds, { maxNodes, isEntry, verify });
+        result.mode = `reachability (mark-sweep from ${dceRoots.length} root${dceRoots.length === 1 ? "" : "s"}${verify ? ", reference-verified" : ""})`;
+      } else {
+        result = await analyzeDeadCode(query, seeds, { maxNodes, isEntry, verify });
+        result.mode = gate.forceInconclusive ? "allowCold" : verify ? "thorough (reference-verified)" : "fast (call-graph only)";
+      }
+      if (gate.forceInconclusive) result.coldNote = `clangd index not warm for ${root} — running in allowCold mode: every verdict is forced to INCONCLUSIVE (nothing is marked DEAD). Build the index (build=true, or vts preindex) for real DEAD/HELD verdicts.`;
       const rows = result.dead.map((dd) => `${dd.file}:${dd.line}`);
       return finishOut(rows, formatDce(result, { cap: MAX_RESULTS }));
     }

--- a/server/dce.js
+++ b/server/dce.js
@@ -32,9 +32,27 @@ export function dceWarmGate(backendName, persisted, allowCold) {
   return { refuse: false, forceInconclusive: false };
 }
 
+// REFERENCE RECONCILIATION — the "thorough" correctness check that closes the call graph's blind spot. The
+// call graph sees CALLS; it does not see a function used as a value/callback, via reflection, a string/dynamic
+// dispatch, or a member taken by address. So before trusting a "no live callers → DEAD" verdict, compare the
+// total SEMANTIC reference count (textDocument/references — every use, not just calls) against the number of
+// CALL SITES the graph accounts for. If there are MORE references than call sites, the surplus are non-call
+// uses that keep the symbol alive → it is NOT provably dead. PURE — the caller supplies the two counts.
+//   refCount === null  → references could not be counted → cannot confirm (treat as not-dead, safe).
+//   refCount  >  callSites → extra non-call references exist → not dead.
+//   refCount <= callSites → every reference is a call the removal set will delete → confirmed dead.
+export function reconcileRefs(callSites, refCount) {
+  const cs = Number(callSites) || 0;
+  if (refCount == null || Number.isNaN(Number(refCount))) return { confirmed: false, reason: "could not count references to verify it is unused (index not ready?)" };
+  const rc = Number(refCount);
+  if (rc > cs) return { confirmed: false, reason: `${rc} reference(s) but only ${cs} call-site(s) — the surplus are non-call uses (function value / reflection / dynamic dispatch), so it is NOT provably dead` };
+  return { confirmed: true };
+}
+
 export async function analyzeDeadCode(query, seeds, opts = {}) {
   const maxNodes = Math.max(1, opts.maxNodes || 200);
   const isEntry = opts.isEntry || (() => false);
+  const verify = opts.verify || null;   // async (name, queryResult) -> { confirmed, reason } — the thorough gate
   const seedList = [...new Set(seeds.filter(Boolean))];
 
   const info = new Map();
@@ -59,6 +77,13 @@ export async function analyzeDeadCode(query, seeds, opts = {}) {
       if (r.cert !== "COMPLETE") { incon.set(name, `caller set is ${r.cert || "unverified"} — cannot prove it is unused`); continue; }
       const live = (r.callers || []).filter((c) => c.name !== name && !removal.has(c.name));
       if (live.length === 0) {
+        // THOROUGH gate: before marking DEAD (and cascading through it), verify via the full reference set that
+        // no non-call use keeps it alive. A failed verify → INCONCLUSIVE, and we do NOT cascade through it (its
+        // callees stay candidates but aren't freed by it), so a single unverifiable symbol can't fan out false DEAD.
+        if (verify) {
+          const v = await verify(name, r);
+          if (!v || !v.confirmed) { incon.set(name, (v && v.reason) || "reference verification did not confirm it is unused"); continue; }
+        }
         removal.add(name); order.push(name); changed = true;
         for (const ce of r.callees || []) if (ce.name !== name) candidates.add(ce.name);
       }
@@ -83,11 +108,70 @@ export async function analyzeDeadCode(query, seeds, opts = {}) {
   };
 }
 
+// REACHABILITY (mark-sweep) mode — the Go-`deadcode`/RTA model. Instead of asking "does this symbol have a
+// caller?" (which a missing/unindexed caller can answer wrong → false DEAD), it computes liveness FORWARD from
+// the program's ENTRY POINTS: mark everything reachable from the roots (over callees), then a seed is DEAD iff
+// it is NOT in the reachable set. Computed from roots, so a missing *caller* edge cannot make a live symbol
+// look dead — the only way to be wrong is an INCOMPLETE ROOT SET (a symbol reachable only from a root you did
+// not name), which the `verify` reference-check then catches (a reference from reachable code ⇒ not dead).
+// Stays demand-driven (universe = the seed closure, not the whole program), so it scales to a huge tree.
+// PURE — `query(name)` (callees + cert) and `verify` are injected; `roots`/`seeds` are name lists.
+export async function reachabilityDeadCode(query, roots, seeds, opts = {}) {
+  const maxNodes = Math.max(1, opts.maxNodes || 2000);
+  const verify = opts.verify || null;
+  const isEntry = opts.isEntry || (() => false);
+  const rootList = [...new Set((roots || []).filter(Boolean))];
+  const seedList = [...new Set((seeds || []).filter(Boolean))];
+  const info = new Map();
+  const q = async (name) => { if (!info.has(name)) info.set(name, await query(name)); return info.get(name); };
+
+  // 1. MARK — everything reachable from the roots, walking callees forward.
+  const reachable = new Set();
+  const queue = [...rootList];
+  while (queue.length && reachable.size < maxNodes) {
+    const name = queue.shift();
+    if (reachable.has(name)) continue;
+    reachable.add(name);
+    const r = await q(name);
+    if (!r || !r.resolved) continue;           // an unresolvable root/callee is still "named reachable", just can't expand
+    for (const ce of r.callees || []) if (!reachable.has(ce.name)) queue.push(ce.name);
+  }
+
+  // 2. SWEEP — classify the seed closure (seeds, then the callees of any dead one) by reachability.
+  const rootSet = new Set(rootList);
+  const dead = [], held = [], order = [], incon = new Map();
+  const visited = new Set();
+  const work = [...seedList];
+  while (work.length && dead.length < maxNodes) {
+    const name = work.shift();
+    if (visited.has(name)) continue;
+    visited.add(name);
+    if (rootSet.has(name)) { held.push({ name, note: "is a root" }); continue; }
+    if (isEntry(name)) { held.push({ name, note: "entry point / public API" }); continue; }
+    if (reachable.has(name)) { held.push({ name, note: "reachable from a root" }); continue; }
+    const r = await q(name);
+    if (!r || !r.resolved) { incon.set(name, "could not resolve to a callable symbol"); continue; }
+    if (r.cert !== "COMPLETE") { incon.set(name, `call graph is ${r.cert || "unverified"} — cannot trust reachability`); continue; }
+    if (verify) { const v = await verify(name, r); if (!v || !v.confirmed) { incon.set(name, (v && v.reason) || "a reference from reachable code keeps it alive (incomplete roots?)"); continue; } }
+    dead.push({ name, file: r.file, line: r.line }); order.push(name);
+    for (const ce of r.callees || []) if (!visited.has(ce.name)) work.push(ce.name); // its callees may also be unreachable
+  }
+  return {
+    dead, order, held,
+    entry: [],
+    inconclusive: [...incon].map(([name, reason]) => ({ name, reason })),
+    truncated: dead.length >= maxNodes,
+    seeds: seedList, roots: rootList,
+    mode: "reachability (mark-sweep from roots)",
+  };
+}
+
 // Token-capped, sectioned preview. Never prints source bodies — names + file:line + ready safe_delete calls.
 export function formatDce(result, opts = {}) {
   const cap = opts.cap || 60;
-  const { dead, held, entry, inconclusive, truncated, seeds, coldNote } = result;
-  const L = [`dead-code analysis from seed(s): ${seeds.join(", ")} — PREVIEW ONLY, nothing was deleted.`];
+  const { dead, held, entry, inconclusive, truncated, seeds, roots, coldNote, mode } = result;
+  const L = [`dead-code analysis from seed(s): ${seeds.join(", ")}${mode ? ` — ${mode}` : ""} — PREVIEW ONLY, nothing was deleted.`];
+  if (roots && roots.length) L.push(`roots (liveness computed forward from these): ${roots.join(", ")}`);
   if (coldNote) L.push(`⚠ ${coldNote}`);
   L.push("");
 
@@ -105,7 +189,10 @@ export function formatDce(result, opts = {}) {
 
   if (held.length) {
     L.push("", `HELD — ${held.length} still referenced (NOT dead):`);
-    held.slice(0, cap).forEach((h) => L.push(`  ${h.name}${h.callers.length ? `  ← called by ${h.callers.join(", ")}` : ""}`));
+    held.slice(0, cap).forEach((h) => {
+      const why = h.callers && h.callers.length ? `  ← called by ${h.callers.join(", ")}` : h.note ? `  (${h.note})` : "";
+      L.push(`  ${h.name}${why}`);
+    });
   }
   if (entry.length) L.push("", `ENTRY — ${entry.length} kept as root(s): ${entry.map((e) => e.name).join(", ")}`);
   if (inconclusive.length) {
@@ -121,4 +208,18 @@ export function formatDce(result, opts = {}) {
     "as CANDIDATES, not a verdict: safe_delete re-checks each with find_references and refuses while referenced.",
   );
   return L.join("\n");
+}
+
+// Parse a committable root list — `<root>/.vts-index/dce-roots.json` — the team-curated, version-controlled,
+// inspectable declaration of a project's ENTRY POINTS for reachability mode (its tests, route handlers, DI
+// registrations, public API, reflection/dynamic-dispatch targets). Generic and framework-agnostic: vts hard-
+// codes NO framework markers (no UFUNCTION, no @Route) — the team names its own roots, the same charter-pure,
+// no-drift mechanism as the committable concept-synonyms file. Accepts `["a","b"]` or `{ "roots": [...] }`.
+// PURE (text → string[]); returns [] on a malformed/empty file (reachability then runs on the passed roots alone).
+export function parseRootsFile(text) {
+  let obj;
+  try { obj = JSON.parse(String(text)); } catch { return []; }
+  const arr = Array.isArray(obj) ? obj : obj && Array.isArray(obj.roots) ? obj.roots : null;
+  if (!arr) return [];
+  return [...new Set(arr.map((x) => String(x).trim()).filter(Boolean))];
 }

--- a/skills/vs-dce/SKILL.md
+++ b/skills/vs-dce/SKILL.md
@@ -29,6 +29,13 @@ Show the result verbatim. Buckets: **DEAD** (no live caller, in safe deletion or
 **ENTRY** (kept root: main / public API / a name passed via `entry`) · **INCONCLUSIVE** (unresolved or the
 caller set couldn't be proven complete).
 
+**Two modes.** Default = caller-cascade (start from seeds, follow callers). Pass `roots` to switch to
+**reachability / mark-sweep** (the Go-`deadcode`/RTA model): liveness is computed FORWARD from the named entry
+points, so a *missing caller* can't cause a false DEAD — only an incomplete root set can (the reference verify
+catches it). Roots are **framework-agnostic** — name them (`roots="main,RunTests"`) or commit a team-curated
+`.vts-index/dce-roots.json`. vts hard-codes NO framework markers (no UFUNCTION / `@Route` / `[Test]`); you
+declare your own entry points, the same charter-pure mechanism as the committable concept-synonyms file.
+
 ## The safety model — it NEVER deletes
 
 `dce` only PROPOSES candidates from the call graph. The actual removal goes through `safe_delete`


### PR DESCRIPTION
Finishes DCE into a complete-but-slow analysis, charter-pure throughout (local, official engine, token-capped `file:line`, **no framework hard-coding**).

## Three additions

**Thorough reference-verify (default on).** Before marking a candidate DEAD, count its FULL semantic reference set (`textDocument/references` — non-call uses too) and reconcile against the call-site count. More references than call sites ⇒ a non-call use (function value, reflection, dynamic dispatch) keeps it alive ⇒ NOT dead. Closes the call graph's blind spot in preview, without mutating. *Live-verified:* `formatDce` (3 refs / 1 call site) is correctly held as INCONCLUSIVE instead of a false DEAD.

**Reachability / mark-sweep (`roots`).** The Go-`deadcode`/RTA model — liveness computed FORWARD from named entry points, so a *missing caller* can't cause a false DEAD; only an incomplete root set can (the verify catches it). Roots are **generic & framework-agnostic**: `roots="main,RunTests"` or a committable `.vts-index/dce-roots.json` (mirrors the concept-synonyms file). vts hard-codes **no** framework markers — the team declares its own entry points. Stays demand-driven (universe = seed closure) → scales to a huge tree.

**Build-and-wait (`build=true`).** Instead of refusing a cold clangd tree, build the full index + wait (slow), then run COMPLETE.

## Charter check
Discussed and deliberately avoided UE-specific reflection hard-coding (UFUNCTION/@Route/[Test]) — that would drift vts into a framework-aware static-analysis tool and create unbounded maintenance + false-completeness. Roots stay user-declared (patterns + committable file), the same charter-pure mechanism as committable synonyms.

## Verification
- `node eval/run.mjs` → 87 checks (guard 85: reconcileRefs, the verify gate, reachability mark-sweep, parseRootsFile). lint clean.
- End-to-end smoke on this repo: reachability mode + reference-verify render correctly and degrade safely (INCONCLUSIVE, never false DEAD).
- safe_delete remains the disposal backstop; the warm gate is the earlier line of defense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
