### PR TITLE
fix(clangd): v0.38.1 — tiered bg-index policy, OOM guard for huge unscoped trees

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "vs-token-safer",
       "source": "./",
-      "version": "0.37.3",
+      "version": "0.38.0",
       "category": "development",
       "description": "Sits between Claude Code and your codebase and hands back a short file:line list instead of dumping source. Real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a no-embeddings fuzzy search built from your repo's own naming when you don't know the exact name. Section-edits Markdown and config too. Local-only. Bundles gamedev-log-analyzer."
     },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "vs-token-safer",
       "source": "./",
-      "version": "0.38.0",
+      "version": "0.38.1",
       "category": "development",
       "description": "Sits between Claude Code and your codebase and hands back a short file:line list instead of dumping source. Real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a no-embeddings fuzzy search built from your repo's own naming when you don't know the exact name. Section-edits Markdown and config too. Local-only. Bundles gamedev-log-analyzer."
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vs-token-safer",
   "description": "Sits between Claude Code and your codebase and hands back a short file:line list instead of dumping source into the chat. It uses a real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a fuzzy search built from your repo's own naming when you don't know the exact name (no embeddings). It section-edits Markdown and config files the same way. Everything stays on your machine. No IDE required. Bundles gamedev-log-analyzer for reading huge editor/build logs.",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/vs-token-safer",
   "repository": "https://github.com/JSungMin/vs-token-safer",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vs-token-safer",
   "description": "Sits between Claude Code and your codebase and hands back a short file:line list instead of dumping source into the chat. It uses a real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a fuzzy search built from your repo's own naming when you don't know the exact name (no embeddings). It section-edits Markdown and config files the same way. Everything stays on your machine. No IDE required. Bundles gamedev-log-analyzer for reading huge editor/build logs.",
-  "version": "0.37.3",
+  "version": "0.38.0",
   "author": { "name": "JSungMin", "url": "https://github.com/JSungMin" },
   "homepage": "https://github.com/JSungMin/vs-token-safer",
   "repository": "https://github.com/JSungMin/vs-token-safer",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,12 @@ forced backend (one global server serves every repo, so a `backend:"clangd"` pin
 sent this repo's `.js`/`.cs`/`.py` → clangd answers `-32001 invalid AST`; live-found dogfooding goto on the vts
 repo while config pinned clangd for a UE tree) > forced `VTS_BACKEND`/config `backend` > `backendForPath(a.path)` >
 `pickBackend(root)`. A path-less query (search_symbol by name) keeps the forced backend. Eval guard 55.
+  CENSUS FALLBACK (core.js `censusFallbackBackends`): a path-less query keeping the forced/root backend is the
+  mixed-repo hole — clangd (root) answers 0 for a Python symbol and the model abandons vts. So when the primary
+  backend's `search_symbol` comes back EMPTY on a path-less, non-explicit query, retry against the OTHER backends
+  the `languageCensus` shows have files (most-code-first) BEFORE the syntactic/literal fallback — still the EXACT
+  rung, just from the right LSP. Gated: `!a.path && !a.backend`, count ≥ `VTS_CENSUS_FALLBACK_MIN` (1),
+  `VTS_CENSUS_FALLBACK=0` off; no cost on a single-language repo (census returns no other candidate). Eval guard 90.
   Override via `VTS_CLANGD_CMD/ARGS`,
   `VTS_ROSLYN_CMD/ARGS`, `VTS_TS_CMD/ARGS`, `VTS_PY_CMD/ARGS`. `winShell` flag spawns the npm `.cmd`
   shims (ts/pyright) through a shell on Windows. `langIdForPath` (lsp.js) maps file ext → LSP languageId.

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1176,6 +1176,46 @@ const censusFallbackOk =
   JSON.stringify(_cf("clangd", { clangd: 100, pyright: 5, typescript: 20 }, { VTS_CENSUS_FALLBACK_MIN: "10" })) === JSON.stringify(["typescript"]) && // min raised → pyright:5 dropped
   _cf("clangd", { clangd: 100, pyright: 5 }, { VTS_CENSUS_FALLBACK: "0" }).length === 0; // kill switch
 
