### PR TITLE
feat(concept): git co-change ranking signal (M1) + footprint trim (v0.37.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "vs-token-safer",
       "source": "./",
-      "version": "0.37.2",
+      "version": "0.37.3",
       "category": "development",
       "description": "Sits between Claude Code and your codebase and hands back a short file:line list instead of dumping source. Real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a no-embeddings fuzzy search built from your repo's own naming when you don't know the exact name. Section-edits Markdown and config too. Local-only. Bundles gamedev-log-analyzer."
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vs-token-safer",
   "description": "Sits between Claude Code and your codebase and hands back a short file:line list instead of dumping source into the chat. It uses a real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a fuzzy search built from your repo's own naming when you don't know the exact name (no embeddings). It section-edits Markdown and config files the same way. Everything stays on your machine. No IDE required. Bundles gamedev-log-analyzer for reading huge editor/build logs.",
-  "version": "0.37.2",
+  "version": "0.37.3",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/vs-token-safer",
   "repository": "https://github.com/JSungMin/vs-token-safer",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,10 +108,17 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   attached leading comment (gap≤3, skip header blocks ≥4 lines, cap 200ch) feeds the concept units. NO embeddings,
   nothing transmitted, output token-capped file:line. Eval guard 83; **follow-up paper** `paper/fuzzy-concept-
   dictionary.tex` (companion to the Token-Safer paper, motivated by the CCE correspondence). Env: `VTS_CONCEPT_*`.
-  SCORING = 3 deterministic channels (name > **path** > comment; `scoreSymbol`) + a 2nd-pass **import-graph
-  proximity** boost (`importSpecifiers` → within-repo basename adjacency; a symbol whose file imports/imported-by
-  a strongly-matching file is lifted by `VTS_CONCEPT_IMPORT_FACTOR` 0.3 × the neighbour's score — reranks the
-  matched set, never invents a match). A **click-feedback loop was CRITIC-REJECTED** (self-confirming via
+  SCORING = 3 deterministic channels (name > **path** > comment; `scoreSymbol`) + 2nd-pass **structural-proximity**
+  boosts off TWO neighbour graphs (same LARGER anchor gate, reranks the matched set, never invents a match):
+  (a) **import-graph** (`importSpecifiers` → within-repo basename adjacency; lifted by `VTS_CONCEPT_IMPORT_FACTOR`
+  0.3 × the neighbour's score) and (b) **git CO-CHANGE** (`server/cochange.js` `cochangeNeighbors` — files
+  committed together in the last `VTS_COCHANGE_MAX_COMMITS` 500 commits are coupled; mega-commits >
+  `VTS_COCHANGE_MAX_FILES_PER_COMMIT` 30 skipped as merge/format noise; ≥ `VTS_COCHANGE_MIN_WEIGHT` 2 co-commits
+  to count; lifted by `VTS_CONCEPT_COCHANGE_FACTOR` 0.25, BELOW imports — a softer signal). Co-change is the M1
+  migration toward the Cursor/Augment "what clusters semantically" axis, embedding-free: the repo's own history is
+  the cluster signal. PURE `parseCoChange` (git-log text → pair weights, both directions) + thin `git log` read,
+  cached in `conceptIndexFor`; absent git → empty map (boost no-ops). `VTS_CONCEPT_COCHANGE=0` off. Eval guard 89;
+  live-verified on the vts repo (core.js → 49 co-change neighbours: eval/run.mjs, policy.js, …). A **click-feedback loop was CRITIC-REJECTED** (self-confirming via
   position bias, non-deterministic, unmeasurable, erodes inspectability); the charter-pure adaptation paths are
   these code-mined structural signals + a **committable synonym file** (DONE): a team-curated, git-committable
   `<root>/.vts-index/concept-synonyms.json` (`{ "term": ["syn", …] }`) — `concept.js parseSynonyms` (tokenises

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -2050,6 +2050,8 @@ const prfOk = fbTerms.some(([t, w]) => t === "authenticate" && w === 0.5) &&  //
   cPrf(prfModel, [["a"]], ["q"], { minDocs: 2 }).length === 0;                 // nothing clears consensus → empty
 let conceptToolOk = true;
 if (tsAvailable()) {
+  process.env.VTS_CONCEPT_COCHANGE = "0"; // pin OFF for this fixture: a CI tmpdir nested in a git repo would
+  //                                         otherwise mine unrelated history and perturb the import-graph asserts
   const cdir = path.join(os.tmpdir(), `vts-eval-${process.pid}-concept`);
   fs.mkdirSync(cdir, { recursive: true });
   // write every fixture BEFORE the first query — conceptIndexFor caches the model per root on first use.
@@ -2077,8 +2079,27 @@ if (tsAvailable()) {
   conceptToolOk = !cr.isError && /validateSession/.test(cr.text) && /refreshToken/.test(cr.text) && !/renderWidget/.test(cr.text) && /no embeddings/.test(cr.text) &&
     /ladder.*[Cc]limb/.test(cr.text) && pathLocalityOk && importBoostOk && seedOk; // ladder nav + path-locality + import-graph proximity + intrinsic-best climb seed
   try { fs.rmSync(cdir, { recursive: true, force: true }); } catch { /* ignore */ }
+  delete process.env.VTS_CONCEPT_COCHANGE;
 }
 const conceptOk = splitOk && expandOk && synOk && scoreOk && dfGateOk && anchorGateOk && prfOk && conceptToolOk;
+
+// 89) GIT CO-CHANGE signal (cochange.js) — M1 migration (the Cursor/Augment "what clusters semantically" axis,
+// embedding-free): files committed together feed a 2nd structural neighbour channel into concept_search's pass-2
+// proximity boost (alongside the import graph, same LARGER anchor gate, weighted below it). parseCoChange is PURE
+// (canned git-log text → pair weights, BOTH directions, mega-commits skipped); cochangeNeighbors degrades to an
+// empty map on a non-git dir (graceful — the boost then does nothing). Local, deterministic, nothing transmitted.
+const { parseCoChange: ccParse, cochangeNeighbors: ccNeighbors } = await import("../server/cochange.js");
+const ccSEP = "<<<VTS-COMMIT>>>";
+const ccLog = [ccSEP, "a.js", "b.js", "", ccSEP, "a.js", "b.js", "", ccSEP, "a.js", "c.js", "",
+  ccSEP, ...Array.from({ length: 31 }, (_, i) => "m" + i)].join("\n");
+const ccPairs = ccParse(ccLog);
+const cochangeOk =
+  ccPairs.get("a.js").get("b.js") === 2 &&                  // co-changed in 2 commits
+  ccPairs.get("b.js").get("a.js") === 2 &&                  // stored BOTH directions
+  ccPairs.get("a.js").get("c.js") === 1 &&                  // co-changed once
+  !ccPairs.has("m0") &&                                     // a 31-file commit > cap 30 → skipped (merge/format noise)
+  ccParse(ccLog, { maxFilesPerCommit: 1 }).size === 0 &&    // cap 1 → every commit skipped (no pairs)
+  ccNeighbors(os.tmpdir()) instanceof Map;                  // non-git (or any) dir → a Map, never throws
 
 // 85) PREVIEW-ONLY DCE (dce.js): topological dead-code analysis over an INJECTED call-graph query — pure +
 // deterministic with a mock graph. DEAD cascades to a fixpoint (a callee dies only once ALL its callers are
@@ -2317,6 +2338,7 @@ const rows = [
   ["syntactic tier: tree-sitter decl extraction (36 langs, zero setup) + committable .vts-index symbol index + HTML <script>/<style> exact-range injection", tsTierOk, "true", tsTierOk],
   ["Roslyn dotnet-host path OS-aware (macOS/Linux C# regression: win32/darwin/linux globalStorage)", roslynOsPathOk, "true", roslynOsPathOk],
   ["fuzzy concept retrieval (B): repo co-occurrence dictionary + concept_search (no embeddings, ranked decls)", conceptOk, "true", conceptOk],
+  ["git co-change signal (M1): parseCoChange pair weights (both dirs) + mega-commit skip + graceful non-git", cochangeOk, "true", cochangeOk],
   ["preview-only DCE: caller-cascade + reachability(mark-sweep from roots) + reference-verify + warm gate (safe_delete backstop)", dceOk, "true", dceOk],
   ["structure tier: section outline/read/edit for md/toml/yaml/html/css/scss/… via the symbol tools (no backend, by heading/selector/rule/function)", structOk, "true", structOk],
 ];

--- a/server/cochange.js
+++ b/server/cochange.js
@@ -1,0 +1,79 @@
+// cochange.js — GIT CO-CHANGE signal for the FUZZY rung (concept_search).
+//
+// Files committed together hold related code. That co-occurrence is a deterministic, LOCAL, embedding-free
+// proxy for the "what clusters semantically" signal cloud tools (Cursor/Augment) get from vectors — mined
+// straight from the repo's own history, nothing transmitted. We feed it as a SECOND structural neighbour map
+// (alongside the import graph) into the concept_search pass-2 proximity boost: a symbol whose file frequently
+// co-changes with a strongly-matching file is lifted, GATED by the same LARGER anchor confidence so a weak
+// neighbour can't drag it up. The boost only reranks the already-matched, already-capped file:line set — it
+// never invents a match, so the charter (capped output, honest precision, local) holds.
+//
+// PURE core (`parseCoChange`, text → map) + one thin git read (`cochangeNeighbors`). Absent git / not a repo
+// → an empty map (the boost then does nothing — graceful, exactly like the import graph on an unsupported lang).
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+// Commit-boundary marker. We make git print it once per commit (`--pretty=format:<SEP>`), so a line equal to
+// it starts a new commit and every other non-empty line is a touched file. A printable sentinel (no control
+// chars — diff/eslint friendly) that cannot collide with a real path line.
+const SEP = "<<<VTS-COMMIT>>>";
+
+// Parse the output of `git log --name-only --pretty=format:<SEP>` into a file→file co-change weight map. Each
+// commit contributes +1 to every unordered pair of files it touched (stored BOTH directions for O(1) neighbour
+// lookup). A commit touching MORE than maxFilesPerCommit files is SKIPPED — a merge / format sweep / mass-rename
+// couples hundreds of unrelated files and is noise, not a semantic signal. Pure: text → Map, no fs, no git.
+// Returns Map<relpath, Map<relpath, count>>.
+export function parseCoChange(logText, { maxFilesPerCommit = 30, boundary = SEP } = {}) {
+  const pairs = new Map();
+  const bump = (a, b) => {
+    if (a === b) return;
+    if (!pairs.has(a)) pairs.set(a, new Map());
+    const m = pairs.get(a);
+    m.set(b, (m.get(b) || 0) + 1);
+  };
+  const flush = (files) => {
+    const uniq = [...new Set(files)];
+    if (uniq.length < 2 || uniq.length > maxFilesPerCommit) return; // singletons + mega-commits carry no signal
+    for (let i = 0; i < uniq.length; i++)
+      for (let j = i + 1; j < uniq.length; j++) {
+        bump(uniq[i], uniq[j]);
+        bump(uniq[j], uniq[i]);
+      }
+  };
+  let cur = [];
+  for (const raw of String(logText).split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith(boundary)) { flush(cur); cur = []; continue; } // commit boundary (SEP, optionally + the next file glued by git)
+    cur.push(line.replace(/\\/g, "/"));
+  }
+  flush(cur);
+  return pairs;
+}
+
+// Build a file→Set<neighbour-file> co-change map from the last `maxCommits` of git history under `root`. Keys
+// and values are ABSOLUTE forward-slash paths (resolved against the git TOPLEVEL so they line up with the
+// concept index's `symbol.file`, which is an absolute walk path). Only neighbours co-changed >= minWeight times
+// are kept (a single shared commit is a coincidence, not a coupling). Not a git repo / git missing → empty map.
+export function cochangeNeighbors(root, { maxCommits = 500, maxFilesPerCommit = 30, minWeight = 2 } = {}) {
+  let top, out;
+  try {
+    top = execFileSync("git", ["-C", root, "rev-parse", "--show-toplevel"], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    out = execFileSync(
+      "git",
+      ["-C", root, "log", "--name-only", "--no-renames", `--pretty=format:${SEP}`, "-n", String(maxCommits)],
+      { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] },
+    );
+  } catch {
+    return new Map(); // no git / not a repo → no co-change edges (graceful)
+  }
+  const pairs = parseCoChange(out, { maxFilesPerCommit });
+  const abs = (rel) => path.resolve(top, rel).replace(/\\/g, "/");
+  const neighbors = new Map();
+  for (const [f, m] of pairs) {
+    const set = new Set();
+    for (const [g, w] of m) if (w >= minWeight) set.add(abs(g));
+    if (set.size) neighbors.set(abs(f), set);
+  }
+  return neighbors;
+}

--- a/server/core.js
+++ b/server/core.js
@@ -22,6 +22,7 @@ import { compactGit, compactP4 } from "./compact.js";
 import { tsSearchSymbols, tsSearchReferences, tsFileDeclDocs, tsSupports, tsAvailable, htmlEmbeddedDecls, tsChunkEnd } from "./treesitter.js";
 import { searchSymIndex, buildSymIndex, symIndexPath, loadSymIndex } from "./symindex.js";
 import { splitIdent, tokenize, buildConceptModel, expandQuery, scoreSymbol, importSpecifiers, parseSynonyms, anchorConfident, prfTerms } from "./concept.js";
+import { cochangeNeighbors } from "./cochange.js";
 import { isStructFile, structOutlineInjected, resolveInOutline, fmtOutline } from "./textstruct.js";
 import { analyzeDeadCode, reachabilityDeadCode, formatDce, dceWarmGate, reconcileRefs, parseRootsFile } from "./dce.js";
 
@@ -303,8 +304,8 @@ function savingsLine(rawTok, outTok, tool) {
   if (rawTok < 2000) return "";
   const ratio = outTok > 0 ? Math.round(rawTok / outTok) : rawTok;
   const pct = (100 * (1 - outTok / Math.max(rawTok, 1))).toFixed(1);
-  const vs = AVOIDED_READ_TOOLS.has(tool) ? "smaller than a full-file Read" : "smaller than the raw index response";
-  return `\n\n✓ Saved ~${(rawTok - outTok).toLocaleString()} tokens here (${pct}% / ${ratio}× ${vs}).`;
+  const vs = AVOIDED_READ_TOOLS.has(tool) ? "vs a full-file Read" : "vs the raw index";
+  return `\n\n✓ Saved ~${(rawTok - outTok).toLocaleString()} tok here (${pct}% / ${ratio}× ${vs}).`;
 }
 const usd = (tokens) => (tokens / 1e6) * USD_PER_MTOK;
 // ASCII sparkline-style bar graph of saved tokens for the last `days` days (RTK `gain --graph` analog).
@@ -1614,7 +1615,20 @@ async function conceptIndexFor(root) {
     const neighbors = new Map();
     const link = (a, b) => { if (a === b) return; if (!neighbors.has(a)) neighbors.set(a, new Set()); neighbors.get(a).add(b); };
     for (const [f, specs] of fileSpecs) for (const s of specs) for (const g of byBase.get(s) || []) { link(f, g); link(g, f); }
-    return { model: buildConceptModel(units), symbols, files, neighbors };
+    // GIT CO-CHANGE neighbours (a 2nd structural signal, embedding-free): files frequently committed together
+    // are semantically related even with no shared token/import — the local proxy for what vectors cluster.
+    // Built once per root (this index is cached). Off / non-git → empty map (the boost then does nothing).
+    let cochange = new Map();
+    if (!/^(0|false|off|no)$/i.test(String(process.env.VTS_CONCEPT_COCHANGE ?? "1"))) {
+      try {
+        cochange = cochangeNeighbors(root, {
+          maxCommits: envInt("VTS_COCHANGE_MAX_COMMITS", 500),
+          maxFilesPerCommit: envInt("VTS_COCHANGE_MAX_FILES_PER_COMMIT", 30),
+          minWeight: envInt("VTS_COCHANGE_MIN_WEIGHT", 2),
+        });
+      } catch { cochange = new Map(); }
+    }
+    return { model: buildConceptModel(units), symbols, files, neighbors, cochange };
   })();
   _conceptCache.set(root, build);
   const res = await build;
@@ -2041,7 +2055,7 @@ export async function runTool(name, a = {}) {
       const root = resolveRoot(a);
       if (!tsAvailable()) return err("concept_search needs the tree-sitter grammars (web-tree-sitter + tree-sitter-wasms); they install with the plugin. Until then use search_text (multi-word, ranked by term coverage).");
       const max = Number(a.maxResults) || MAX_RESULTS;
-      const { model, symbols, neighbors } = await conceptIndexFor(root);
+      const { model, symbols, neighbors, cochange } = await conceptIndexFor(root);
       if (!symbols.length) return finishOut([], `No indexable declarations under ${root} for concept search (no tree-sitter-supported files in scope?).` + EMPTY_HINT);
       const qToks = tokenize(String(a.q));
       if (!qToks.length) return err(`"${a.q}" has no usable concept tokens (too short / all stop-words). Try concrete nouns: "auth session token".`);
@@ -2086,17 +2100,25 @@ export async function runTool(name, a = {}) {
       const fileBase = new Map();
       for (const r of based) if ((fileBase.get(r.s.file) || 0) < r.base) fileBase.set(r.s.file, r.base);
       const nf = Number(process.env.VTS_CONCEPT_IMPORT_FACTOR ?? 0.3);
-      // LARGER confidence gate (arXiv:2605.16352): expand the import-graph neighbourhood ONLY from high-confidence
-      // anchors — a neighbour file lifts a symbol only if its own base clears a fraction of the strongest intrinsic
-      // match. Stops a weak/cross-cutting neighbour from dragging its imports up. VTS_CONCEPT_ANCHOR_MIN=0 = old.
+      // GIT CO-CHANGE factor — a 2nd structural neighbour channel (files committed together), weighted BELOW the
+      // import graph (a co-change is a softer signal than an explicit import). Same anchor gate. FACTOR=0 off.
+      const cf = Number(process.env.VTS_CONCEPT_COCHANGE_FACTOR ?? 0.25);
+      // LARGER confidence gate (arXiv:2605.16352): expand the neighbourhood ONLY from high-confidence anchors — a
+      // neighbour file lifts a symbol only if its own base clears a fraction of the strongest intrinsic match.
+      // Stops a weak/cross-cutting neighbour from dragging its imports/co-changes up. VTS_CONCEPT_ANCHOR_MIN=0 = old.
       const topBase = based.reduce((m, r) => (r.base > m ? r.base : m), 0);
       const anchorRatio = Number(process.env.VTS_CONCEPT_ANCHOR_MIN ?? 0.5);
+      const bestNeighbour = (map, file) => {
+        let best = 0;
+        const ns = map && map.get(file);
+        if (ns) for (const g of ns) { const fb = fileBase.get(g) || 0; if (anchorConfident(fb, topBase, anchorRatio) && fb > best) best = fb; }
+        return best;
+      };
       const scoredAll = based
         .map((r) => {
-          let nb = 0;
-          const ns = nf && neighbors && neighbors.get(r.s.file);
-          if (ns) for (const g of ns) { const fb = fileBase.get(g) || 0; if (anchorConfident(fb, topBase, anchorRatio) && fb > nb) nb = fb; }
-          return { s: r.s, sc: r.base + nb * nf, base: r.base };
+          const nb = nf ? bestNeighbour(neighbors, r.s.file) : 0;       // import-graph neighbour
+          const cb = cf ? bestNeighbour(cochange, r.s.file) : 0;        // git co-change neighbour
+          return { s: r.s, sc: r.base + nb * nf + cb * cf, base: r.base };
         })
         .sort((a2, b2) => b2.sc - a2.sc);
       // Fuzzy results have a long low-relevance tail (a trivial local matching one weak expansion term). Cap

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vs-token-safer",
-  "version": "0.37.2",
+  "version": "0.37.3",
   "type": "module",
   "description": "Sits between an LLM coding agent and your repository and answers where/what/how questions with a short file:line list instead of raw source. It uses a real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a no-embeddings fuzzy search built from the repo's own naming when you don't know the exact name. It section-edits Markdown and config files the same way. Local-only, nothing transmitted. CLI + MCP. No IDE required.",
   "keywords": [


### PR DESCRIPTION
## Why
Two threads, shipped as one patch per request:
1. **Footprint (cont. of v0.37.2)** — trim the per-result savings line.
2. **M1 competitor migration** — narrow the Cursor/Augment "what clusters semantically" gap WITHOUT embeddings, using the repo's own git history.

## M1 — git co-change ranking signal
Files committed together hold related code — a deterministic, local, embedding-free proxy for what vectors cluster.
- **`server/cochange.js`** — `parseCoChange` (PURE: git-log text -> file-pair weights, both directions; mega-commits > 30 files skipped as merge/format noise) + `cochangeNeighbors` (thin `git log` read, abs paths via git toplevel; non-git -> empty map).
- **`core.js`** — `conceptIndexFor` builds a 2nd structural neighbour map (cached). `concept_search` pass-2 lifts a symbol whose file co-changes with a strongly-matching file — **same LARGER anchor gate**, weighted 0.25 (below imports 0.3).
- **Env** — `VTS_CONCEPT_COCHANGE` (on), `_COCHANGE_FACTOR`, `VTS_COCHANGE_MAX_COMMITS` (500) / `_MAX_FILES_PER_COMMIT` (30) / `_MIN_WEIGHT` (2).

## Charter
Local, deterministic, nothing transmitted. The boost only reranks the already-capped file:line set — never invents a match. Absent git -> no-op.

## Review points
- Live-verified on this repo: `core.js` -> 49 co-change neighbours (eval/run.mjs, policy.js, CLAUDE.md — the always-co-committed set). A/B on a strong-match query is identical (boost is conservative by design); it tips only near-tie orderings.
- Import-graph path refactored to a shared `bestNeighbour` helper (same gate/logic).
- Eval guard 89 (parseCoChange pair weights + mega-skip + graceful non-git). 89 guards green, lint clean, parity validated.

-> v0.37.3 (patch, per request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
