### PR TITLE
perf: cut vts's own context footprint (schema -21%)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "vs-token-safer",
       "source": "./",
-      "version": "0.37.1",
+      "version": "0.37.2",
       "category": "development",
       "description": "Sits between Claude Code and your codebase and hands back a short file:line list instead of dumping source. Real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a no-embeddings fuzzy search built from your repo's own naming when you don't know the exact name. Section-edits Markdown and config too. Local-only. Bundles gamedev-log-analyzer."
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vs-token-safer",
   "description": "Sits between Claude Code and your codebase and hands back a short file:line list instead of dumping source into the chat. It uses a real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a fuzzy search built from your repo's own naming when you don't know the exact name (no embeddings). It section-edits Markdown and config files the same way. Everything stays on your machine. No IDE required. Bundles gamedev-log-analyzer for reading huge editor/build logs.",
-  "version": "0.37.1",
+  "version": "0.37.2",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/vs-token-safer",
   "repository": "https://github.com/JSungMin/vs-token-safer",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,12 @@ repo while config pinned clangd for a UE tree) > forced `VTS_BACKEND`/config `ba
   `vts_admin{op,params}` MCP tool (index.js maps `vts_admin`→`runTool("vts_"+op,params)`; hot search/nav/edit
   tools stay first-class so the model still reaches for them). core.js runTool + the CLI keep the individual
   `vts_*` names UNCHANGED (the grep-block hook still reroutes git/p4 to the CLI, not this tool); eval guard 62.
+  FOOTPRINT SLIM (v0.37.2 — vts's OWN MCP usage measured at ~24%, mostly the per-request tool schema): the
+  self-evident common params (`projectPath`/`backend`/`maxResults`) carry NO description (shared `ROOT`/
+  `BACKEND`/`CAP` consts in `tools.js`), tool descriptions trimmed (adoption "USE INSTEAD OF" + routing cues
+  KEPT) → tool-list schema 3455→2723 tok (−21%, recurring every API call); guard 62 cap 3500→2900. Also the
+  per-RESULT `completenessCert` rung lines + `EMPTY_HINT`/`LOG_STEER` and the SessionStart `routingDigest`
+  (policy.js) are trimmed ~40-50% (rung keywords + the one actionable command kept; guards 76/16/digest green).
   The folded ops: `vts_warmup`, `vts_setup`,
   `vts_config`, `vts_savings` (RTK-gain-style: `graph`/`daily`/`history` + est. USD over timestamped day
   buckets; ALSO FOLDS IN the bundled gamedev-log-analyzer's ledger [`~/.gamedev-log-analyzer/savings.json`,

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -240,7 +240,7 @@ fs.mkdirSync(logDir, { recursive: true });
 const lsRes = await runTool("search_text", { q: "anything", projectPath: logDir }); // log target → LOG_STEER
 const ffRes = await runTool("find_files", { q: "no_such_file_xyz", projectPath: os.tmpdir() }); // empty, non-log
 const logSteerOk =
-  !lsRes.isError && /This looks like a LOG target/.test(lsRes.text) && // path-based steer (LOG_STEER)
+  !lsRes.isError && /Looks like a LOG/.test(lsRes.text) && // path-based steer (LOG_STEER)
   !ffRes.isError && /gamedev-log/.test(ffRes.text);                    // path-less empty hint (LOG_EMPTY_HINT)
 try { fs.rmSync(logRoot, { recursive: true, force: true }); } catch { /* ignore */ }
 
@@ -1317,7 +1317,7 @@ const toolsBudgetOk =
   JSON.stringify(adminTool?.inputSchema?.properties?.op?.enum || []) === JSON.stringify([...ADMIN_OPS]) && // enum matches the dispatch set
   !cfgViaOp.isError && /settings/i.test(cfgViaOp.text) && // op→vts_config resolves to a real handler
   ["replace_symbol_body", "safe_delete", "read_symbol"].every((n) => /INSTEAD OF/.test(TOOL_DEFS.find((t) => t.name === n)?.description || "")) && // 2602.20426 adoption lever: the symbol-edit/read tools front-load the "use INSTEAD OF Read/Edit" selection cue so the model picks them over Read+Edit (the 135k-tok/wk leak)
-  toolsTok <= 3500; // ~3226 (14 tools) + find_references direction/depth params. Cap still blocks prose creep.
+  toolsTok <= 2900; // ~2723 (15 tools) after the v0.37.2 schema slim (common-param descriptions stripped). Cap blocks prose creep.
 
 // 63) LSP-glue strengthening (referencing OMC lsp_* / IDE surfaces): a `diagnostics` tool + goto_definition
 // `kind` (type_definition/implementation/declaration). The mock pushes 2 diagnostics (publishDiagnostics on
@@ -2294,7 +2294,7 @@ const rows = [
   ["edit-warn control-flow exclusion (if/for block ≠ a whole decl)", ctrlFlowExclusionOk, "true", ctrlFlowExclusionOk],
   ["outline-hunt Grep steer (decl-keyword alt → document_symbols; FP-safe)", outlineSteerOk, "true", outlineSteerOk],
   ["common-prefix factoring: find_files + search_text (toggle)", prefixFactoringOk, "true", prefixFactoringOk],
-  ["tool-def budget + vts_admin fold: hot tools named, cold folded, ≤ 3500 tok", toolsBudgetOk, "true", toolsBudgetOk],
+  ["tool-def budget + vts_admin fold: hot tools named, cold folded, ≤ 2900 tok", toolsBudgetOk, "true", toolsBudgetOk],
   ["LSP glue: diagnostics tool + goto kinds (typeDef/impl/decl)", lspGlueOk, "true", lspGlueOk],
   ["star nudge: value-tied, threshold-gated, pure (no network), toggle", starNudgeOk, "true", starNudgeOk],
   ["symbol-edit P4 auto-checkout: read-only → p4 edit, writable skips, toggle", p4EditOk, "true", p4EditOk],

--- a/server/core.js
+++ b/server/core.js
@@ -148,15 +148,13 @@ function looksLogTarget(a) {
   return [a.path, a.projectPath, a.paths].flat().filter((v) => typeof v === "string").some((v) => LOG_PATHISH.test(v));
 }
 const LOG_STEER =
-  "\n\n↪ This looks like a LOG target. The language-server index only covers source code, not logs — use " +
-  "the gamedev-log tools (/gamedev-log-analyzer:logs, or the gamedev-log CLI: summary / search / locate / " +
-  "fields / diff) for log analysis instead.";
+  "\n\n↪ Looks like a LOG. The index covers source, not logs — use gamedev-log " +
+  "(/gamedev-log-analyzer:logs, or CLI: summary/search/locate/fields/diff).";
 // Appended to an empty symbol result (mirrors rider's honest empty-result hint): an empty answer can be a
 // stale index, a definitions-only match, or a string that only lives in a log (excluded from the index).
 const EMPTY_HINT =
-  " If you JUST edited the target, the index may lag the save — retry, or use search_text for a literal " +
-  "match. search_symbol matches DEFINITIONS, not every reference. Looking for something in a LOG? Logs " +
-  "aren't indexed — use gamedev-log.";
+  " Empty can mean: JUST-edited (index lags the save — retry or search_text), a DEFINITIONS-only match " +
+  "(not every reference), or a LOG (not indexed — use gamedev-log).";
 const LOG_EMPTY_HINT = " Looking for something in a LOG? Logs aren't indexed for code search — use gamedev-log for log content.";
 // search_text → symbol steer (dogfood-found): a TEXT query that is really a SYMBOL/CLASS usage hunt — a
 // template arg `Foo<Bar>`, a `::` scope, or a dominant CamelCase/snake identifier — is answered better by
@@ -1111,35 +1109,34 @@ function completenessCert({ shown = 0, total = null, truncated = null, semantic 
   // SECTION rung — the structure tier (docs/config) addressed by heading/selector/rule. Exact text spans, but
   // document structure, not semantic code analysis.
   if (section) {
-    return `\n[completeness: SECTION rung — the structure tier returned ${shown} section(s) addressed by heading/selector/rule (exact text spans, no language server); this is document structure, not semantic code.]`;
+    return `\n[completeness: SECTION rung — ${shown} section(s) by heading/selector (exact text spans, not semantic code).]`;
   }
   // FUZZY rung — the concept dictionary mined from the repo's own naming (no embeddings). Related, not exact.
   if (fuzzy && truncated !== "cap" && !(total != null && shown < total)) {
-    return `\n[completeness: FUZZY rung — a concept dictionary mined from the repo's own naming matched ${shown} declaration(s) by co-occurrence (no embeddings); related, not exact. Climb to find_references/goto_definition on a hit for ground truth.]`;
+    return `\n[completeness: FUZZY rung — ${shown} decl(s) by naming co-occurrence (no embeddings); climb to find_references/goto_definition for ground truth.]`;
   }
   // SYNTACTIC rung — tree-sitter / committed index finds DECLARATIONS without a toolchain, but does not resolve