+// 92) TIERED clangd background-index policy (RAM/CPU OOM guard): a huge UNSCOPED tree must NOT be indexed at
+// `normal` priority across all cores (live incident: 26k-TU UE tree → 18GB+ on a single read_symbol). Scale to
+// the effective (post-scope) TU count: FULL ≤ soft (4000), SAFE soft..hard (idle priority + -j=2), OFF > hard
+// (15000; no whole-tree crawl — single-file ops still work, project search falls to the syntactic tier). Env
+// VTS_CLANGD_BG_INDEX=0/1 forces; VTS_CLANGD_INDEX_PRIORITY / VTS_CLANGD_JOBS override. Pure (tus injectable).
+const { clangdIndexFlags, clangdIndexModeAdvisory } = await import("../server/backends/index.js");
+const cif = (tus, env = {}) => {
+  const saved = {}; for (const k in env) { saved[k] = process.env[k]; process.env[k] = env[k]; }
+  try { return clangdIndexFlags("/r", tus); }
+  finally { for (const k in env) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; } }
+};
+const ixFull = cif(100), ixSafe = cif(8000), ixOff = cif(20000);
+const idxTierOk =
+  ixFull.mode === "full" && ixFull.backgroundIndex === true && ixFull.priority === "normal" && ixFull.warmCapMax === Infinity && ixFull.jobs >= 2 &&
+  ixSafe.mode === "safe" && ixSafe.backgroundIndex === true && ixSafe.priority === "background" && ixSafe.jobs === 2 && Number.isFinite(ixSafe.warmCapMax) &&
+  ixOff.mode === "off" && ixOff.backgroundIndex === false && ixOff.jobs === 2 &&                       // > hard → whole-tree crawl disabled
+  cif(20000, { VTS_CLANGD_BG_INDEX: "1" }).mode === "full" &&                                          // force ON
+  cif(100, { VTS_CLANGD_BG_INDEX: "0" }).mode === "off" &&                                             // force OFF
+  cif(100, { VTS_CLANGD_INDEX_PRIORITY: "low" }).priority === "low" &&                                 // priority override wins
+  cif(20000, { VTS_CLANGD_JOBS: "3" }).jobs === 3 &&                                                   // jobs override wins
+  cif(8000, { VTS_CLANGD_BG_INDEX_SOFT_TUS: "9000" }).mode === "full" &&                               // raise soft → back to full
+  cif(8000, { VTS_CLANGD_BG_INDEX_HARD_TUS: "5000" }).mode === "off";                                  // lower hard → off
+// advisory text: force off/safe on a tiny tmp compile DB by lowering the thresholds, assert the bounded-fix steer.
+let idxAdvisoryOk;
+{
+  const idir = path.join(os.tmpdir(), `vts-eval-${process.pid}-idxmode`);
+  fs.mkdirSync(idir, { recursive: true });
+  fs.writeFileSync(path.join(idir, "compile_commands.json"), JSON.stringify(Array.from({ length: 50 }, (_, i) => ({ file: `a${i}.cpp`, directory: idir, command: "clang a.cpp" }))));
+  process.env.VTS_CLANGD_BG_INDEX_SOFT_TUS = "10"; process.env.VTS_CLANGD_BG_INDEX_HARD_TUS = "40"; // 50 TUs → off
+  const advOff = clangdIndexModeAdvisory(idir);
+  process.env.VTS_CLANGD_BG_INDEX_HARD_TUS = "100"; // 50 TUs now in 10..100 → safe
+  const advSafe = clangdIndexModeAdvisory(idir);
+  delete process.env.VTS_CLANGD_BG_INDEX_SOFT_TUS; delete process.env.VTS_CLANGD_BG_INDEX_HARD_TUS;
+  const advFull = clangdIndexModeAdvisory(idir); // default thresholds, 50 TUs → full → no advisory
+  idxAdvisoryOk = /index is OFF/.test(advOff) && /vts setup --scope/.test(advOff) && /syntactic tier/.test(advOff) &&
+    /THROTTLED/.test(advSafe) && /vts setup --scope/.test(advSafe) && advFull === "";
+  try { fs.rmSync(idir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+const idxPolicyOk = idxTierOk && idxAdvisoryOk;
+
 // 56) vts_setup genCompileDb — setup can kick off the compile-DB generation in the same step (so the user
 // doesn't have to find the separate vts_gen_compile_db tool): `true` = DRY-RUN (prints the UBT command, runs
 // nothing), "apply" = run UBT. Wiring test: the section appears with the GenerateClangDatabase command and
@@ -2328,6 +2368,7 @@ const rows = [
   ["edit-steer hook: L1 warn (replace/insert) + L2 safe-insert escalation", editHookOk, "true", editHookOk],
   ["per-file-language backend (.py→pyright in a clangd-rooted mixed repo)", backendPathOk, "true", backendPathOk],
   ["census fallback: path-less search_symbol retries OTHER backends present in the mixed repo (census-desc, gated)", censusFallbackOk, "true", censusFallbackOk],
+  ["clangd bg-index OOM guard: tiered full/safe/off by effective TU count + env overrides + scope advisory", idxPolicyOk, "true", idxPolicyOk],
   ["vts_setup genCompileDb: generates the compile DB in the setup step (dry)", setupGenOk, "true", setupGenOk],
   ["vts_setup clangdCmd: persists the clangd-binary path to config", setupClangdOk, "true", setupClangdOk],
   ["search_text → symbol steer (find_references on a `<Type>`/symbol hunt)", textSteerOk, "true", textSteerOk],

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1158,6 +1158,24 @@ const backendPathOk =
   preferBackend("", "typescript", "") === "typescript" &&      // no forced backend → the file's backend
   preferBackend("", null, "") === "";                          // nothing resolvable → "" (caller does pickBackend(root))
 
+// 90) CENSUS-BASED multi-backend fallback for a PATH-LESS search_symbol: the bug is that preferBackend keeps the
+// forced/root backend (clangd in a UE tree) for a name-only query, so a Python tooling dir in the SAME repo is
+// invisible (clangd answers 0, model gives up). censusFallbackBackends consults the language census and returns
+// the OTHER backends with files, most-code-first, so the empty-result branch can retry against the right LSP.
+// Pure with an injected census (no fs). Gated to count ≥ VTS_CENSUS_FALLBACK_MIN; VTS_CENSUS_FALLBACK=0 disables.
+const { censusFallbackBackends } = await import("../server/core.js");
+const _cf = (primary, census, env = {}) => {
+  const saved = {}; for (const k in env) { saved[k] = process.env[k]; process.env[k] = env[k]; }
+  try { return censusFallbackBackends("/r", primary, census); }
+  finally { for (const k in env) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; } }
+};
+const censusFallbackOk =
+  JSON.stringify(_cf("clangd", { clangd: 100, pyright: 5, typescript: 0, roslyn: 0 })) === JSON.stringify(["pyright"]) && // 0-count excluded, primary excluded
+  JSON.stringify(_cf("clangd", { clangd: 100, pyright: 5, typescript: 20, roslyn: 0 })) === JSON.stringify(["typescript", "pyright"]) && // census-desc order
+  _cf("pyright", { clangd: 0, pyright: 100, typescript: 0, roslyn: 0 }).length === 0 && // no OTHER language present → no fallback
+  JSON.stringify(_cf("clangd", { clangd: 100, pyright: 5, typescript: 20 }, { VTS_CENSUS_FALLBACK_MIN: "10" })) === JSON.stringify(["typescript"]) && // min raised → pyright:5 dropped
+  _cf("clangd", { clangd: 100, pyright: 5 }, { VTS_CENSUS_FALLBACK: "0" }).length === 0; // kill switch
+
 // 56) vts_setup genCompileDb — setup can kick off the compile-DB generation in the same step (so the user
 // doesn't have to find the separate vts_gen_compile_db tool): `true` = DRY-RUN (prints the UBT command, runs
 // nothing), "apply" = run UBT. Wiring test: the section appears with the GenerateClangDatabase command and
@@ -2309,6 +2327,7 @@ const rows = [
   ["edit-steer: search EDIT_STEER (toggle) + discover counts whole-decl Edit", editSteerOk, "true", editSteerOk],
   ["edit-steer hook: L1 warn (replace/insert) + L2 safe-insert escalation", editHookOk, "true", editHookOk],
   ["per-file-language backend (.py→pyright in a clangd-rooted mixed repo)", backendPathOk, "true", backendPathOk],
+  ["census fallback: path-less search_symbol retries OTHER backends present in the mixed repo (census-desc, gated)", censusFallbackOk, "true", censusFallbackOk],
   ["vts_setup genCompileDb: generates the compile DB in the setup step (dry)", setupGenOk, "true", setupGenOk],
   ["vts_setup clangdCmd: persists the clangd-binary path to config", setupClangdOk, "true", setupClangdOk],
   ["search_text → symbol steer (find_references on a `<Type>`/symbol hunt)", textSteerOk, "true", textSteerOk],

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -249,6 +249,63 @@ function nodeLspBackend(binJs, cmdOverride, globalName, argsEnv, rest) {
 const TS_BIN = resolveBinJs("typescript-language-server", "typescript-language-server");
 const PY_BIN = resolveBinJs("pyright", "pyright-langserver");
 
+// Count TUs in the EFFECTIVE (post-scope) compile DB — exactly what clangd would background-index. No DB
+// (uproject-only) → 0 (clangd has nothing to crawl). Cheap: one JSON read of the file clangd already reads.
+export function effectiveTuCount(root) {
+  const dir = effectiveCdbDir(root);
+  if (!dir) return 0;
+  try {
+    const e = JSON.parse(fs.readFileSync(path.join(dir, "compile_commands.json"), "utf8"));
+    return Array.isArray(e) ? e.length : 0;
+  } catch { return 0; }
+}
+
+// TIERED, resource-aware clangd background-index policy. Live OOM incident: a ~26k-TU UNSCOPED Unreal tree,
+// indexed at `normal` priority across all cores (our latency tuning), ate 18GB+ RAM and starved every core on
+// a single read_symbol. The latency defaults are correct on a BOUNDED tree but catastrophic on a huge unscoped
+// one. So scale indexing aggression to the EFFECTIVE (post-scope) TU count — scoping a big tree drops it below
+// the threshold and restores full speed automatically:
+//   • ≤ soft (4000)         → FULL: --background-index, priority=normal, -j=cores-1 (unchanged fast path)
+//   • soft..hard (4k..15k)  → SAFE: --background-index, priority=background (idle-CPU-only), -j=2 (slow, low peak)
+//   • > hard (15000)        → OFF:  no --background-index — open-file parsing only (read_symbol/hover/outline stay
+//                             cheap), search_symbol/find_references fall to the syntactic tier; advise scoping.
+// A prebuilt static --index-file still loads in OFF mode (memory-mapped, no crawl) → full semantic search with
+// zero RAM blowup once `vts preindex --static` has run. Env escape hatches: VTS_CLANGD_BG_INDEX=0/1 forces
+// off/full; VTS_CLANGD_INDEX_PRIORITY / VTS_CLANGD_JOBS still override the per-tier defaults. `tusArg` injectable
+// for the eval. The warm-up open-set is clamped in SAFE/OFF too (opening many UE TUs is itself a parse spike).
+export function clangdIndexFlags(root, tusArg) {
+  const cores = Math.max(2, (os.cpus()?.length || 4) - 1);
+  const tus = Number.isFinite(tusArg) ? tusArg : effectiveTuCount(root);
+  const soft = envInt("VTS_CLANGD_BG_INDEX_SOFT_TUS", 4000);
+  const hard = envInt("VTS_CLANGD_BG_INDEX_HARD_TUS", 15000);
+  let mode = tus > hard ? "off" : tus > soft ? "safe" : "full";
+  const force = env("VTS_CLANGD_BG_INDEX");
+  if (force != null && /^(0|false|off|no)$/i.test(String(force))) mode = "off";
+  else if (force != null && /^(1|true|on|yes)$/i.test(String(force))) mode = "full";
+  const prioOv = env("VTS_CLANGD_INDEX_PRIORITY");
+  const jobsOv = parseInt(env("VTS_CLANGD_JOBS"), 10);
+  const priority = prioOv || (mode === "full" ? "normal" : "background");
+  const jobs = Number.isFinite(jobsOv) && jobsOv > 0 ? jobsOv : (mode === "full" ? cores : Math.min(2, cores));
+  const warmCapMax = mode === "full" ? Infinity : envInt("VTS_CLANGD_HUGE_WARM_CAP", 8);
+  return { mode, backgroundIndex: mode !== "off", priority, jobs, warmCapMax, tus };
+}
+
+// One-line advisory surfaced in clangd results when the tree is large enough that background indexing was
+// throttled (SAFE) or disabled (OFF) — names the bounded fix so the model/user knows search degraded ON PURPOSE.
+export function clangdIndexModeAdvisory(root) {
+  let ix; try { ix = clangdIndexFlags(root); } catch { return ""; }
+  if (ix.mode === "safe") {
+    return `⚠ clangd: ${ix.tus} TUs (unscoped/large) — background index THROTTLED (idle CPU, -j=${ix.jobs}) to protect RAM/CPU. ` +
+      `For full-speed semantic search, scope it: \`vts setup --scope <module>\` then \`vts preindex\`.`;
+  }
+  if (ix.mode === "off") {
+    return `⚠ clangd: ${ix.tus} TUs (unscoped/very large) — project background index is OFF to protect RAM (a single open would otherwise crawl every TU). ` +
+      `Single-file ops (read_symbol/hover/outline) still work; project-wide search_symbol/find_references fall back to the syntactic tier. ` +
+      `Enable bounded semantic search: \`vts setup --scope <module>\` then \`vts preindex\` (or \`vts preindex --static\` for a project-wide index with no live crawl).`;
+  }
+  return "";
+}
+
 export const BACKENDS = {
   // C/C++ via clangd (LLVM). Needs compile_commands.json (Unreal: generate via UBT
   // `-mode=GenerateClangDatabase`, or CMake `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`). LIVE-TARGET.
@@ -257,18 +314,22 @@ export const BACKENDS = {
     args: (root) => {
       const ov = splitArgs(env("VTS_CLANGD_ARGS"));
       if (ov) return ov;
+      // TIERED background-index policy (see clangdIndexFlags): FULL on a bounded/scoped tree (the latency-
+      // optimised default), THROTTLED or OFF on a huge unscoped one so a single query can't crawl 26k TUs at
+      // full power and OOM the box. priority/jobs scale with the effective TU count; env still overrides.
+      const ix = clangdIndexFlags(root);
       const a = [
         // --compile-commands-dir only tells clangd where to FIND compile_commands.json (out-of-tree home
         // or in-tree); it does NOT relocate the index. clangd has no index-dir flag — it persists its
         // background index in `<project>/.cache/clangd` (in-tree), reused across spawns for warm speed.
         `--compile-commands-dir=${effectiveCdbDir(root) || root}`,
-        "--background-index",
-        // Default priority is `background` = MINIMUM, idle-CPU-only — so a fresh index crawls (a big reason
-        // the first query felt far slower than a warm IDE like Rider). We want it built NOW; `normal` lets
-        // it use real CPU. Override with VTS_CLANGD_INDEX_PRIORITY (e.g. `background` to be a good citizen).
-        `--background-index-priority=${env("VTS_CLANGD_INDEX_PRIORITY", "normal")}`,
-        // More async workers → faster background indexing (default is conservative). Cap at the box's cores.
-        `-j=${Math.max(2, parseInt(env("VTS_CLANGD_JOBS", String(Math.max(2, (os.cpus()?.length || 4) - 1))), 10) || 4)}`,
+        // FULL/SAFE keep --background-index (SAFE just at idle priority + few jobs); OFF disables the
+        // whole-tree crawl entirely — open-file parsing still works, and a static --index-file still loads.
+        ...(ix.backgroundIndex
+          ? ["--background-index", `--background-index-priority=${ix.priority}`]
+          : ["--background-index=false"]),
+        // Async workers: cores-1 on FULL (fast), 2 on SAFE/OFF (low peak parse RAM). Caps at the box's cores.
+        `-j=${ix.jobs}`,
         "--header-insertion=never",
       ];
       // Prebuilt STATIC index (clangd-indexer output): load it directly via --index-file — a local file, no
@@ -302,7 +363,11 @@ export const BACKENDS = {
       // Open just a small nudge set so clangd starts loading; the full project is already in the index.
       // (A cold project with NO index still opens the full cap to force the first dynamic index.)
       const persisted = hasPersistedIndex(root);
-      const cap = persisted ? Math.min(warmCap(root, "clangd", "VTS_CLANGD_OPEN_CAP", 100), envInt("VTS_CLANGD_WARM_CAP_PERSISTED", 8)) : warmCap(root, "clangd", "VTS_CLANGD_OPEN_CAP", 100);
+      // Clamp the warm-up open-set to the tier cap: in SAFE/OFF mode, opening many UE TUs (each a full parse)
+      // is itself a RAM spike — even with background indexing throttled/off. FULL mode → Infinity (no clamp).
+      const tierCap = clangdIndexFlags(root).warmCapMax;
+      const baseCap = persisted ? Math.min(warmCap(root, "clangd", "VTS_CLANGD_OPEN_CAP", 100), envInt("VTS_CLANGD_WARM_CAP_PERSISTED", 8)) : warmCap(root, "clangd", "VTS_CLANGD_OPEN_CAP", 100);
+      const cap = Math.min(baseCap, tierCap);
       // Order the open-set by likely-query-first (query-history > git-recency > mtime), then cap — this
       // steers clangd's IndexBoostedFile priority so the warm window covers what the dev actually queries.
       const open = orderForWarm(root, [...new Set([...files, ...extra])], cap);

--- a/server/core.js
+++ b/server/core.js
@@ -11,7 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync, execSync } from "node:child_process";
 import { LspClient, fromUri, langIdForPath, envInt, canonFsPath } from "./lsp.js";
-import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot, effectiveCdbDir, scopeDirsFor, buildStaticIndex, hasClangdIndexer, indexerEnabled } from "./backends/index.js";
+import { pickBackend, BACKENDS, clangdAdvisory, dbDirFor, resolveCdbDir, hasPersistedIndex, findProjectRoot, effectiveCdbDir, scopeDirsFor, buildStaticIndex, hasClangdIndexer, indexerEnabled, clangdIndexModeAdvisory } from "./backends/index.js";
 import { scopeStats, inScope } from "./scope.js";
 import { recordQueryResults, languageCensus, histRank } from "./warmset.js";
 import { splitSegments } from "./shell-split.js";
@@ -970,11 +970,15 @@ export function ensureDbIgnored(root, patterns = DB_IGNORES) {
   return notes;
 }
 let _dbAdvisoryShown = false;
+let _idxModeShown = false;
 function backendAdvisory(backendName, root) {
   if (backendName !== "clangd") return "";
   let s = "";
   if (!_advisoryShown) { const a = clangdAdvisory(BACKENDS.clangd.cmd); if (a) { _advisoryShown = true; s += a + "\n\n"; } }
   if (!_dbAdvisoryShown && root) { const d = compileDbAdvisory(root); if (d) { _dbAdvisoryShown = true; s += d + "\n\n"; } }
+  // Background-index tier advisory (huge tree → throttled/off to protect RAM). One-time per process so it
+  // doesn't repeat on every clangd result, but loud enough that a degraded search isn't mistaken for a miss.
+  if (!_idxModeShown && root) { const m = clangdIndexModeAdvisory(root); if (m) { _idxModeShown = true; s += m + "\n\n"; } }
   return s;
 }
 

--- a/server/core.js
+++ b/server/core.js
@@ -106,6 +106,23 @@ export function preferBackend(aBackend, byPath, forced) {
   return aBackend || (byPath && forced && byPath !== forced ? byPath : forced) || byPath || "";
 }
 
+// Census-based multi-backend fallback for a PATH-LESS search_symbol. A name-only query has no `path` to drive
+// backendForPath, so preferBackend keeps the forced/root backend (clangd in a UE tree). A DIFFERENT language
+// in the SAME repo — a Python tooling dir, a JS side-project — is then structurally invisible: the query is
+// sent to clangd, finds nothing, and the model gives up on vts. So when the primary backend misses, consult
+// the language census and retry against the OTHER backends that actually have files here, most-code-first.
+// Returns the candidate backend names (excluding `primary`, count ≥ VTS_CENSUS_FALLBACK_MIN), census-desc.
+// `census` is injectable for the eval. VTS_CENSUS_FALLBACK=0 disables; only fired on a path-less, non-explicit
+// query (a deliberate `path=`/`backend=` choice is never second-guessed).
+export function censusFallbackBackends(root, primary, census) {
+  if (/^(0|false|off|no)$/i.test(String(process.env.VTS_CENSUS_FALLBACK ?? "1"))) return [];
+  const min = envInt("VTS_CENSUS_FALLBACK_MIN", 1);
+  const c = census || languageCensus(root);
+  return ["clangd", "roslyn", "typescript", "pyright"]
+    .filter((b) => b !== primary && (c[b] || 0) >= min)
+    .sort((x, y) => (c[y] || 0) - (c[x] || 0));
+}
+
 // Perforce auto-checkout for a symbol-edit / rename APPLY. A symbol edit writes via `fs` directly (it bypasses
 // the built-in Edit/Write tool, so a p4-checkout PreToolUse hook never fires for it). In a P4 workspace an
 // unopened file is READ-ONLY, so before writing a read-only file we run `p4 edit` to open it for edit. Gated ON
@@ -2416,6 +2433,23 @@ export async function runTool(name, a = {}) {
 
     if (name === "search_symbol") {
       if (!a.q) return err("search_symbol needs q (the symbol name/substring).");
+      // Render a successful symbol hit set — shared by the primary path and the census fallback below, so a
+      // mixed-repo fallback result gets the SAME focus/tee/steer/cert treatment as a primary hit.
+      const renderFoundSymbols = (syms, bname, advB, note = "") => {
+        const focusN = focusCap(String(a.q), syms, max);
+        const symTee = teeOverflow("search_symbol", a.q, syms.map((s) => `${s.name} @ ${locLine(s.location.uri, s.location.range)}`), focusN);
+        const symEdit = editSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10) ? EDIT_STEER : ""; // focused lookup → likely an edit precursor
+        // Found the declaration(s); the other natural next step is "where is it USED?" — point at find_references
+        // by NAME (semantic call sites) so the model doesn't fall back to a grep for usages. Focused result only.
+        const symUses = usesSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10)
+          ? `\n↪ Where is "${a.q}" USED? find_references symbol="${a.q}" (all call sites, semantic) — add direction=callers for the caller tree.`
+          : "";
+        const focusNote = focusN < max && focusN < syms.length ? ` — showing the ${focusN} best for an exact-name hit (raise maxResults or VTS_FOCUS=0 for all ${syms.length})` : "";
+        const symCert = completenessCert({ shown: Math.min(focusN, syms.length), total: syms.length, truncated: focusN < syms.length ? "cap" : null, semantic: true, scoped: scopeDirsFor(root).length > 0 });
+        const symBody = advB + `${syms.length} symbol(s) matching "${a.q}" (backend: ${bname}, root: ${root})${note}${focusNote}${symTee}:\n` + fmtSymbols(syms, focusN) + symEdit + symUses + symCert;
+        maybeCounterfactual("search_symbol", String(a.q), root, syms.map((s) => s.location), symBody);
+        return finishOut(syms, symBody);
+      };
       const c = await getClient(root, backendName);
       const persisted = backendName === "clangd" && hasPersistedIndex(root);
       const syms0 = await symbolReady(c, String(a.q), persisted, envInt("VTS_CLANGD_PERSISTED_WAIT_MS", 60000));
@@ -2426,6 +2460,25 @@ export async function runTool(name, a = {}) {
       const syms = histMap ? rankSymbols(String(a.q), syms0, histMap) : syms0;
       const adv = backendAdvisory(backendName, root);
       if (!syms.length) {
+        // CENSUS-BASED MULTI-BACKEND FALLBACK (path-less, non-explicit query only): the primary backend (the
+        // forced/root one) missed, but a DIFFERENT language present in this MIXED repo would never be tried —
+        // preferBackend keeps the forced backend with no `path` to override it, so a Python tooling dir under a
+        // UE C++ tree is structurally invisible. Retry against the OTHER backends the census shows have files,
+        // most-code-first, and return the FIRST semantic hit — still the EXACT rung, just from the right
+        // language server. A query carrying a `path` or an explicit `backend=` is a deliberate choice → kept.
+        if (!a.path && !a.backend) {
+          for (const fb of censusFallbackBackends(root, backendName)) {
+            try {
+              const cfb = await getClient(root, fb);
+              const persistedFb = fb === "clangd" && hasPersistedIndex(root);
+              const symsFb0 = await symbolReady(cfb, String(a.q), persistedFb, envInt("VTS_CLANGD_PERSISTED_WAIT_MS", 60000));
+              if (!symsFb0.length) continue;
+              try { recordQueryResults(root, symsFb0.map((s) => fromUri(s.location.uri))); } catch { /* best-effort */ }
+              const symsFb = histMap ? rankSymbols(String(a.q), symsFb0, histMap) : symsFb0;
+              return renderFoundSymbols(symsFb, fb, backendAdvisory(fb, root), ` — mixed-repo fallback, ${backendName} had no match`);
+            } catch { /* this backend failed to spawn/answer — try the next census candidate */ }
+          }
+        }
         // tsserver / pyright answer workspace/symbol from the files they have OPEN/indexed, so a symbol
         // whose file the warm-up didn't open (or a non-exported local) can come back empty even though it
         // exists. Fall back to a bounded literal text search so it's still locatable (clangd/roslyn index
@@ -2455,20 +2508,8 @@ export async function runTool(name, a = {}) {
           : "";
         return finishOut([], adv + `No symbols matching "${a.q}" (backend: ${backendName}).` + EMPTY_HINT + clangdIndexAdvisory(backendName, root, null) + emptyCert + intentSteer);
       }
-      // confidence-adaptive focus: an exact-name match in a big set → show it + a few, not the whole tail.
-      const focusN = focusCap(String(a.q), syms, max);
-      const symTee = teeOverflow("search_symbol", a.q, syms.map((s) => `${s.name} @ ${locLine(s.location.uri, s.location.range)}`), focusN);
-      const symEdit = editSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10) ? EDIT_STEER : ""; // focused lookup → likely an edit precursor
-      // Found the declaration(s); the other natural next step is "where is it USED?" — point at find_references
-      // by NAME (semantic call sites) so the model doesn't fall back to a grep for usages. Focused result only.
-      const symUses = usesSteerOn() && syms.length <= envInt("VTS_EDIT_STEER_MAX", 10)
-        ? `\n↪ Where is "${a.q}" USED? find_references symbol="${a.q}" (all call sites, semantic) — add direction=callers for the caller tree.`
-        : "";
-      const focusNote = focusN < max && focusN < syms.length ? ` — showing the ${focusN} best for an exact-name hit (raise maxResults or VTS_FOCUS=0 for all ${syms.length})` : "";
-      const symCert = completenessCert({ shown: Math.min(focusN, syms.length), total: syms.length, truncated: focusN < syms.length ? "cap" : null, semantic: true, scoped: scopeDirsFor(root).length > 0 });
-      const symBody = adv + `${syms.length} symbol(s) matching "${a.q}" (backend: ${backendName}, root: ${root})${focusNote}${symTee}:\n` + fmtSymbols(syms, focusN) + symEdit + symUses + symCert;
-      maybeCounterfactual("search_symbol", String(a.q), root, syms.map((s) => s.location), symBody);
-      return finishOut(syms, symBody);
+      // confidence-adaptive focus + steers + cert (shared with the census fallback above).
+      return renderFoundSymbols(syms, backendName, adv);
     }
     if (name === "find_references") {
       const c = await getClient(root, backendName);

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vs-token-safer",
-  "version": "0.37.3",
+  "version": "0.38.0",
   "type": "module",
   "description": "Sits between an LLM coding agent and your repository and answers where/what/how questions with a short file:line list instead of raw source. It uses a real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a no-embeddings fuzzy search built from the repo's own naming when you don't know the exact name. It section-edits Markdown and config files the same way. Local-only, nothing transmitted. CLI + MCP. No IDE required.",
   "keywords": [

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vs-token-safer",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "type": "module",
   "description": "Sits between an LLM coding agent and your repository and answers where/what/how questions with a short file:line list instead of raw source. It uses a real language server when it can (clangd / Roslyn / tsserver / pyright), tree-sitter when there's no toolchain, and a no-embeddings fuzzy search built from the repo's own naming when you don't know the exact name. It section-edits Markdown and config files the same way. Local-only, nothing transmitted. CLI + MCP. No IDE required.",
   "keywords": [


### PR DESCRIPTION
## Summary

Hotfix for the live OOM incident: a single `read_symbol` on a ~26k-TU unscoped Unreal tree pinned all cores and consumed 18GB+ RAM because the latency tuning (`--background-index-priority=normal`, `-j=cores-1`) was applied unconditionally. The fix scales clangd's indexing aggression to the effective (post-scope) TU count:

| Effective TUs | Mode | Behavior |
|---|---|---|
| ≤ 4000 | FULL | unchanged fast path |
| 4k–15k | SAFE | idle priority, -j=2 |
| > 15000 | OFF | no whole-tree crawl; single-file ops work; project search → syntactic tier |

Scoping drops the tree under the threshold and restores full speed. One-time advisory in clangd results names the fix (`vts setup --scope <module>` → `vts preindex`).

All env overrides preserved: `VTS_CLANGD_BG_INDEX=0/1`, `_SOFT_TUS`, `_HARD_TUS`, `VTS_CLANGD_INDEX_PRIORITY`, `VTS_CLANGD_JOBS`, `VTS_CLANGD_HUGE_WARM_CAP`.

## CI
- Eval guard 92 (tier matrix + overrides + advisory text)
- Node 18/20/22 × Ubuntu+Windows — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)