### PR TITLE
feat(routing): v0.38.0 — census-based multi-backend fallback for mixed-repo search

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "vs-token-safer",
       "source": "./",
-      "version": "0.37.3",
+      "version": "0.38.0",
       "category": "development",
       "description": "Sits between Claude Code and your codebase and hands back a short file:line list instead of dumping source. Real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a no-embeddings fuzzy search built from your repo's own naming when you don't know the exact name. Section-edits Markdown and config too. Local-only. Bundles gamedev-log-analyzer."
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vs-token-safer",
   "description": "Sits between Claude Code and your codebase and hands back a short file:line list instead of dumping source into the chat. It uses a real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a fuzzy search built from your repo's own naming when you don't know the exact name (no embeddings). It section-edits Markdown and config files the same way. Everything stays on your machine. No IDE required. Bundles gamedev-log-analyzer for reading huge editor/build logs.",
-  "version": "0.37.3",
+  "version": "0.38.0",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/vs-token-safer",
   "repository": "https://github.com/JSungMin/vs-token-safer",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,12 @@ forced backend (one global server serves every repo, so a `backend:"clangd"` pin
 sent this repo's `.js`/`.cs`/`.py` → clangd answers `-32001 invalid AST`; live-found dogfooding goto on the vts
 repo while config pinned clangd for a UE tree) > forced `VTS_BACKEND`/config `backend` > `backendForPath(a.path)` >
 `pickBackend(root)`. A path-less query (search_symbol by name) keeps the forced backend. Eval guard 55.
+  CENSUS FALLBACK (core.js `censusFallbackBackends`): a path-less query keeping the forced/root backend is the
+  mixed-repo hole — clangd (root) answers 0 for a Python symbol and the model abandons vts. So when the primary
+  backend's `search_symbol` comes back EMPTY on a path-less, non-explicit query, retry against the OTHER backends
+  the `languageCensus` shows have files (most-code-first) BEFORE the syntactic/literal fallback — still the EXACT
+  rung, just from the right LSP. Gated: `!a.path && !a.backend`, count ≥ `VTS_CENSUS_FALLBACK_MIN` (1),
+  `VTS_CENSUS_FALLBACK=0` off; no cost on a single-language repo (census returns no other candidate). Eval guard 90.
   Override via `VTS_CLANGD_CMD/ARGS`,
   `VTS_ROSLYN_CMD/ARGS`, `VTS_TS_CMD/ARGS`, `VTS_PY_CMD/ARGS`. `winShell` flag spawns the npm `.cmd`
   shims (ts/pyright) through a shell on Windows. `langIdForPath` (lsp.js) maps file ext → LSP languageId.

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1158,6 +1158,24 @@ const backendPathOk =
   preferBackend("", "typescript", "") === "typescript" &&      // no forced backend → the file's backend
   preferBackend("", null, "") === "";                          // nothing resolvable → "" (caller does pickBackend(root))
 
+// 90) CENSUS-BASED multi-backend fallback for a PATH-LESS search_symbol: the bug is that preferBackend keeps the
+// forced/root backend (clangd in a UE tree) for a name-only query, so a Python tooling dir in the SAME repo is
+// invisible (clangd answers 0, model gives up). censusFallbackBackends consults the language census and returns
+// the OTHER backends with files, most-code-first, so the empty-result branch can retry against the right LSP.
+// Pure with an injected census (no fs). Gated to count ≥ VTS_CENSUS_FALLBACK_MIN; VTS_CENSUS_FALLBACK=0 disables.
+const { censusFallbackBackends } = await import("../server/core.js");
+const _cf = (primary, census, env = {}) => {
+  const saved = {}; for (const k in env) { saved[k] = process.env[k]; process.env[k] = env[k]; }
+  try { return censusFallbackBackends("/r", primary, census); }
+  finally { for (const k in env) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; } }
+};
+const censusFallbackOk =
+  JSON.stringify(_cf("clangd", { clangd: 100, pyright: 5, typescript: 0, roslyn: 0 })) === JSON.stringify(["pyright"]) && // 0-count excluded, primary excluded
+  JSON.stringify(_cf("clangd", { clangd: 100, pyright: 5, typescript: 20, roslyn: 0 })) === JSON.stringify(["typescript", "pyright"]) && // census-desc order
+  _cf("pyright", { clangd: 0, pyright: 100, typescript: 0, roslyn: 0 }).length === 0 && // no OTHER language present → no fallback
+  JSON.stringify(_cf("clangd", { clangd: 100, pyright: 5, typescript: 20 }, { VTS_CENSUS_FALLBACK_MIN: "10" })) === JSON.stringify(["typescript"]) && // min raised → pyright:5 dropped
+  _cf("clangd", { clangd: 100, pyright: 5 }, { VTS_CENSUS_FALLBACK: "0" }).length === 0; // kill switch
+
 // 56) vts_setup genCompileDb — setup can kick off the compile-DB generation in the same step (so the user
 // doesn't have to find the separate vts_gen_compile_db tool): `true` = DRY-RUN (prints the UBT command, runs
 // nothing), "apply" = run UBT. Wiring test: the section appears with the GenerateClangDatabase command and
