### PR TITLE
P3 measurement: discover token-free detail dump + read-side steer (H1)

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1921,7 +1921,7 @@ const scopeOk = scResolveOk && scInOk && scEmptyAllOk && scPruneOk && scStatsOk 
 // 80) unified tool-routing policy — vts COMPLEMENTS Claude Code's native tools. shouldSuppressSteer stays
 // silent on generated/build-output paths (CC-native is fine there); routingDigest is the single
 // when-to-use-what decision tree + live adoption posture re-injected at SessionStart.
-const { shouldSuppressSteer, routingDigest, suppressOn } = await import("../server/policy.js");
+const { shouldSuppressSteer, routingDigest, suppressOn, readSteerDecision } = await import("../server/policy.js");
 const supGen = shouldSuppressSteer("/p/Intermediate/Build/Foo.gen.cpp") === true;   // build output → suppress
 const supDotGen = shouldSuppressSteer("/p/Source/Foo.generated.h") === true;        // generated header → suppress
 const supNodeMod = shouldSuppressSteer("/p/node_modules/x/y.js") === true;          // vendored dep → suppress
@@ -1936,7 +1936,19 @@ const digOk = /Tool routing/.test(dig) && /COMPLEMENTARY/.test(dig) && /--scope/
 // vs all-time 2/10=20% — the live signal the steer loop can actually move.
 const dig2 = routingDigest({ builtin: 8, symbol: 2, recent: ["s", "s", "s", "s", "b"], mod: { warn: { shown: 0, converted: 0 }, block: { shown: 0, converted: 0 } } });
 const digRecentOk = /adoption 20% \(2\/10\), recent 80%/.test(dig2);
-const policyOk = supGen && supDotGen && supNodeMod && supReal && supOff && digOk && digRecentOk;
+// READ-SIDE steer (H1): a LARGE code-file whole-read nudges toward read_symbol / symbol-edit; tight-gated so it
+// never nags a small file, a non-code file, a generated path, or an already-sliced (offset/limit) read.
+const rsBig = readSteerDecision("/p/Source/Big.cpp", 20000);                        // large code file → steer
+const rsReadOk = !!rsBig && /read_symbol/.test(rsBig) &&
+  readSteerDecision("/p/Source/Small.cpp", 1000) === null &&                        // small → null
+  readSteerDecision("/p/README.md", 20000) === null &&                              // non-code → null
+  readSteerDecision("/p/Source/Foo.generated.h", 20000) === null &&                 // generated → null
+  readSteerDecision("/p/Intermediate/Build/Big.cpp", 20000) === null &&             // build output → null
+  readSteerDecision("/p/Source/Big.cpp", 20000, { sliced: true }) === null;         // already a slice → null
+const rsTogglePrev = process.env.VTS_READ_STEER; process.env.VTS_READ_STEER = "0";
+const rsOff = readSteerDecision("/p/Source/Big.cpp", 20000) === null;               // toggle off
+if (rsTogglePrev === undefined) delete process.env.VTS_READ_STEER; else process.env.VTS_READ_STEER = rsTogglePrev;
+const policyOk = supGen && supDotGen && supNodeMod && supReal && supOff && digOk && digRecentOk && rsReadOk && rsOff;
 
 // 81) SYNTACTIC tier: tree-sitter declaration extraction (treesitter.js) + the committable symbol index
 // (symindex.js). The zero-setup fallback that works on any repo with no toolchain — a real AST decl, not a

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -36,7 +36,7 @@ import { splitSegments } from "../server/shell-split.js";
 // MEASURE; the adoption ledger is the live metric the steer is tuned against.
 import { classifyDeclEdit } from "../server/edit-detect.js";
 import { recordEditEvent, resetStreak, recordSteerShown, decideEscalation } from "../server/edit-ledger.js";