-  // references, overloads, or types — so even a "complete" syntactic answer is not the semantic certainty the
-  // LSP gives. Label it as such so the agent knows a language server would tighten it.
+  // references, overloads, or types — so even a "complete" syntactic answer is not the semantic certainty the LSP gives.
   if (syntactic && truncated !== "cap" && !(total != null && shown < total)) {
-    return `\n[completeness: SYNTACTIC rung — tree-sitter found ${shown} declaration(s) with zero project setup; this tier locates decls but does NOT resolve references/overloads/types. Install a language server (or generate compile_commands.json) for semantic certainty.]`;
+    return `\n[completeness: SYNTACTIC rung — ${shown} decl(s), zero setup; locates decls, not refs/overloads/types. Install a language server (or compile_commands.json) for semantic certainty.]`;
   }
   // When an indexing scope is active, a semantic COMPLETE (or authoritative 0) is complete WITHIN THE SCOPE,
   // not across the whole project — qualify it so the agent doesn't read it as project-wide coverage.
-  const within = scoped ? " within the configured indexing scope (not the whole project — widen or unset the scope for full coverage)" : "";
+  const within = scoped ? " within the configured indexing scope (widen/unset for full coverage)" : "";
   // INCONCLUSIVE walks are where AUTO-SCOPE pays off: a bounded scan on a big tree is exactly the case a scoped
   // index fixes, so the advisory is actionable (the concrete `vts setup --scope` + `vts preindex` commands).
   if (truncated === "time" || truncated === "scan") {
     const how = truncated === "time" ? "time-boxed" : "scan-limited";
-    return `\n[completeness: INCONCLUSIVE — a bounded ${how} walk did not cover the whole tree, so this result (a 0 included) may be incomplete. Narrow the indexing scope (vts setup --scope <module>, then vts preindex) or use a semantic tool (search_symbol/find_references) to certify.]`;
+    return `\n[completeness: INCONCLUSIVE — bounded ${how} walk didn't cover the tree (a 0 may be incomplete); scope it (vts setup --scope <module>; vts preindex) or certify with search_symbol/find_references.]`;
   }
   if (truncated === "index") {
-    return `\n[completeness: INCONCLUSIVE — this backend answers from open/indexed files only, so a symbol whose file isn't indexed yet can be missed; this is not an authoritative 0. A big tree indexes far faster scoped (vts setup --scope <module>, then vts preindex).]`;
+    return `\n[completeness: INCONCLUSIVE — indexed/open files only, so a not-yet-indexed file can be missed (not an authoritative 0); scope a big tree (vts setup --scope <module>; vts preindex).]`;
   }
   if (truncated === "cap" || (total != null && shown < total)) {
     const more = total != null ? `${shown} of ${total}` : `the top ${shown}`;
-    return `\n[completeness: PARTIAL — showing ${more}; the remainder is known and recoverable (raise the cap or read the tee file).]`;
+    return `\n[completeness: PARTIAL — showing ${more}; remainder known + recoverable (raise the cap or read the tee file).]`;
   }