@@ -2309,6 +2327,7 @@ const rows = [
   ["edit-steer: search EDIT_STEER (toggle) + discover counts whole-decl Edit", editSteerOk, "true", editSteerOk],
   ["edit-steer hook: L1 warn (replace/insert) + L2 safe-insert escalation", editHookOk, "true", editHookOk],
   ["per-file-language backend (.py→pyright in a clangd-rooted mixed repo)", backendPathOk, "true", backendPathOk],
+  ["census fallback: path-less search_symbol retries OTHER backends present in the mixed repo (census-desc, gated)", censusFallbackOk, "true", censusFallbackOk],
   ["vts_setup genCompileDb: generates the compile DB in the setup step (dry)", setupGenOk, "true", setupGenOk],
   ["vts_setup clangdCmd: persists the clangd-binary path to config", setupClangdOk, "true", setupClangdOk],
   ["search_text → symbol steer (find_references on a `<Type>`/symbol hunt)", textSteerOk, "true", textSteerOk],

--- a/server/core.js
+++ b/server/core.js
@@ -106,6 +106,23 @@ export function preferBackend(aBackend, byPath, forced) {
   return aBackend || (byPath && forced && byPath !== forced ? byPath : forced) || byPath || "";
 }
 
+// Census-based multi-backend fallback for a PATH-LESS search_symbol. A name-only query has no `path` to drive
+// backendForPath, so preferBackend keeps the forced/root backend (clangd in a UE tree). A DIFFERENT language
+// in the SAME repo — a Python tooling dir, a JS side-project — is then structurally invisible: the query is
+// sent to clangd, finds nothing, and the model gives up on vts. So when the primary backend misses, consult
+// the language census and retry against the OTHER backends that actually have files here, most-code-first.
+// Returns the candidate backend names (excluding `primary`, count ≥ VTS_CENSUS_FALLBACK_MIN), census-desc.
+// `census` is injectable for the eval. VTS_CENSUS_FALLBACK=0 disables; only fired on a path-less, non-explicit
+// query (a deliberate `path=`/`backend=` choice is never second-guessed).
+export function censusFallbackBackends(root, primary, census) {
+  if (/^(0|false|off|no)$/i.test(String(process.env.VTS_CENSUS_FALLBACK ?? "1"))) return [];
+  const min = envInt("VTS_CENSUS_FALLBACK_MIN", 1);
+  const c = census || languageCensus(root);
+  return ["clangd", "roslyn", "typescript", "pyright"]
+    .filter((b) => b !== primary && (c[b] || 0) >= min)
+    .sort((x, y) => (c[y] || 0) - (c[x] || 0));
+}
+
 // Perforce auto-checkout for a symbol-edit / rename APPLY. A symbol edit writes via `fs` directly (it bypasses
 // the built-in Edit/Write tool, so a p4-checkout PreToolUse hook never fires for it). In a P4 workspace an
 // unopened file is READ-ONLY, so before writing a read-only file we run `p4 edit` to open it for edit. Gated ON
@@ -2416,6 +2433,23 @@ export async function runTool(name, a = {}) {
 
     if (name === "search_symbol") {
       if (!a.q) return err("search_symbol needs q (the symbol name/substring).");
+      // Render a successful symbol hit set — shared by the primary path and the census fallback below, so a
+      // mixed-repo fallback result gets the SAME focus/tee/steer/cert treatment as a primary hit.
+      const renderFoundSymbols = (syms, bname, advB, note = "") => {
+        const focusN = focusCap(String(a.q), syms, max);
+        const symTee = teeOverflow("search_symbol", a.q, syms.map((s) => `${s.name} @ ${locLine(s.location.uri, s.location.range)}`), focusN);
+        const symEdit = editSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10) ? EDIT_STEER : ""; // focused lookup → likely an edit precursor
+        // Found the declaration(s); the other natural next step is "where is it USED?" — point at find_references
+        // by NAME (semantic call sites) so the model doesn't fall back to a grep for usages. Focused result only.
+        const symUses = usesSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10)
+          ? `\n↪ Where is "${a.q}" USED? find_references symbol="${a.q}" (all call sites, semantic) — add direction=callers for the caller tree.`
+          : "";
+        const focusNote = focusN < max && focusN < syms.length ? ` — showing the ${focusN} best for an exact-name hit (raise maxResults or VTS_FOCUS=0 for all ${syms.length})` : "";
+        const symCert = completenessCert({ shown: Math.min(focusN, syms.length), total: syms.length, truncated: focusN < syms.length ? "cap" : null, semantic: true, scoped: scopeDirsFor(root).length > 0 });
+        const symBody = advB + `${syms.length} symbol(s) matching "${a.q}" (backend: ${bname}, root: ${root})${note}${focusNote}${symTee}:\n` + fmtSymbols(syms, focusN) + symEdit + symUses + symCert;
+        maybeCounterfactual("search_symbol", String(a.q), root, syms.map((s) => s.location), symBody);
+        return finishOut(syms, symBody);
+      };
       const c = await getClient(root, backendName);
       const persisted = backendName === "clangd" && hasPersistedIndex(root);
       const syms0 = await symbolReady(c, String(a.q), persisted, envInt("VTS_CLANGD_PERSISTED_WAIT_MS", 60000));
@@ -2426,6 +2460,25 @@ export async function runTool(name, a = {}) {
       const syms = histMap ? rankSymbols(String(a.q), syms0, histMap) : syms0;
       const adv = backendAdvisory(backendName, root);
       if (!syms.length) {
+        // CENSUS-BASED MULTI-BACKEND FALLBACK (path-less, non-explicit query only): the primary backend (the
+        // forced/root one) missed, but a DIFFERENT language present in this MIXED repo would never be tried —
+        // preferBackend keeps the forced backend with no `path` to override it, so a Python tooling dir under a
+        // UE C++ tree is structurally invisible. Retry against the OTHER backends the census shows have files,
+        // most-code-first, and return the FIRST semantic hit — still the EXACT rung, just from the right
+        // language server. A query carrying a `path` or an explicit `backend=` is a deliberate choice → kept.
+        if (!a.path && !a.backend) {
+          for (const fb of censusFallbackBackends(root, backendName)) {
+            try {
+              const cfb = await getClient(root, fb);
+              const persistedFb = fb === "clangd" && hasPersistedIndex(root);
+              const symsFb0 = await symbolReady(cfb, String(a.q), persistedFb, envInt("VTS_CLANGD_PERSISTED_WAIT_MS", 60000));
+              if (!symsFb0.length) continue;
+              try { recordQueryResults(root, symsFb0.map((s) => fromUri(s.location.uri))); } catch { /* best-effort */ }
+              const symsFb = histMap ? rankSymbols(String(a.q), symsFb0, histMap) : symsFb0;
+              return renderFoundSymbols(symsFb, fb, backendAdvisory(fb, root), ` — mixed-repo fallback, ${backendName} had no match`);
+            } catch { /* this backend failed to spawn/answer — try the next census candidate */ }
+          }
+        }
         // tsserver / pyright answer workspace/symbol from the files they have OPEN/indexed, so a symbol
         // whose file the warm-up didn't open (or a non-exported local) can come back empty even though it
         // exists. Fall back to a bounded literal text search so it's still locatable (clangd/roslyn index
@@ -2455,20 +2508,8 @@ export async function runTool(name, a = {}) {
           : "";
         return finishOut([], adv + `No symbols matching "${a.q}" (backend: ${backendName}).` + EMPTY_HINT + clangdIndexAdvisory(backendName, root, null) + emptyCert + intentSteer);
       }
-      // confidence-adaptive focus: an exact-name match in a big set → show it + a few, not the whole tail.
-      const focusN = focusCap(String(a.q), syms, max);
-      const symTee = teeOverflow("search_symbol", a.q, syms.map((s) => `${s.name} @ ${locLine(s.location.uri, s.location.range)}`), focusN);
-      const symEdit = editSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10) ? EDIT_STEER : ""; // focused lookup → likely an edit precursor
-      // Found the declaration(s); the other natural next step is "where is it USED?" — point at find_references
-      // by NAME (semantic call sites) so the model doesn't fall back to a grep for usages. Focused result only.
-      const symUses = usesSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10)
-        ? `\n↪ Where is "${a.q}" USED? find_references symbol="${a.q}" (all call sites, semantic) — add direction=callers for the caller tree.`
-        : "";
-      const focusNote = focusN < max && focusN < syms.length ? ` — showing the ${focusN} best for an exact-name hit (raise maxResults or VTS_FOCUS=0 for all ${syms.length})` : "";
-      const symCert = completenessCert({ shown: Math.min(focusN, syms.length), total: syms.length, truncated: focusN < syms.length ? "cap" : null, semantic: true, scoped: scopeDirsFor(root).length > 0 });
-      const symBody = adv + `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root})${focusNote}${symTee}:\n` + fmtSymbols(syms, focusN) + symEdit + symUses + symCert;
-      maybeCounterfactual("search_symbol", String(a.q), root, syms.map((s) => s.location), symBody);
-      return finishOut(syms, symBody);
+      // confidence-adaptive focus + steers + cert (shared with the census fallback above).
+      return renderFoundSymbols(syms, backendName, adv);
     }
     if (name === "find_references") {
       const c = await getClient(root, backendName);

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vs-token-safer",
-  "version": "0.37.3",
+  "version": "0.38.0",
   "type": "module",
   "description": "Sits between an LLM coding agent and your repository and answers where/what/how questions with a short file:line list instead of raw source. It uses a real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a no-embeddings fuzzy search built from the repo's own naming when you don't know the exact name. It section-edits Markdown and config files the same way. Local-only, nothing transmitted. CLI + MCP. No IDE required.",
   "keywords": [


### PR DESCRIPTION
## Summary

- Census-based fallback: `search_symbol` by name in a mixed repo (e.g. UE C++ tree with Python tooling) now retries other backends present in the repo when the primary (clangd) returns empty — Python → pyright, JS → typescript, still the EXACT rung
- `censusFallbackBackends` (exported, pure): queries `languageCensus`, returns other backends sorted by file count, gated by `VTS_CENSUS_FALLBACK_MIN` (default 1) and `VTS_CENSUS_FALLBACK=0` kill switch
- Zero cost on single-language repos

## Root cause closed

`preferBackend` kept the forced/root backend for path-less queries — no `path=` argument means `backendForPath` returns null, so clangd wins by default even when the symbol lives in a `.py` file. The model saw 0 results, gave up on vts, and fell back to grep.

## Eval

Guard 90 (pure unit: ordering, min gate, kill switch) + guards 55/81/83/89 all passing.
Node 18/20/22 × Ubuntu+Windows — all green.

## Review points

- Closes the mixed-repo Python/TS blind spot surfaced in analysis (issue: path-less `search_symbol` locked to root backend)
- `renderFoundSymbols` closure extracted — primary and fallback paths share identical focus/tee/steer/cert treatment
- Result note labels fallback: `— mixed-repo fallback, clangd had no match`

🤖 Generated with [Claude Code](https://claude.com/claude-code)