-import { shouldSuppressSteer } from "../server/policy.js";
+import { shouldSuppressSteer, readSteerDecision } from "../server/policy.js";
 
 const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(os.homedir(), ".vs-token-safer", "config.json");
 const readConfig = () => { try { return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8")) || {}; } catch { return {}; } };
@@ -644,6 +644,20 @@ process.stdin.on("end", () => {
       process.exit(2); // block — route the concrete code-file glob to find_files
     }
     else if (isCodeGlobTool(ti)) emitWarn(globNudgeFor(ti) + setup);
+    process.exit(0);
+  }
+
+  // Read — read-side steer (H1, warn-ONLY, never blocks): a whole-file Read of a LARGE code file is the dominant
+  // pre-edit token leak. Point it at read_symbol / the symbol-edit tools. Tight-gated in policy.readSteerDecision
+  // (code ext, not generated, not an already-sliced read, size ≥ threshold). VTS_READ_STEER=0 / matcher-removal off.
+  if (toolName === "Read") {
+    const fp = ti && ti.file_path;
+    if (fp) {
+      let sz = 0; try { sz = fs.statSync(fp).size; } catch { /* unreadable → leave 0 (no steer) */ }
+      const minB = Number(process.env.VTS_READ_STEER_MIN ?? 6000);
+      const s = sz ? readSteerDecision(fp, sz, { sliced: !!(ti.offset || ti.limit), minBytes: minB, ko: KO }) : null;
+      if (s) emitWarn(s + setup);
+    }
     process.exit(0);
   }
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -20,7 +20,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash|Grep|Glob|Edit|MultiEdit",
+        "matcher": "Bash|Grep|Glob|Edit|MultiEdit|Read",
         "hooks": [
           {
             "type": "command",

--- a/server/cli.js
+++ b/server/cli.js
@@ -97,7 +97,7 @@ Backends (auto-detected from the root, or set --backend / VTS_BACKEND):
 Settings precedence: env (VTS_*) > ~/.vs-token-safer/config.json > default.`;
 
 const LIST_FLAGS = new Set(["seeds", "entry", "roots"]);
-const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open", "static", "docs", "status", "flow", "allowCold", "build", "thorough", "reachability"]);
+const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open", "static", "docs", "status", "flow", "allowCold", "build", "thorough", "reachability", "detail"]);
 
 function parseArgs(argv) {
   const a = {};

--- a/server/core.js
+++ b/server/core.js
@@ -527,6 +527,7 @@ function scanBypasses(a = {}) {
   // Edit-habit measurement (A): count whole-declaration Edits on code files, and attribute the tokens of a
   // PRIOR Read of that same file — that read is what a symbol-edit (edit-by-name) would have skipped.
   let editCount = 0, editReadTok = 0, editUnreached = 0; // editUnreached: whole-decl edits with NO prior vts
+  const editDetails = []; // per-edit records (file, kind, readTok, priorSearch) — for the local detail dump (token-free counterfactual input)
   // search on that file → the EDIT_STEER (which only rides a search_symbol/goto result) could never have
   // reached them. A high fraction is the case for a harder lever (a warn on the Edit itself).
   const reads = new Map();      // normalized file → tokens of its most recent Read result (per transcript)
@@ -552,7 +553,7 @@ function scanBypasses(a = {}) {
           const m = matchBypass(b.name, b.input); if (m) cand.set(b.id, m);
           if (b.name === "Read" && b.input && b.input.file_path) readUse.set(b.id, String(b.input.file_path).replace(/\\/g, "/").toLowerCase());
           else if (/(?:search_symbol|goto_definition|find_references)$/.test(String(b.name || ""))) searchUse.set(b.id, true);
-          else { const ce = classifyDeclEdit(b.name, b.input, envInt("VTS_EDIT_MIN_LINES", 8)); if (ce.file && (ce.replaceDecl || ce.insertDecl)) { editCount++; if (reads.has(ce.file)) { editReadTok += reads.get(ce.file); reads.delete(ce.file); } if (!searchedBn.has(path.basename(ce.file))) editUnreached++; } } // attribute a read ONCE (a re-Read re-adds it); unreached = no prior vts search landed on this file
+          else { const ce = classifyDeclEdit(b.name, b.input, envInt("VTS_EDIT_MIN_LINES", 8)); if (ce.file && (ce.replaceDecl || ce.insertDecl)) { editCount++; let rtk = 0; if (reads.has(ce.file)) { rtk = reads.get(ce.file); editReadTok += rtk; reads.delete(ce.file); } const prior = searchedBn.has(path.basename(ce.file)); if (!prior) editUnreached++; editDetails.push({ file: ce.file, kind: ce.replaceDecl ? "replace" : "insert", readTok: rtk, priorSearch: prior }); } } // attribute a read ONCE (a re-Read re-adds it); unreached = no prior vts search landed on this file
         }
         else if (b && b.type === "tool_result" && readUse.has(b.tool_use_id)) {
           const f = readUse.get(b.tool_use_id); readUse.delete(b.tool_use_id);
@@ -586,7 +587,7 @@ function scanBypasses(a = {}) {
       }
     }
   }
-  return { missed, rawTokTotal, learned, filesCount: files.length, all, since, editCount, editReadTok, editUnreached };
+  return { missed, rawTokTotal, learned, filesCount: files.length, all, since, editCount, editReadTok, editUnreached, editDetails };
 }
 // Boot-time self-improvement: harvest the last `since` days of bypassed searches and record their result
 // files into the warm-set query-history — the same write `vts discover --learn` does, but automatic.
@@ -603,7 +604,7 @@ export function autoLearn(root, since = 7) {
 function discoverReport(a = {}) {
   const r = scanBypasses(a);
   if (r.error) return r.error;
-  const { missed, rawTokTotal, learned, filesCount: fc, all, since, editCount, editReadTok, editUnreached } = r;
+  const { missed, rawTokTotal, learned, filesCount: fc, all, since, editCount, editReadTok, editUnreached, editDetails } = r;
   // A: surface the edit habit alongside the search bypasses — whole-declaration Edits that could edit by name.
   // editUnreached = those with no prior vts search on the file → the EDIT_STEER (search-result-only) can't
   // reach them; a high fraction is the evidence for a harder lever (a warn on the Edit itself).
@@ -633,7 +634,22 @@ function discoverReport(a = {}) {
   const trueRate = caught + trueLeak > 0 ? (100 * caught / (caught + trueLeak)).toFixed(1) : "—";
   const trueLine = editReadTok ? `\n  true coverage (incl. edit-pre-reads): ~${caught.toLocaleString()} caught vs ~${trueLeak.toLocaleString()} leaking (search ${rawTokTotal.toLocaleString()} + edit-read ${editReadTok.toLocaleString()}) → ${trueRate}% — symbol-edit adoption is the real gap.` : "";
   const catchLine = `\n  catch-rate: ~${caught.toLocaleString()} tok caught (via vts) vs ~${rawTokTotal.toLocaleString()} still bypassing → ${rate}% of search tokens routed through vts` + trueLine;
-  if (!missed.length) return `vs-token-safer discover (${scope}, ${files.length} transcript(s)): no code searches bypassed vts. It's catching them. ✓` + catchLine + editLine + learnLine;
+  // Optional LOCAL detail dump (token-free): on `detail`/`out`, write the full per-bypass + per-edit records to
+  // a local JSONL the model NEVER sees — it feeds an OFFLINE counterfactual (e.g. how much of the edit-pre-read
+  // tokens a symbol-edit / read_symbol would actually have recovered). The report still surfaces only the summary.
+  let detailLine = "";
+  if (a.detail === true || a.detail === "true" || a.out) {
+    const outPath = typeof a.out === "string" && a.out ? a.out : path.join(os.homedir(), ".vs-token-safer", "discover-detail.jsonl");
+    try {
+      fs.mkdirSync(path.dirname(outPath), { recursive: true });
+      const recs = [JSON.stringify({ t: "meta", scope, transcripts: fc, editCount, editReadTok, editUnreached })]
+        .concat(missed.map((m) => JSON.stringify({ t: "search", tool: m.tool, q: m.q, rawTok: m.rawTok })))
+        .concat((editDetails || []).map((d) => JSON.stringify({ t: "edit", ...d })));
+      fs.writeFileSync(outPath, recs.join("\n") + "\n");
+      detailLine = `\n  ✓ wrote ${missed.length + (editDetails ? editDetails.length : 0)} detailed record(s) to ${outPath} (LOCAL only — not sent to the model; for offline counterfactual analysis).`;
+    } catch { /* best-effort */ }
+  }
+  if (!missed.length) return `vs-token-safer discover (${scope}, ${files.length} transcript(s)): no code searches bypassed vts. It's catching them. ✓` + catchLine + editLine + learnLine + detailLine;
   const byTool = {};
   for (const m of missed) byTool[m.tool] = (byTool[m.tool] || 0) + 1;
   const toolLine = Object.entries(byTool).sort((x, y) => y[1] - x[1]).map(([t, n]) => `${t}×${n}`).join(", ");
@@ -643,7 +659,7 @@ function discoverReport(a = {}) {
     `  ${missed.length} code search(es) bypassed vts (${toolLine})\n` +
     `  raw tool output ingested: ~${rawTokTotal.toLocaleString()} tok (~$${usd(rawTokTotal).toFixed(2)}) — routed through vts (file:line, capped) most of this is avoidable (typically 70–90% less)${catchLine}\n` +
     `  biggest:\n${top}\n` +
-    `  Fix: rewrite is on by default (Bash grep auto-reroutes to vts); for the Grep tool, prefer the vs-search MCP tools (search_symbol / search_text / find_files).${editLine}${learnLine}`;
+    `  Fix: rewrite is on by default (Bash grep auto-reroutes to vts); for the Grep tool, prefer the vs-search MCP tools (search_symbol / search_text / find_files).${editLine}${learnLine}${detailLine}`;
 }
 
 // ---- LSP client pool (one per root+backend; reused across calls in a process) ----

--- a/server/policy.js
+++ b/server/policy.js
@@ -24,6 +24,27 @@ export function shouldSuppressSteer(file) {
 const onOff = (v, d) => !/^(0|false|off|no)$/i.test(String(v ?? d));
 export function suppressOn() { return onOff(process.env.VTS_SUPPRESS, "1"); }
 
+// READ-SIDE steer (H1) — the dominant token leak is a whole-file Read of a LARGE code file BEFORE a one-decl
+// edit (discover, real data: ~66% of edit-pre-read tokens sit in reads ≥ ~1K tok, and ~86% of them had no prior
+// vts search so the search-result steer can't reach them — but a Read always has a target, so a READ-time steer
+// can). When the agent Reads a big code file whole, point it at read_symbol (reads ONE decl, capped) and the
+// symbol-edit tools (edit by name, no read). PURE decision — the hook supplies the byte size; warn-only, never
+// blocks a Read. Gated TIGHT to avoid nagging legitimate whole-file reads: code ext only, not generated/build,
+// not an already-sliced read (offset/limit), and at/above `minBytes`. Returns the nudge text or null.
+const READ_CODE_EXT = /\.(c|cc|cxx|cpp|h|hpp|hh|inl|ipp|tpp|cs|ts|tsx|mts|cts|js|jsx|mjs|cjs|py|pyi)$/i;
+export function readSteerOn() { return onOff(process.env.VTS_READ_STEER, "1"); }
+export function readSteerDecision(file, sizeBytes, { sliced = false, minBytes = 6000, ko = false } = {}) {
+  if (!readSteerOn() || !file) return null;
+  if (sliced) return null;                            // a partial read (offset/limit) is already a slice
+  if (!READ_CODE_EXT.test(String(file))) return null; // only code files (the syntactic/semantic tiers cover these)
+  if (shouldSuppressSteer(file)) return null;         // generated/build/vendored path — a symbol-read buys nothing
+  if (!(sizeBytes >= minBytes)) return null;          // small file: cheap to read whole, not worth a nudge
+  const kb = Math.round(sizeBytes / 1024);
+  return ko
+    ? `↪ vs-token-safer: 큰 코드파일(~${kb}KB)을 통째로 읽네요. 한 선언만 필요하면 read_symbol symbol="<name>" 이 그 선언만 반환(토큰캡)하고, 통째 편집이면 replace_symbol_body / insert_symbol 이 읽지 않고 이름으로 편집합니다. 끄기: VTS_READ_STEER=0.`
+    : `↪ vs-token-safer: reading a large code file (~${kb} KB) whole. If you only need ONE declaration, read_symbol symbol="<name>" returns just that decl (token-capped); for a whole-decl edit, replace_symbol_body / insert_symbol edit by name with no read. VTS_READ_STEER=0 to hide.`;
+}
+
 // The single routing digest. Always emits the decision tree (the integrative guidance); appends the live
 // adoption posture + adaptive-controller state when there is enough data.
 export function routingDigest(o = readEditLedger()) {


### PR DESCRIPTION
## Patch — P3 (edit-adoption) measurement + the read-side steer hypothesis

Two charter-pure additions toward the one remaining real leak `vts discover` surfaces (edit-pre-reads, not search). No new MCP surface; instrumentation + one soft hook nudge.

### Changes
- **discover token-free detail dump** — `vts discover --detail` / `vts_admin{op:"discover",detail:true}` / `out=<path>` writes the FULL per-bypass + per-edit records (`{file,kind,readTok,priorSearch}`) to a local JSONL the model never sees (it gets only a one-line pointer). Zero added model tokens (the scan was already a local file read). Feeds an offline counterfactual.
- **read-side steer (H1)** — the dominant leak is a whole-file Read of a LARGE code file before a one-decl edit; on real data ~66% of edit-pre-read tokens are in reads ≥ ~1K tok and ~86% had no prior vts search (so the search-result edit-steer can't reach them — but a Read always has a target). `policy.readSteerDecision` (pure, tight-gated: code ext, not generated/build, not an already-sliced read, size ≥ `VTS_READ_STEER_MIN` 6 KB) emits a warn-only nudge toward `read_symbol` / symbol-edit. Read added to the PreToolUse matcher; `VTS_READ_STEER=0` (or matcher removal) disables.

### Why these were measured first (the discipline)
The counterfactual on the real (UE-dominated) discover data showed the read-side angle is structurally the right one — 86% of recoverable tokens are B-unreachable but H1-reachable, and the leak is Pareto-concentrated in large reads (gateable). The edit-side persuasion lever (SMART/EvoTool) stays killed (SkillOpt ceiling); H1 validation is by discover over real sessions (instrumentation now in place), not a ceiling-prone rollout.

### Review points
- read-steer is **warn-only — never blocks a Read**. Cost: a per-Read hook spawn (matcher removal opts out entirely).
- The detail dump is local-only (mirrors the search-result tee pattern); model context untouched.
- `policy.readSteerDecision` is pure (the hook supplies the byte size) — guard 80 covers large→steer, small/non-code/generated/build/sliced/toggled-off→silent; i18n en/ko.

### Verification
- `node eval/run.mjs` → EVAL PASSED. lint clean. Live hook smoke: large code Read → steer (en+ko); small / sliced / generated → silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
