### PR TITLE
feat(code-locator): spawn-cost guard — direct vts tools for single lookups

### DIFF
--- a/agents/code-locator.md
+++ b/agents/code-locator.md
@@ -2,10 +2,14 @@
 name: code-locator
 description: >-
   Delegated, token-isolated code search for C/C++ (clangd), C#/.NET (Roslyn), JS/TS (tsserver), and Python
-  (pyright) projects — no IDE needed. Hand it "where is X defined", "what calls Y", "all usages of Z", "find
-  the file named W", "type info at this position", or "find this string in code" — it uses the official
-  language-server index (clangd / Roslyn / tsserver / pyright), not raw grep, and returns ONLY a compact
-  file:line table; the matched source never enters the caller's context. Use instead of grepping a codebase.
+  (pyright) projects — no IDE needed. SPAWN ONLY FOR MULTI-STEP EXPLORATION whose intermediate output would
+  flood the caller's context (mapping a directory, chasing a call chain across several files, cross-referencing
+  many candidates). For a SINGLE lookup ("where is X", "what calls Y", "find file W", "string in code"), do
+  NOT spawn this agent — call the `vs-search` MCP tools (search_symbol / find_references / read_symbol /
+  find_files / search_text) DIRECTLY: they already return a token-capped file:line table with no subagent
+  context overhead, so spawning here is pure net cost (extra system prompt + tool schemas) on a small query.
+  When spawned, it uses the official language-server index (clangd / Roslyn / tsserver / pyright), not raw
+  grep, and returns ONLY a compact file:line table; the matched source never enters the caller's context.
   Not for logs (use the gamedev-log analyzer).
 ---
 
@@ -15,6 +19,17 @@ You are a focused subagent. Your job: locate symbols / references / definitions 
 **compact `file:line` table**, doing the searching in *your* throwaway context so the caller's context
 stays small. Same idea as the token-cap, applied at the orchestration layer: a search that would have
 been thousands of grep lines comes back as a few dozen `file:line` rows.
+
+## When you should NOT exist (spawn gate)
+A subagent costs a fixed overhead (this system prompt + the re-sent tool schemas) the moment it spawns —
+which only pays off if the searching would otherwise dump a LOT of raw output into the caller's context.
+So **the caller should not spawn you for a single lookup.** If your whole task is one `search_symbol` /
+`find_references` / `find_files` / `search_text` call, the caller should have called that `vs-search` MCP
+tool directly (it already returns a token-capped `file:line` table — no subagent layer needed), and you are
+net cost. When that happens anyway: run the one query, return the rows, and **note in one line that this was
+a direct-tool case** so the caller stops delegating single lookups. You earn your overhead ONLY on
+multi-step work: mapping a directory, walking a call chain across files, or cross-referencing many
+candidates — where the intermediate output is large and stays in your throwaway context.
 
 ## Iron rules
 1. **Use the language-server index over Bash grep.** Call the `vs-search` MCP tools — they run the official

--- a/server/policy.js
+++ b/server/policy.js
@@ -56,6 +56,7 @@ export function routingDigest(o = readEditLedger()) {
     "  • ADD/REPLACE a whole decl → vts replace_symbol_body / insert_symbol (by name, skips the Read)",
     "  • doc/log, quick literal peek, JUST-edited or unindexed file, sub-decl tweak → CC-native Read/Grep/Edit",
     "  • big tree, slow first query → vts setup --scope <module>; vts preindex",
+    "  • SINGLE lookup → call vts tools DIRECTLY; spawn code-locator ONLY for multi-file exploration (a subagent adds context overhead a one-shot query can't repay)",
   ];
   if (pct !== null && total >= 3) {
     const hasSteer = (((o.mod || {}).warn || {}).shown || 0) + (((o.mod || {}).block || {}).shown || 0) > 0;


### PR DESCRIPTION
## Theme
Cut wasted tokens from spawning the `code-locator` subagent on lookups that don't need it.

## Why
A subagent costs a fixed overhead (its system prompt + re-sent tool schemas) the instant it spawns. That only repays when the search would otherwise dump a lot of raw output into the caller's context. A **single** lookup never does — the `vs-search` MCP tools already return a token-capped `file:line` table with no subagent layer. So delegating a one-shot `search_symbol`/`find_references` to code-locator is pure net cost.

## Changes
- **agents/code-locator.md** — `description` (the routing signal the orchestrator reads) now states: SPAWN ONLY for multi-step exploration whose intermediate output would flood context; for a SINGLE lookup call the vts MCP tools DIRECTLY. Added a **spawn-gate** body section so an erroneous spawn runs the one query, returns the rows, and flags itself as a direct-tool case (a learning signal so the caller stops delegating single lookups).
- **server/policy.js** — `routingDigest` gains a single-lookup bullet, reinforcing the same rule at SessionStart.

## Review points
- Pure guidance/routing change — no behavior in the search path itself.
- `routingDigest` eval guard unaffected; full eval green (41/41 + guards).
- Charter: description text adds a little tool-schema footprint, but a single avoided spawn dwarfs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