-  return `\n[completeness: ${semantic ? "EXACT rung, COMPLETE" : "COMPLETE"} — ${semantic ? "the language-server index" : "the bounded scan"} returned every match${within} (${shown}).]`;
+  return `\n[completeness: ${semantic ? "EXACT rung, COMPLETE" : "COMPLETE"} — ${semantic ? "language-server index" : "bounded scan"}, every match${within} (${shown}).]`;
 }
 export { completenessCert };
 function fmtLocations(locs, max, label) {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vs-token-safer",
-  "version": "0.37.1",
+  "version": "0.37.2",
   "type": "module",
   "description": "Sits between an LLM coding agent and your repository and answers where/what/how questions with a short file:line list instead of raw source. It uses a real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a no-embeddings fuzzy search built from the repo's own naming when you don't know the exact name. It section-edits Markdown and config files the same way. Local-only, nothing transmitted. CLI + MCP. No IDE required.",
   "keywords": [

--- a/server/policy.js
+++ b/server/policy.js
@@ -30,11 +30,11 @@ export function routingDigest(o = readEditLedger()) {
   const pct = adoptionPct(o);
   const total = (o.builtin || 0) + (o.symbol || 0);
   const lines = [
-    "[vs-token-safer] Tool routing — vts and Claude Code's native tools are COMPLEMENTARY; use the cheapest tool that fits:",
-    "  • a symbol / its references / a rename, on INDEXED code → vts search_symbol / find_references / rename (semantic, token-capped) — not grep",
-    "  • ADD or REPLACE a whole declaration → vts replace_symbol_body / insert_symbol (edits by name, skips reading the file)",
-    "  • a doc or log, a quick literal peek, a JUST-edited or unindexed file, a sub-declaration tweak → CC-native Read / Grep / Edit is right; vts stays out of the way",
-    "  • a big tree with a slow first query → vts setup --scope <module> then vts preindex (index a subtree, not the whole monorepo)",
+    "[vs-token-safer] Tool routing — vts + CC-native are COMPLEMENTARY; cheapest tool that fits:",
+    "  • symbol / refs / rename on INDEXED code → vts search_symbol / find_references / rename (not grep)",
+    "  • ADD/REPLACE a whole decl → vts replace_symbol_body / insert_symbol (by name, skips the Read)",
+    "  • doc/log, quick literal peek, JUST-edited or unindexed file, sub-decl tweak → CC-native Read/Grep/Edit",
+    "  • big tree, slow first query → vts setup --scope <module>; vts preindex",
   ];
   if (pct !== null && total >= 3) {
     const hasSteer = (((o.mod || {}).warn || {}).shown || 0) + (((o.mod || {}).block || {}).shown || 0) > 0;

--- a/server/tools.js
+++ b/server/tools.js
@@ -1,20 +1,27 @@
 // Tool DEFINITIONS for the MCP server, isolated from index.js so they can be measured/asserted
 // WITHOUT importing the SDK-dependent server (the toolchain-free eval gate spawns nothing). index.js
 // imports TOOLS + ADMIN_OPS from here. Pure data + one Set — no imports, no side effects.
+//
+// SCHEMA IS A FIXED PER-REQUEST CONTEXT COST (the tool list rides in every API call). So descriptions are
+// TERSE and self-evident common params (projectPath/backend/maxResults) carry NO description — their name
+// says it. The routing cue (use-instead-of-grep/Edit) and the `0-based` note on positions are kept; those
+// change model behaviour. eval guard 62 caps the total token budget so prose can't creep back.
+const ROOT = { type: "string" }; // projectPath — project root (default: configured/cwd)
+const BACKEND = { type: "string" }; // clangd|roslyn|typescript|pyright — auto-detected
+const CAP = { type: "number" }; // maxResults — result cap (default 60)
 
 export const TOOLS = [
   {
     name: "search_symbol",
     description:
-      "Find a symbol DECLARATION (class/function/type/variable) by name/substring — semantic index, not grep. " +
-      "→ token-capped `kind name @ file:line`, no bodies. Use instead of grep/rg to locate a symbol.",
+      "Find a symbol DECLARATION (class/function/type/var) by name/substring — semantic index, not grep. → capped `kind name @ file:line`, no bodies. Use instead of grep/rg to locate a symbol.",
     inputSchema: {
       type: "object",
       properties: {
-        q: { type: "string", description: "Symbol name or substring to search for." },
-        projectPath: { type: "string", description: "Project root (default: configured projectPath or cwd)." },
-        backend: { type: "string", description: "clangd | roslyn | typescript | pyright (default: auto-detect from the root)." },
-        maxResults: { type: "number", description: "Cap on returned locations (default 60)." },
+        q: { type: "string", description: "Symbol name or substring." },
+        projectPath: ROOT,
+        backend: BACKEND,
+        maxResults: CAP,
       },
       required: ["q"],
     },
@@ -22,55 +29,52 @@ export const TOOLS = [
   {
     name: "find_references",
     description:
-      "Every call site of a symbol (semantic, not grep) — pass `symbol` (a name): resolves the decl + returns " +
-      "all refs in one call (a 0-based path+line+character disambiguates an overload). → token-capped " +
-      "`file:line`; detail=file|dir for a blast-radius summary. `direction`=callers|callees switches to a " +
-      "multi-hop call hierarchy to `depth` hops — use before changing a function.",
+      "Every call site of a symbol (semantic, not grep) — pass `symbol` (a name); resolves the decl + returns all refs in one call. → capped `file:line`; detail=file|dir for a blast-radius summary; direction=callers|callees switches to a multi-hop call hierarchy. Use before changing a function.",
     inputSchema: {
       type: "object",
       properties: {
-        symbol: { type: "string", description: "Symbol NAME — resolved via the index, no position needed (the usual way when editing)." },
-        path: { type: "string", description: "Source file (with line/character for an exact position; or with `symbol` to disambiguate)." },
+        symbol: { type: "string", description: "Symbol NAME — resolved via the index, no position needed." },
+        path: { type: "string", description: "Source file (+line/character for an exact position, or with `symbol` to disambiguate an overload)." },
         line: { type: "number", description: "0-based line." },
         character: { type: "number", description: "0-based column." },
-        includeDeclaration: { type: "boolean", description: "Include the declaration." },
+        includeDeclaration: { type: "boolean" },
         detail: { type: "string", description: "`file`|`dir` blast-radius summary." },
         direction: { type: "string", description: "callers|callees call hierarchy." },
         depth: { type: "number", description: "Call-hierarchy hops (default 2)." },
-        projectPath: { type: "string", description: "Project root (cwd)." },
-        backend: { type: "string", description: "Backend override; auto-detected." },
-        maxResults: { type: "number", description: "Result cap (60)." },
+        projectPath: ROOT,
+        backend: BACKEND,
+        maxResults: CAP,
       },
     },
   },
   {
     name: "goto_definition",
-    description: "Jump from a 0-based position to a definition (semantic). `kind`: definition (default) | type_definition | implementation | declaration. → token-capped `file:line`. For usages, use find_references.",
+    description: "Jump from a 0-based position to a definition (semantic). `kind`: definition (default)|type_definition|implementation|declaration. → capped `file:line`. For usages, use find_references.",
     inputSchema: {
       type: "object",
       properties: {
         path: { type: "string", description: "Source file containing the symbol." },
-        line: { type: "number", description: "0-based line of the symbol position." },
-        character: { type: "number", description: "0-based character/column of the symbol position." },
-        kind: { type: "string", description: "definition (default) | type_definition | implementation | declaration." },
-        projectPath: { type: "string", description: "Project root (cwd)." },
-        backend: { type: "string", description: "Backend override; auto-detected." },
-        maxResults: { type: "number", description: "Result cap (60)." },
+        line: { type: "number", description: "0-based line." },
+        character: { type: "number", description: "0-based column." },
+        kind: { type: "string", description: "definition (default)|type_definition|implementation|declaration." },
+        projectPath: ROOT,
+        backend: BACKEND,
+        maxResults: CAP,
       },
       required: ["path", "line", "character"],
     },
   },
   {
     name: "diagnostics",
-    description: "Compiler/linter errors + warnings (semantic) → token-capped `file:line:col severity [code]: message`, sorted error→hint with a count — the compact stand-in for raw build output. Empty = clean. Default = one file (`path`); `scope=\"directory\"` scans the project.",
+    description: "Compiler/linter errors + warnings (semantic) → capped `file:line:col severity [code]: message`, sorted error→hint with a count — the compact stand-in for raw build output. Empty = clean. Default = one `path`; scope=\"directory\" scans the project.",
     inputSchema: {
       type: "object",
       properties: {
-        path: { type: "string", description: "Source file to check (or, with scope=directory, the subdirectory to scan; default = project root)." },
-        scope: { type: "string", description: "`file` (default) checks one `path`; `directory` scans the project for errors/warnings across files." },
-        projectPath: { type: "string", description: "Project root (cwd)." },
-        backend: { type: "string", description: "Backend override; auto-detected." },
-        maxResults: { type: "number", description: "Max diagnostics returned (default 60)." },
+        path: { type: "string", description: "File to check (or, with scope=directory, the subtree to scan; default = root)." },
+        scope: { type: "string", description: "`file` (default) | `directory` (scan project)." },
+        projectPath: ROOT,
+        backend: BACKEND,
+        maxResults: CAP,
       },
     },
   },
@@ -82,24 +86,24 @@ export const TOOLS = [
       properties: {
         path: { type: "string", description: "Source file." },
         line: { type: "number", description: "0-based line." },
-        character: { type: "number", description: "0-based character/column." },
-        projectPath: { type: "string", description: "Project root (cwd)." },
-        backend: { type: "string", description: "Backend override; auto-detected." },
+        character: { type: "number", description: "0-based column." },
+        projectPath: ROOT,
+        backend: BACKEND,
       },
       required: ["path", "line", "character"],
     },
   },
   {
     name: "document_symbols",
-    description: "Outline a file — classes/functions/types as a token-capped `kind name :line` list. Cheaper than reading the whole file for its structure. `scope=\"directory\"` builds a signatures-only skeleton of every code file under `path` (the module's shape without Reading each).",
+    description: "Outline a file — classes/functions/types as a capped `kind name :line` list. Cheaper than reading the whole file for its structure. scope=\"directory\" builds a signatures-only skeleton of every code file under `path`.",
     inputSchema: {
       type: "object",
       properties: {
-        path: { type: "string", description: "File to outline (or, with scope=directory, the subdirectory to skeletonize; default = project root)." },
-        scope: { type: "string", description: "`file` (default) outlines one `path`; `directory` builds a signatures-only skeleton of every code file under it." },
-        projectPath: { type: "string", description: "Project root (cwd)." },
-        backend: { type: "string", description: "Backend override; auto-detected." },
-        maxResults: { type: "number", description: "Result cap (60)." },
+        path: { type: "string", description: "File to outline (or, with scope=directory, the subtree; default = root)." },
+        scope: { type: "string", description: "`file` (default) | `directory` (skeleton of every file under it)." },
+        projectPath: ROOT,
+        backend: BACKEND,
+        maxResults: CAP,
       },
     },
   },
@@ -109,172 +113,150 @@ export const TOOLS = [
     inputSchema: {
       type: "object",
       properties: {
-        symbol: { type: "string", description: "Declaration name to read (function/class/method/…)." },
-        path: { type: "string", description: "File holding the symbol (pins the outline; else resolved via the index)." },
+        symbol: { type: "string", description: "Declaration name to read." },
+        path: { type: "string", description: "File holding the symbol (else resolved via the index)." },
         line: { type: "number", description: "0-based line; disambiguate same-named (optional)." },
-        signatureOnly: { type: "boolean", description: "Return just the declaration head (signature), not the full body." },
-        projectPath: { type: "string", description: "Project root (cwd)." },
-        backend: { type: "string", description: "Backend override; auto-detected." },
+        signatureOnly: { type: "boolean", description: "Return just the declaration head." },
+        projectPath: ROOT,
+        backend: BACKEND,
       },
       required: ["symbol"],
     },
   },
   {
     name: "rename",
-    description:
-      "Rename the symbol at a 0-based position project-wide (semantic — every reference, not a sed). " +
-      "PREVIEW by default (affected `file:line`); apply=true writes. Use instead of editing call sites by hand.",
+    description: "Rename the symbol at a 0-based position project-wide (semantic — every reference, not a sed). PREVIEW by default (affected `file:line`); apply=true writes. Use instead of editing call sites by hand.",
     inputSchema: {
       type: "object",
       properties: {
         path: { type: "string", description: "Source file containing the symbol." },
-        line: { type: "number", description: "0-based line of the symbol." },
-        character: { type: "number", description: "0-based character/column of the symbol." },
-        newName: { type: "string", description: "New name for the symbol." },
-        apply: { type: "boolean", description: "Write the edits to disk (default false = preview only)." },
-        projectPath: { type: "string", description: "Project root (cwd)." },
-        backend: { type: "string", description: "Backend override; auto-detected." },
-        maxResults: { type: "number", description: "Result cap (60)." },
+        line: { type: "number", description: "0-based line." },
+        character: { type: "number", description: "0-based column." },
+        newName: { type: "string", description: "New name." },
+        apply: { type: "boolean", description: "Write to disk (default false = preview)." },
+        projectPath: ROOT,
+        backend: BACKEND,
+        maxResults: CAP,
       },
       required: ["path", "line", "character", "newName"],
     },
   },
   {
     name: "replace_symbol_body",
-    description:
-      "Change a whole function/class/method by NAMING it — USE INSTEAD OF Read-the-file + Edit (the outline " +
-      "gives the span, so you skip the whole-file Read and the exact-match line-counting). PREVIEW by default; " +
-      "apply=true writes it in ONE call.",
+    description: "Change a whole function/class/method by NAMING it — USE INSTEAD OF Read-the-file + Edit (the outline gives the span, so you skip the whole-file Read and exact-match line-counting). PREVIEW by default; apply=true writes in ONE call.",
     inputSchema: {
       type: "object",
       properties: {
-        symbol: { type: "string", description: "Declaration name to replace (e.g. a function/class name)." },
-        body: { type: "string", description: "New full text for the declaration (signature + body)." },
-        path: { type: "string", description: "File holding the symbol (pins the outline; else resolved via the index)." },
+        symbol: { type: "string", description: "Declaration name to replace." },
+        body: { type: "string", description: "New full text (signature + body)." },
+        path: { type: "string", description: "File holding the symbol (else resolved via the index)." },
         line: { type: "number", description: "0-based line; disambiguate same-named (optional)." },
-        apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
-        projectPath: { type: "string", description: "Project root (cwd)." },
-        backend: { type: "string", description: "Backend override; auto-detected." },
-        maxResults: { type: "number", description: "Result cap (60)." },
+        apply: { type: "boolean", description: "Write to disk (default false = preview)." },
+        projectPath: ROOT,
+        backend: BACKEND,
+        maxResults: CAP,
       },
       required: ["symbol", "body"],
     },
   },
   {
     name: "insert_symbol",
-    description:
-      "Insert text next to a named declaration — `position=after` (default) or `before`. The outline gives the " +
-      "point (no Read). PREVIEW by default; apply=true writes. Use instead of Read-then-Edit to add a declaration.",
+    description: "Insert text next to a named declaration — position=after (default)|before. The outline gives the point (no Read). PREVIEW by default; apply=true writes. Use instead of Read-then-Edit to add a declaration.",
     inputSchema: {
       type: "object",
       properties: {
         symbol: { type: "string", description: "Declaration to insert next to." },
-        text: { type: "string", description: "Text to insert (on its own line)." },
-        position: { type: "string", description: "`after` (default) or `before` the declaration." },
+        text: { type: "string", description: "Text to insert (own line)." },
+        position: { type: "string", description: "`after` (default) | `before`." },
         path: { type: "string", description: "File holding the symbol (else resolved via the index)." },
         line: { type: "number", description: "0-based line; disambiguate same-named (optional)." },
-        apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
-        projectPath: { type: "string", description: "Project root (cwd)." },
-        backend: { type: "string", description: "Backend override; auto-detected." },
-        maxResults: { type: "number", description: "Result cap (60)." },
+        apply: { type: "boolean", description: "Write to disk (default false = preview)." },
+        projectPath: ROOT,
+        backend: BACKEND,
+        maxResults: CAP,
       },
       required: ["symbol", "text"],
     },
   },
   {
     name: "safe_delete",
-    description:
-      "Delete a named declaration — USE INSTEAD OF Edit-deleting it; REFUSES while still referenced (lists the " +
-      "refs, force=true overrides) so a delete can't silently orphan call sites. PREVIEW by default; apply=true writes.",
+    description: "Delete a named declaration — USE INSTEAD OF Edit-deleting it; REFUSES while still referenced (lists the refs, force=true overrides) so a delete can't silently orphan call sites. PREVIEW by default; apply=true writes.",
     inputSchema: {
       type: "object",
       properties: {
         symbol: { type: "string", description: "Declaration to delete." },
         path: { type: "string", description: "File holding the symbol (else resolved via the index)." },
         line: { type: "number", description: "0-based line; disambiguate same-named (optional)." },
-        force: { type: "boolean", description: "Delete even if references remain (default false = refuse when referenced)." },
-        apply: { type: "boolean", description: "Write to disk (default false = preview only)." },
-        projectPath: { type: "string", description: "Project root (cwd)." },
-        backend: { type: "string", description: "Backend override; auto-detected." },
-        maxResults: { type: "number", description: "Result cap (60)." },
+        force: { type: "boolean", description: "Delete even if referenced (default false = refuse)." },
+        apply: { type: "boolean", description: "Write to disk (default false = preview)." },
+        projectPath: ROOT,
+        backend: BACKEND,
+        maxResults: CAP,
       },
       required: ["symbol"],
     },
   },
   {
     name: "find_files",
-    description:
-      "Find files by name (substring or glob like *Manager.cpp) — replaces Bash `find -name`. → token-capped " +
-      "file list; walk-bounded (skips node_modules/build dirs, time-boxed).",
+    description: "Find files by name (substring or glob like *Manager.cpp) — replaces Bash `find -name`. → capped file list; walk-bounded (skips node_modules/build, time-boxed).",
     inputSchema: {
       type: "object",
       properties: {
         q: { type: "string", description: "Filename substring or glob (* ? supported)." },
-        projectPath: { type: "string", description: "Project root (cwd)." },
-        maxResults: { type: "number", description: "Result cap (60)." },
+        projectPath: ROOT,
+        maxResults: CAP,
       },
       required: ["q"],
     },
   },
   {
     name: "search_text",
-    description:
-      "Raw text/regex search (string literals, comments, config — what the symbol index can't answer). " +
-      "Replaces Bash grep when you need text, not symbols. → token-capped `file:line: line`. For code " +
-      "symbols prefer search_symbol.",
+    description: "Raw text/regex search (string literals, comments, config — what the symbol index can't answer). Replaces Bash grep when you need text, not symbols. → capped `file:line: line`. For code symbols prefer search_symbol.",
     inputSchema: {
       type: "object",
       properties: {
-        q: { type: "string", description: "String or regular expression to find." },
-        path: { type: "string", description: "Search ONE file (any extension auto-included; relative or absolute)." },
-        glob: { type: "string", description: "Only files matching this basename glob (e.g. *.md) — any extension it covers." },
-        projectPath: { type: "string", description: "Project root (cwd)." },
-        maxResults: { type: "number", description: "Result cap (60)." },
-        docs: { type: "boolean", description: "With no path/glob, widen the sweep to docs/config text (md/json/yaml/…), not just source." },
+        q: { type: "string", description: "String or regular expression." },
+        path: { type: "string", description: "Search ONE file (any extension auto-included)." },
+        glob: { type: "string", description: "Only files matching this basename glob (e.g. *.md)." },
+        projectPath: ROOT,
+        maxResults: CAP,
+        docs: { type: "boolean", description: "With no path/glob, widen the sweep to docs/config text (md/json/yaml/…)." },
       },
       required: ["q"],
     },
   },
   {
     name: "concept_search",
-    description:
-      "FUZZY search for a concept you can't name (\"how does auth work\"). Mines a dictionary from the repo's " +
-      "own identifier+comment co-occurrence (no embeddings, nothing sent) → ranked `file:line`. Use when you " +
-      "don't know the symbol name (search_symbol needs it). flow=true traces the top hit's call graph.",
+    description: "FUZZY search for a concept you can't name (\"how does auth work\"). Mines a dictionary from the repo's own identifier+comment co-occurrence (no embeddings, nothing sent) → ranked `file:line`. Use when you don't know the symbol name. flow=true traces the top hit's call graph.",
     inputSchema: {
       type: "object",
       properties: {
         q: { type: "string", description: "Concept/intent phrase (concrete nouns work best)." },
         flow: { type: "boolean", description: "Also trace the top hit along the call graph." },
-        projectPath: { type: "string", description: "Project root (cwd)." },
-        maxResults: { type: "number", description: "Result cap (60)." },
+        projectPath: ROOT,
+        maxResults: CAP,
       },
       required: ["q"],
     },
   },
   {
-    // vts_admin folds the 9 RARELY-reflexive admin/meta tools behind ONE schema to cut the fixed
-    // per-session tool-definition cost (the hot search/nav/edit tools stay first-class so the model still
-    // reaches for them over grep/Edit). index.js maps vts_admin{op,params} → runTool("vts_"+op, params);
-    // core.js + the CLI keep the individual vts_* implementations unchanged (the grep-block hook still
-    // reroutes git/p4 to the CLI, not this tool).
+    // vts_admin folds the 12 RARELY-reflexive admin/meta ops behind ONE schema to cut the fixed per-session
+    // tool-definition cost (the hot search/nav/edit tools stay first-class so the model still reaches for them
+    // over grep/Edit). index.js maps vts_admin{op,params} → runTool("vts_"+op, params); core.js + the CLI keep
+    // the individual vts_* implementations unchanged (the grep-block hook still reroutes git/p4 to the CLI).
     name: "vts_admin",
     description:
-      "vs-token-safer admin/meta operations (rarely needed reflexively) — set `op` and put that op's args in " +
-      "`params`:\n" +
-      "  • setup {projectPath,backend,maxResults,genCompileDb,clangdCmd} — configure (writes config)\n" +
-      "  • config {} — show effective settings · savings {graph,daily,history} — tokens saved · savings_reset {} — clear it\n" +
-      "  • discover {since,all,learn,projectPath} — find code searches that BYPASSED vts (missed savings)\n" +
-      "  • warmup {projectPath,backend} — pre-build the index · preindex {projectPath,backend} — build ahead (clangd static index if available)\n" +
-      "  • scope {projectPath} — show the indexing scope + TU stats + dirs to pick\n" +
-      "  • index {projectPath,status} — build the committable .vts-index (tree-sitter cold-start tier)\n" +
-      "  • gen_compile_db {projectPath,apply,inTree,engineRoot,target,…} — generate the UE clangd compile DB\n" +
-      "  • git {argv|args,projectPath} · p4 {argv|args,projectPath} — run a READ-ONLY VCS command, output compacted (mutating REFUSED)",
+      "vs-token-safer admin/meta ops (rarely needed reflexively) — set `op`, put that op's args in `params`:\n" +
+      "  setup·config·savings{graph|daily|history}·savings_reset — configure / settings / tokens saved\n" +
+      "  discover{since,learn} — code searches that BYPASSED vts · warmup·preindex — pre-build the index\n" +
+      "  scope — indexing scope + TU stats · index{status} — build the committable .vts-index (cold-start tier)\n" +
+      "  gen_compile_db{apply,…} — generate the UE clangd compile DB\n" +
+      "  git·p4{argv} — run a READ-ONLY VCS command, output compacted (mutating REFUSED)",
     inputSchema: {
       type: "object",
       properties: {
-        op: { type: "string", enum: ["setup", "config", "savings", "savings_reset", "discover", "warmup", "preindex", "scope", "index", "gen_compile_db", "git", "p4"], description: "Which admin operation (see the description)." },
-        params: { type: "object", description: 'Arguments for the op, e.g. {"argv":["status"]} for git, {"since":30} for discover, {"projectPath":"…"} for setup.' },
+        op: { type: "string", enum: ["setup", "config", "savings", "savings_reset", "discover", "warmup", "preindex", "scope", "index", "gen_compile_db", "git", "p4"], description: "Which admin op (see description)." },
+        params: { type: "object", description: 'Args for the op, e.g. {"argv":["status"]} for git, {"since":30} for discover.' },
       },
       required: ["op"],
     },


### PR DESCRIPTION
## Why
vts's own MCP usage measured ~24% of a session (per-request tool schema + per-result appends). Token-safer should not be a token cost. Reduce its footprint with zero loss of routing/adoption signal.

## What
- **tools.js** — self-evident common params (`projectPath`/`backend`/`maxResults`) carry no description (shared `ROOT`/`BACKEND`/`CAP` consts); tool descriptions trimmed. Kept: `USE INSTEAD OF` adoption cues + routing cues. Tool-list schema **3455 -> 2723 tok (-21%)**, recurring on every API call.
- **core.js `completenessCert`** — rung lines trimmed ~40-50% (rung keywords + the one actionable scope command kept). `EMPTY_HINT` / `LOG_STEER` trimmed.
- **policy.js `routingDigest`** — SessionStart when-to-use tree trimmed (`Tool routing` / `COMPLEMENTARY` / `--scope` / posture format kept).
- **eval** — guard 62 cap 3500 -> 2900 (now 2723); guard 16 LOG_STEER phrase updated.

## Review points
- No capability removed — only descriptions/prose. All params + required unchanged.
- Precision-label keywords preserved (guard 76): EXACT/SYNTACTIC/FUZZY/SECTION rung, PARTIAL, INCONCLUSIVE.
- 88 guards green, lint clean, marketplace parity validated.

Closes nothing (standalone perf patch -> v0.37.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
