### PR TITLE
feat(discover): agent-spawn accounting (A) + concrete read-steer nudge (B)

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1103,6 +1103,46 @@ const editDiscOk = !discEdit.isError && /1 whole-declaration Edit/.test(discEdit
 try { fs.rmSync(eProj, { recursive: true, force: true }); } catch { /* ignore */ }
 const editSteerOk = ssSteerOk && ssOffOk && editDiscOk;
 
+// 91) AGENT-SPAWN accounting (A): discover now sees agent SPAWNS — the dark surface where a code-locator/Explore
+// fleet outweighs any single search bypass. EXACT cost via the result entry's top-level toolUseResult.totalTokens
+// (fallback: the summary's tok count when absent). FLEET = ≥2 same-type in-window; HEAVY = a single spawn over the
+// threshold; WOULD-BE-DIRECT = a single-lookup-shaped description (advisory). Synthetic transcript, isolated dir.
+const aProj = path.join(os.tmpdir(), `vts-eval-${process.pid}-spawndisc`);
+fs.mkdirSync(path.join(aProj, "P--proj"), { recursive: true });
+const ANOW = new Date().toISOString();
+// a spawn is ASYNC: a tool_use launch, a tool_result that carries only the agentId (NO tokens), and a later
+// COMPLETION notification carrying `<task-id> … <subagent_tokens>N`. The token join is task-id === agentId.
+const spU = (id, desc) => JSON.stringify({ type: "assistant", cwd: aProj, timestamp: ANOW, message: { role: "assistant", content: [{ type: "tool_use", id, name: "Agent", input: { subagent_type: "code-locator", description: desc, prompt: "x" } }] } });
+const spLaunch = (id, agentId) => JSON.stringify({ type: "user", cwd: aProj, timestamp: ANOW, toolUseResult: { isAsync: true, status: "success", agentId }, message: { role: "user", content: [{ type: "tool_result", tool_use_id: id, content: "launched" }] } });
+const spDone = (agentId, toks) => JSON.stringify({ type: "user", cwd: aProj, timestamp: ANOW, message: { role: "user", content: [{ type: "text", text: `<task-notification><task-id>${agentId}</task-id><status>completed</status><usage><subagent_tokens>${toks}</subagent_tokens></usage></task-notification>` }] } });
+fs.writeFileSync(path.join(aProj, "P--proj", "t.jsonl"),
+  [spU("a1", "Audit OnUpdate states 1-100"), spLaunch("a1", "ag1"), spDone("ag1", 60000),        // two heavy code-locators in one window → fleet + 2 heavy; EXACT cost via the completion join
+   spU("a2", "Audit OnUpdate states 100-200"), spLaunch("a2", "ag2"), spDone("ag2", 55000),
+   // an Explore spawn whose launch result carries inline totalTokens (the sync fallback path) — single, small.
+   JSON.stringify({ type: "assistant", cwd: aProj, timestamp: ANOW, message: { role: "assistant", content: [{ type: "tool_use", id: "e1", name: "Agent", input: { subagent_type: "Explore", description: "map the dir", prompt: "x" } }] } }),
+   JSON.stringify({ type: "user", cwd: aProj, timestamp: ANOW, toolUseResult: { agentType: "Explore", totalTokens: 5000 }, message: { role: "user", content: [{ type: "tool_result", tool_use_id: "e1", content: "done" }] } }),
+  ].join("\n") + "\n");
+process.env.VTS_CLAUDE_PROJECTS = aProj;
+const discAgent = await runTool("vts_discover", { since: 7, agents: true });
+// fallback proxy + WOULD-BE-DIRECT advisory: a Task spawn with NO toolUseResult and a single-lookup description.
+fs.writeFileSync(path.join(aProj, "P--proj", "u.jsonl"),
+  [JSON.stringify({ type: "assistant", cwd: aProj, timestamp: ANOW, message: { role: "assistant", content: [{ type: "tool_use", id: "b1", name: "Task", input: { subagent_type: "code-locator", description: "where is Foo defined", prompt: "x" } }] } }),
+   JSON.stringify({ type: "user", cwd: aProj, timestamp: ANOW, message: { role: "user", content: [{ type: "tool_result", tool_use_id: "b1", content: "some result text" }] } }),
+  ].join("\n") + "\n");
+const discAgent2 = await runTool("vts_discover", { since: 7, agents: true });
+const aOffPrev = process.env.VTS_DISCOVER_AGENTS; process.env.VTS_DISCOVER_AGENTS = "0";
+const discAgentOff = await runTool("vts_discover", { since: 7, agents: true });
+if (aOffPrev === undefined) delete process.env.VTS_DISCOVER_AGENTS; else process.env.VTS_DISCOVER_AGENTS = aOffPrev;
+delete process.env.VTS_CLAUDE_PROJECTS;
+const agentDiscOk =
+  !discAgent.isError && /agent spawns: 3 spawn/.test(discAgent.text) &&
+  /code-locator ×2 \(~115,000\)/.test(discAgent.text) &&                          // EXACT cost joined from the completion notifications (60k+55k)
+  /Explore ×1 \(~5,000\)/.test(discAgent.text) &&                                 // inline-totalTokens fallback path
+  /fleets: 1/.test(discAgent.text) && /heavy: 2 single/.test(discAgent.text) &&   // both code-locators > 50k threshold
+  /advisory: 1/.test(discAgent2.text) &&                                          // "where is Foo defined" reads like a lookup (summary-approx tier)
+  !/agent spawns:/.test(discAgentOff.text);                                       // VTS_DISCOVER_AGENTS=0 hides the block
+try { fs.rmSync(aProj, { recursive: true, force: true }); } catch { /* ignore */ }
+
 // 54) edit-steer HOOK (L1 warn + L2 escalation): a whole-decl REPLACE/INSERT Edit gets a model-visible
 // nudge with a ready symbol-edit call; a sub-decl tweak / non-code file / VTS_EDIT_WARN=0 stays silent. L2:
 // once the adoption ledger's ignore-streak hits VTS_EDIT_BLOCK_AFTER, a SAFE insert is BLOCKED (a replace
@@ -1921,7 +1961,7 @@ const scopeOk = scResolveOk && scInOk && scEmptyAllOk && scPruneOk && scStatsOk 
 // 80) unified tool-routing policy — vts COMPLEMENTS Claude Code's native tools. shouldSuppressSteer stays
 // silent on generated/build-output paths (CC-native is fine there); routingDigest is the single
 // when-to-use-what decision tree + live adoption posture re-injected at SessionStart.
-const { shouldSuppressSteer, routingDigest, suppressOn, readSteerDecision } = await import("../server/policy.js");
+const { shouldSuppressSteer, routingDigest, suppressOn, readSteerDecision, topLevelDeclNames } = await import("../server/policy.js");
 const supGen = shouldSuppressSteer("/p/Intermediate/Build/Foo.gen.cpp") === true;   // build output → suppress
 const supDotGen = shouldSuppressSteer("/p/Source/Foo.generated.h") === true;        // generated header → suppress
 const supNodeMod = shouldSuppressSteer("/p/node_modules/x/y.js") === true;          // vendored dep → suppress
@@ -1939,7 +1979,16 @@ const digRecentOk = /adoption 20% \(2\/10\), recent 80%/.test(dig2);
 // READ-SIDE steer (H1): a LARGE code-file whole-read nudges toward read_symbol / symbol-edit; tight-gated so it
 // never nags a small file, a non-code file, a generated path, or an already-sliced (offset/limit) read.
 const rsBig = readSteerDecision("/p/Source/Big.cpp", 20000);                        // large code file → steer
-const rsReadOk = !!rsBig && /read_symbol/.test(rsBig) &&
+// B (concrete nudge): with `symbols` the nudge names real decls (ready read_symbol calls); without, the `<name>`
+// placeholder stands. And topLevelDeclNames (PURE) extracts column-0 decls per language from passed-in text.
+const rsConcrete = readSteerDecision("/p/Source/Big.cpp", 20000, { symbols: ["ParseManifest", "ManifestCache"] });
+const declNamesCpp = topLevelDeclNames("class WidgetFactory {\n  void hidden();\n};\nint WidgetFactory::BuildWidget(int n){ return n; }\n", "Big.cpp");
+const declNamesTs = topLevelDeclNames("export function alphaFn(){}\nexport class BetaClass {}\n  const indentedSkip = 1\n", "x.ts");
+const rsReadOk = !!rsBig && /read_symbol symbol="<name>"/.test(rsBig) &&            // no symbols → placeholder
+  /read_symbol symbol="ParseManifest"/.test(rsConcrete) && /read_symbol symbol="ManifestCache"/.test(rsConcrete) && // concrete calls rendered
+  declNamesCpp.includes("WidgetFactory") && declNamesCpp.includes("BuildWidget") && // C++ class + Class::Method (col-0), indented member skipped
+  declNamesTs.includes("alphaFn") && declNamesTs.includes("BetaClass") && !declNamesTs.includes("indentedSkip") &&
+  topLevelDeclNames("x", "/p/README.md").length === 0 &&                            // non-code ext → no extraction
   readSteerDecision("/p/Source/Small.cpp", 1000) === null &&                        // small → null
   readSteerDecision("/p/README.md", 20000) === null &&                              // non-code → null
   readSteerDecision("/p/Source/Foo.generated.h", 20000) === null &&                 // generated → null
@@ -2437,6 +2486,7 @@ const rows = [
   ["v2.2: find <dir> honored in rewrite + concrete-code Glob blocks → find_files", v22Ok, "true", v22Ok],
   ["symbolic editing: replace/insert/safe_delete by name (preview+apply+ref-guard)", symEditOk, "true", symEditOk],
   ["edit-steer: search EDIT_STEER (toggle) + discover counts whole-decl Edit", editSteerOk, "true", editSteerOk],
+  ["discover: agent-spawn accounting (exact totalTokens + fleet/heavy/advisory, toggle)", agentDiscOk, "true", agentDiscOk],
   ["edit-steer hook: L1 warn (replace/insert) + L2 safe-insert escalation", editHookOk, "true", editHookOk],
   ["per-file-language backend (.py→pyright in a clangd-rooted mixed repo)", backendPathOk, "true", backendPathOk],
   ["census fallback: path-less search_symbol retries OTHER backends present in the mixed repo (census-desc, gated)", censusFallbackOk, "true", censusFallbackOk],

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -36,7 +36,7 @@ import { splitSegments } from "../server/shell-split.js";
 // MEASURE; the adoption ledger is the live metric the steer is tuned against.
 import { classifyDeclEdit } from "../server/edit-detect.js";
 import { recordEditEvent, resetStreak, recordSteerShown, decideEscalation } from "../server/edit-ledger.js";
-import { shouldSuppressSteer, readSteerDecision } from "../server/policy.js";
+import { shouldSuppressSteer, readSteerDecision, topLevelDeclNames } from "../server/policy.js";
 
 const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(os.homedir(), ".vs-token-safer", "config.json");
 const readConfig = () => { try { return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8")) || {}; } catch { return {}; } };
@@ -655,7 +655,16 @@ process.stdin.on("end", () => {
     if (fp) {
       let sz = 0; try { sz = fs.statSync(fp).size; } catch { /* unreadable → leave 0 (no steer) */ }
       const minB = Number(process.env.VTS_READ_STEER_MIN ?? 6000);
-      const s = sz ? readSteerDecision(fp, sz, { sliced: !!(ti.offset || ti.limit), minBytes: minB, ko: KO }) : null;
+      const sliced = !!(ti.offset || ti.limit);
+      let s = sz ? readSteerDecision(fp, sz, { sliced, minBytes: minB, ko: KO }) : null;
+      // B: when the steer fires, upgrade the `<name>` placeholder to concrete read_symbol calls naming the
+      // file's real top-level decls — a ready call converts better. Best-effort, bounded, never throws into
+      // the hook; on any failure the placeholder nudge above stands.
+      if (s) {
+        let names = [];
+        try { names = topLevelDeclNames(fs.readFileSync(fp, "utf8"), fp); } catch { /* keep the placeholder */ }
+        if (names.length) s = readSteerDecision(fp, sz, { sliced, minBytes: minB, ko: KO, symbols: names });
+      }
       if (s) emitWarn(s + setup);
     }
     process.exit(0);

--- a/server/cli.js
+++ b/server/cli.js
@@ -83,7 +83,8 @@ Commands:
                  The since-window filters individual entries by timestamp; --projectPath scopes the
                  count to that root (and bounds what --learn attributes to it).
                  [--since N (days, default 7) --all (all projects, all time)
-                  --learn (feed the files those searches hit into the warm-set) --projectPath <dir>]
+                  --learn (feed the files those searches hit into the warm-set) --projectPath <dir>
+                  --agents (also account agent SPAWNS — code-locator/Explore fleets, exact totalTokens)]
   gen-compile-db Generate compile_commands.json for an Unreal project via UBT (full clangd index).
                  Dry-run by default; --apply runs it. The DB + clangd's .cache/ land OUTSIDE the source
                  tree (~/.vs-token-safer/db/<project>; --inTree keeps the classic project-root layout).
@@ -97,7 +98,7 @@ Backends (auto-detected from the root, or set --backend / VTS_BACKEND):
 Settings precedence: env (VTS_*) > ~/.vs-token-safer/config.json > default.`;
 
 const LIST_FLAGS = new Set(["seeds", "entry", "roots"]);
-const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open", "static", "docs", "status", "flow", "allowCold", "build", "thorough", "reachability", "detail"]);
+const BOOL_FLAGS = new Set(["includeDeclaration", "apply", "graph", "daily", "history", "all", "learn", "inTree", "force", "signatureOnly", "stop", "open", "static", "docs", "status", "flow", "allowCold", "build", "thorough", "reachability", "detail", "agents"]);
 
 function parseArgs(argv) {
   const a = {};

--- a/server/core.js
+++ b/server/core.js
@@ -500,6 +500,29 @@ const isUnder = (p, root) => {
   const r = path.resolve(String(root)).replace(/\\/g, "/").toLowerCase();
   return a2 === r || a2.startsWith(r + "/");
 };
+// A spawn description that reads like a SINGLE lookup — the case the code-locator spawn-guard says should be a
+// direct vs-search call, not a subagent. Advisory only (heuristic over the redacted description, never blocks).
+const SINGLE_LOOKUP_DESC = /\b(where is|what calls|find (the )?(file|symbol|definition)|locate|definition of|all (uses|usages|references) of)\b/i;
+// FLEET detection: ≥2 spawns of the SAME subagent_type falling inside a `winMs` window — the audit-fleet shape
+// (e.g. 4 code-locators over line-ranges in 90s) the v0.40.1 guard targets. A sliding window over each type's
+// timestamp-sorted spawns; a run of ≥2 within winMs is one fleet. Returns [{type,n,tok}].
+function detectFleets(spawns, winMs) {
+  const byType = {};
+  for (const s of spawns) (byType[s.type] || (byType[s.type] = [])).push(s);
+  const out = [];
+  for (const [type, arr] of Object.entries(byType)) {
+    if (arr.length < 2) continue;
+    arr.sort((a, b) => (a.ts || 0) - (b.ts || 0));
+    let i = 0;
+    while (i < arr.length) {
+      let j = i;
+      while (j + 1 < arr.length && (arr[j + 1].ts || 0) - (arr[i].ts || 0) <= winMs) j++;
+      if (j - i + 1 >= 2) { out.push({ type, n: j - i + 1, tok: arr.slice(i, j + 1).reduce((s, x) => s + (x.tok || 0), 0) }); i = j + 1; }
+      else i++;
+    }
+  }
+  return out;
+}
 function scanBypasses(a = {}) {
   const base = process.env.VTS_CLAUDE_PROJECTS || path.join(os.homedir(), ".claude", "projects");
   let dirs;
@@ -524,6 +547,15 @@ function scanBypasses(a = {}) {
   const PATH_RE = /([A-Za-z]:)?[\w./\\-]+\.(?:c|cc|cxx|cpp|h|hpp|hh|inl|ipp|tpp|cs|ts|tsx|mts|cts|js|jsx|mjs|cjs|py|pyi)\b/g;
   const cand = new Map(); // tool_use_id → {tool,q}
   const missed = []; let rawTokTotal = 0; let lines = 0; const MAX_LINES = 300000;
+  // Agent-spawn accounting (the dark surface): a code-locator/Explore fleet can burn far more than any single
+  // search bypass, yet discover never saw it. A spawn is ASYNC — its launch tool_result carries only {agentId,
+  // outputFile, status}, NO tokens. The real cost arrives later in the async COMPLETION notification as
+  // `<task-id>…</task-id> … <subagent_tokens>N</subagent_tokens>` (task-id === the launch agentId). So: capture
+  // the launch (type/desc/agentId), harvest token counts by task-id, and join after the scan.
+  const spawns = [];            // final resolved {type, tok, desc, ts, approx}
+  const spawnUse = new Map();   // Agent/Task tool_use_id → {type,desc,ts} (per-file: tool_use+result share a transcript)
+  const spawnRecs = [];         // launched spawns awaiting reconciliation {type,desc,ts,agentId,inlineTok,summaryTok}
+  const tokenByTask = new Map();// agentId/task-id → subagent_tokens, harvested from the async completion notification
   // Edit-habit measurement (A): count whole-declaration Edits on code files, and attribute the tokens of a
   // PRIOR Read of that same file — that read is what a symbol-edit (edit-by-name) would have skipped.
   let editCount = 0, editReadTok = 0, editUnreached = 0; // editUnreached: whole-decl edits with NO prior vts
@@ -535,12 +567,16 @@ function scanBypasses(a = {}) {
   const searchUse = new Map();  // vts search/goto/refs tool_use id → true (its result carries the file:line)
   const searchedBn = new Set(); // basenames seen in a prior vts search/goto/refs RESULT → steer-reachable
   outer: for (const { p } of files) {
-    cand.clear(); reads.clear(); readUse.clear(); searchUse.clear(); searchedBn.clear(); // tool_use+result share one transcript → bound per file
+    cand.clear(); reads.clear(); readUse.clear(); searchUse.clear(); searchedBn.clear(); spawnUse.clear(); // tool_use+result share one transcript → bound per file
     let txt; try { txt = fs.readFileSync(p, "utf8"); } catch { continue; }
     for (const line of txt.split(/\r?\n/)) {
       if (!line.trim()) continue;
       if (++lines > MAX_LINES) break outer;
       let e; try { e = JSON.parse(line); } catch { continue; }
+      // Harvest async-spawn completion tokens by task-id (=== agentId). Scanned on the raw line (the notification
+      // text lives inside a JSON string with literal <tags>); cheap-guarded so the regex only runs when present.
+      // Done BEFORE the window/scope filters — agentIds are globally unique, so a stray join can't cross projects.
+      if (line.includes("subagent_tokens")) { let cm; const CR = /<task-id>([a-z0-9-]+)<\/task-id>[\s\S]*?<subagent_tokens>(\d+)<\/subagent_tokens>/gi; while ((cm = CR.exec(line))) tokenByTask.set(cm[1], +cm[2]); }
       // entry-level window: a multi-day session keeps its file mtime fresh — without this, its old
       // misses recount in every "last N days" report (and re-enter every auto-learn harvest).
       if (!all && e && e.timestamp) { const t = Date.parse(e.timestamp); if (Number.isFinite(t) && t < cutoff) continue; }
@@ -551,6 +587,7 @@ function scanBypasses(a = {}) {
       for (const b of content) {
         if (b && b.type === "tool_use") {
           const m = matchBypass(b.name, b.input); if (m) cand.set(b.id, m);
+          if ((b.name === "Agent" || b.name === "Task") && b.input && b.input.subagent_type) spawnUse.set(b.id, { type: String(b.input.subagent_type), desc: String(b.input.description || ""), ts: e.timestamp ? Date.parse(e.timestamp) : 0 }); // an agent spawn (NOT the TaskCreate/Update to-do tools — those carry no subagent_type)
           if (b.name === "Read" && b.input && b.input.file_path) readUse.set(b.id, String(b.input.file_path).replace(/\\/g, "/").toLowerCase());
           else if (/(?:search_symbol|goto_definition|find_references)$/.test(String(b.name || ""))) searchUse.set(b.id, true);
           else { const ce = classifyDeclEdit(b.name, b.input, envInt("VTS_EDIT_MIN_LINES", 8)); if (ce.file && (ce.replaceDecl || ce.insertDecl)) { editCount++; let rtk = 0; if (reads.has(ce.file)) { rtk = reads.get(ce.file); editReadTok += rtk; reads.delete(ce.file); } const prior = searchedBn.has(path.basename(ce.file)); if (!prior) editUnreached++; editDetails.push({ file: ce.file, kind: ce.replaceDecl ? "replace" : "insert", readTok: rtk, priorSearch: prior }); } } // attribute a read ONCE (a re-Read re-adds it); unreached = no prior vts search landed on this file
@@ -564,6 +601,15 @@ function scanBypasses(a = {}) {
           searchUse.delete(b.tool_use_id);
           const o = typeof b.content === "string" ? b.content : JSON.stringify(b.content || "");
           let pm; PATH_RE.lastIndex = 0; while ((pm = PATH_RE.exec(o))) searchedBn.add(path.basename(pm[0]).toLowerCase()); // files a prior steer-carrying search surfaced
+        }
+        else if (b && b.type === "tool_result" && spawnUse.has(b.tool_use_id)) {
+          const sp = spawnUse.get(b.tool_use_id); spawnUse.delete(b.tool_use_id);
+          // The launch result carries the agentId (=== the completion's task-id) but NOT the tokens (async). Stash
+          // the agentId for the post-scan join; keep an inline totalTokens (sync spawns, if ever present) and the
+          // returned summary's token count as graceful fallbacks.
+          const tur = e.toolUseResult || {};
+          const o = typeof b.content === "string" ? b.content : JSON.stringify(b.content || "");
+          spawnRecs.push({ type: sp.type, desc: sp.desc, ts: sp.ts, agentId: tur.agentId || null, inlineTok: Number.isFinite(tur.totalTokens) ? tur.totalTokens : null, summaryTok: tok(o) });
         }
         else if (b && b.type === "tool_result" && cand.has(b.tool_use_id)) {
           const meta = cand.get(b.tool_use_id); cand.delete(b.tool_use_id);
@@ -587,7 +633,16 @@ function scanBypasses(a = {}) {
       }
     }
   }
-  return { missed, rawTokTotal, learned, filesCount: files.length, all, since, editCount, editReadTok, editUnreached, editDetails };
+  // Reconcile launched spawns with harvested completion tokens (async) → EXACT; else inline totalTokens (sync);
+  // else the returned-summary token count (approx, flagged). agentId === the completion's task-id.
+  for (const r of spawnRecs) {
+    let t, approx = false;
+    if (r.agentId && tokenByTask.has(r.agentId)) t = tokenByTask.get(r.agentId);
+    else if (Number.isFinite(r.inlineTok)) t = r.inlineTok;
+    else { t = r.summaryTok; approx = true; }
+    spawns.push({ type: r.type, tok: t, desc: r.desc, ts: r.ts, approx });
+  }
+  return { missed, rawTokTotal, learned, filesCount: files.length, all, since, editCount, editReadTok, editUnreached, editDetails, spawns };
 }
 // Boot-time self-improvement: harvest the last `since` days of bypassed searches and record their result
 // files into the warm-set query-history — the same write `vts discover --learn` does, but automatic.
@@ -604,7 +659,28 @@ export function autoLearn(root, since = 7) {
 function discoverReport(a = {}) {
   const r = scanBypasses(a);
   if (r.error) return r.error;
-  const { missed, rawTokTotal, learned, filesCount: fc, all, since, editCount, editReadTok, editUnreached, editDetails } = r;
+  const { missed, rawTokTotal, learned, filesCount: fc, all, since, editCount, editReadTok, editUnreached, editDetails, spawns } = r;
+  // A2: agent-spawn accounting — the largest single token events (a code-locator/Explore fleet) were invisible.
+  // Folded into the report (and `--agents`); VTS_DISCOVER_AGENTS=0 hides. Redacted: type + counts + tokens only,
+  // no prompt/description bodies (same discipline as the search/edit blocks).
+  let agentLine = "";
+  if (process.env.VTS_DISCOVER_AGENTS !== "0" && spawns && spawns.length) {
+    const heavyTok = envInt("VTS_SPAWN_HEAVY_TOK", 50000);
+    const fleetWin = envInt("VTS_SPAWN_FLEET_WINDOW_MS", 120000);
+    const totalSpawnTok = spawns.reduce((s, x) => s + (x.tok || 0), 0);
+    const anyApprox = spawns.some((s) => s.approx);
+    const byType = {};
+    for (const s of spawns) { const t = byType[s.type] || (byType[s.type] = { n: 0, tok: 0 }); t.n++; t.tok += s.tok || 0; }
+    const typeLine = Object.entries(byType).sort((x, y) => y[1].tok - x[1].tok).map(([t, v]) => `${t} ×${v.n} (~${v.tok.toLocaleString()})`).join(", ");
+    const fleets = detectFleets(spawns, fleetWin);
+    const heavy = spawns.filter((s) => (s.tok || 0) >= heavyTok);
+    const advisory = spawns.filter((s) => SINGLE_LOOKUP_DESC.test(s.desc || ""));
+    agentLine = `\n  agent spawns: ${spawns.length} spawn(s), ~${totalSpawnTok.toLocaleString()} tok total (~$${usd(totalSpawnTok).toFixed(2)})${anyApprox ? " (some approx — older transcripts)" : ""}` +
+      `\n    by type: ${typeLine}` +
+      (fleets.length ? `\n    fleets: ${fleets.length} (${fleets.map((f) => `${f.type} ×${f.n}, ~${f.tok.toLocaleString()} tok`).join("; ")}) ← audit-fleet shape the code-locator guard targets` : "") +
+      (heavy.length ? `\n    heavy: ${heavy.length} single spawn(s) over ${heavyTok.toLocaleString()} tok — a locator that reads bodies is doing the wrong job` : "") +
+      (advisory.length ? `\n    advisory: ${advisory.length} description(s) read like a single lookup — those could be a direct vs-search call (no subagent).` : "");
+  }
   // A: surface the edit habit alongside the search bypasses — whole-declaration Edits that could edit by name.
   // editUnreached = those with no prior vts search on the file → the EDIT_STEER (search-result-only) can't
   // reach them; a high fraction is the evidence for a harder lever (a warn on the Edit itself).
@@ -649,7 +725,7 @@ function discoverReport(a = {}) {
       detailLine = `\n  ✓ wrote ${missed.length + (editDetails ? editDetails.length : 0)} detailed record(s) to ${outPath} (LOCAL only — not sent to the model; for offline counterfactual analysis).`;
     } catch { /* best-effort */ }
   }
-  if (!missed.length) return `vs-token-safer discover (${scope}, ${files.length} transcript(s)): no code searches bypassed vts. It's catching them. ✓` + catchLine + editLine + learnLine + detailLine;
+  if (!missed.length) return `vs-token-safer discover (${scope}, ${files.length} transcript(s)): no code searches bypassed vts. It's catching them. ✓` + catchLine + editLine + agentLine + learnLine + detailLine;
   const byTool = {};
   for (const m of missed) byTool[m.tool] = (byTool[m.tool] || 0) + 1;
   const toolLine = Object.entries(byTool).sort((x, y) => y[1] - x[1]).map(([t, n]) => `${t}×${n}`).join(", ");
@@ -659,7 +735,7 @@ function discoverReport(a = {}) {
     `  ${missed.length} code search(es) bypassed vts (${toolLine})\n` +
     `  raw tool output ingested: ~${rawTokTotal.toLocaleString()} tok (~$${usd(rawTokTotal).toFixed(2)}) — routed through vts (file:line, capped) most of this is avoidable (typically 70–90% less)${catchLine}\n` +
     `  biggest:\n${top}\n` +
-    `  Fix: rewrite is on by default (Bash grep auto-reroutes to vts); for the Grep tool, prefer the vs-search MCP tools (search_symbol / search_text / find_files).${editLine}${learnLine}${detailLine}`;
+    `  Fix: rewrite is on by default (Bash grep auto-reroutes to vts); for the Grep tool, prefer the vs-search MCP tools (search_symbol / search_text / find_files).${editLine}${agentLine}${learnLine}${detailLine}`;
 }
 
 // ---- LSP client pool (one per root+backend; reused across calls in a process) ----

--- a/server/policy.js
+++ b/server/policy.js
@@ -33,16 +33,68 @@ export function suppressOn() { return onOff(process.env.VTS_SUPPRESS, "1"); }
 // not an already-sliced read (offset/limit), and at/above `minBytes`. Returns the nudge text or null.
 const READ_CODE_EXT = /\.(c|cc|cxx|cpp|h|hpp|hh|inl|ipp|tpp|cs|ts|tsx|mts|cts|js|jsx|mjs|cjs|py|pyi)$/i;
 export function readSteerOn() { return onOff(process.env.VTS_READ_STEER, "1"); }
-export function readSteerDecision(file, sizeBytes, { sliced = false, minBytes = 6000, ko = false } = {}) {
+// B (concrete nudge): a ready-to-use `read_symbol symbol="Foo"` converts far better than the `<name>` placeholder
+// (the grep-block work proved it). policy.js stays PURE — the HOOK extracts the names (it has fs access) and
+// passes them in like sizeBytes. `symbols` non-empty → render concrete calls; empty → the placeholder, unchanged.
+export function readSteerDecision(file, sizeBytes, { sliced = false, minBytes = 6000, ko = false, symbols = [] } = {}) {
   if (!readSteerOn() || !file) return null;
   if (sliced) return null;                            // a partial read (offset/limit) is already a slice
   if (!READ_CODE_EXT.test(String(file))) return null; // only code files (the syntactic/semantic tiers cover these)
   if (shouldSuppressSteer(file)) return null;         // generated/build/vendored path — a symbol-read buys nothing
   if (!(sizeBytes >= minBytes)) return null;          // small file: cheap to read whole, not worth a nudge
   const kb = Math.round(sizeBytes / 1024);
+  const all = Array.isArray(symbols) ? symbols.filter((s) => typeof s === "string" && s) : [];
+  const names = all.slice(0, 4);
+  if (names.length) {
+    const calls = names.map((n) => `read_symbol symbol="${n}"`).join(" · ");
+    const more = all.length > names.length ? ` (+${all.length - names.length} more — read_symbol lists them)` : "";
+    return ko
+      ? `↪ vs-token-safer: 큰 코드파일(~${kb}KB) 통째 읽기. 한 선언만 필요하면 ${calls}${more} 처럼 그 선언만 반환(토큰캡); 통째 편집이면 replace_symbol_body / insert_symbol 이 읽지 않고 이름으로 편집. 끄기: VTS_READ_STEER=0.`
+      : `↪ vs-token-safer: reading a large code file (~${kb} KB) whole. Need ONE declaration? ${calls}${more} returns just that decl (token-capped); for a whole-decl edit, replace_symbol_body / insert_symbol edit by name with no read. VTS_READ_STEER=0 to hide.`;
+  }
   return ko
     ? `↪ vs-token-safer: 큰 코드파일(~${kb}KB)을 통째로 읽네요. 한 선언만 필요하면 read_symbol symbol="<name>" 이 그 선언만 반환(토큰캡)하고, 통째 편집이면 replace_symbol_body / insert_symbol 이 읽지 않고 이름으로 편집합니다. 끄기: VTS_READ_STEER=0.`
     : `↪ vs-token-safer: reading a large code file (~${kb} KB) whole. If you only need ONE declaration, read_symbol symbol="<name>" returns just that decl (token-capped); for a whole-decl edit, replace_symbol_body / insert_symbol edit by name with no read. VTS_READ_STEER=0 to hide.`;
+}
+
+// PURE top-level declaration-name extractor (no fs — the hook reads the file and passes the text). Heuristic,
+// best-effort: a column-0 declaration line per language (top-level only — indented members are skipped, which
+// is what we want: name the file's outermost decls). Used to make the read-steer nudge concrete; a wrong-but-
+// plausible name still teaches the tool, and document_symbols recovers the full set. Returns up to `max` names.
+// STRONG = functions / classes / types / methods (the decls you usually edit); WEAK = bare const/let/var (named
+// last so a function outranks a top-level constant — the "demote const locals" bias the concept tier uses).
+function declPatternsFor(ext) {
+  if (/^(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/.test(ext)) return {
+    strong: [
+      /^(?:export\s+)?(?:default\s+)?(?:async\s+)?function\*?\s+([A-Za-z_$][\w$]*)/,
+      /^(?:export\s+)?(?:abstract\s+)?class\s+([A-Za-z_$][\w$]*)/,
+      /^(?:export\s+)?(?:interface|type|enum)\s+([A-Za-z_$][\w$]*)/,
+    ],
+    weak: [/^(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=/],
+  };
+  if (/^(py|pyi)$/.test(ext)) return { strong: [/^(?:async\s+)?def\s+([A-Za-z_]\w*)/, /^class\s+([A-Za-z_]\w*)/], weak: [] };
+  if (/^(c|cc|cxx|cpp|h|hpp|hh|inl|ipp|tpp|cs)$/.test(ext)) return {
+    strong: [
+      /^(?:class|struct|enum|namespace|interface|record)\s+([A-Za-z_]\w*)/,
+      /^[\w:<>,*&\s]*?(?:[A-Za-z_]\w*::)+([A-Za-z_]\w*)\s*\(/,           // Class::Method(  → the method name
+      /^(?:[A-Za-z_][\w:<>,*&]*\s+)+\*?\s*([A-Za-z_]\w*)\s*\(/,          // free/member function definition
+    ],
+    weak: [],
+  };
+  return { strong: [], weak: [] };
+}
+export function topLevelDeclNames(text, file, max = 8) {
+  if (!text || typeof text !== "string") return [];
+  const m = /\.([a-z0-9]+)$/i.exec(String(file || ""));
+  const { strong, weak } = declPatternsFor(m ? m[1].toLowerCase() : "");
+  if (!strong.length && !weak.length) return [];
+  const lines = text.slice(0, 200000).split(/\r?\n/);                  // bound the work on a huge file
+  const seen = new Set();
+  const collect = (pats, into) => { for (const raw of lines) { if (into.length >= max) break; if (!raw || /^\s/.test(raw)) continue; for (const re of pats) { const mm = re.exec(raw); if (mm && mm[1] && !seen.has(mm[1])) { seen.add(mm[1]); into.push(mm[1]); break; } } } };
+  const out = [];
+  collect(strong, out);                                               // functions/classes/types first (source order)
+  if (out.length < max) collect(weak, out);                           // then bare const/var to fill remaining slots
+  return out;
 }
 
 // The single routing digest. Always emits the decision tree (the integrative guidance); appends the live


### PR DESCRIPTION
Two token-discipline surfaces for the two leaks `vts discover` surfaces beyond search routing (already ~97% caught): the **dark agent-spawn cost** and the **edit-pre-read**.

## A — `vts discover --agents`: make agent spawns measurable
Discover was blind to agent spawns — the largest single token events (a code-locator/Explore **audit fleet**, ~240k in one observed window). 

**Key finding while implementing:** a spawn is **async** — its launch `tool_result` carries only `{agentId, outputFile, status}`, **NO tokens**. The real cost arrives later in the completion notification as `<task-id>…<subagent_tokens>N`. So `scanBypasses` captures the launch (type/desc/agentId), harvests `subagent_tokens` by task-id, and **joins on `task-id === agentId`** — EXACT attribution, not a proxy (falls back to inline `totalTokens`, then the summary token count, only when the completion is absent).

`discoverReport` renders an **`agent spawns:`** block: total · by-type · **FLEET** (≥2 same-type within `VTS_SPAWN_FLEET_WINDOW_MS`) · **HEAVY** (single spawn over `VTS_SPAWN_HEAVY_TOK`) · advisory **WOULD-BE-DIRECT** count (single-lookup-shaped descriptions). Redacted (type/counts/tokens only, no prompt bodies). `VTS_DISCOVER_AGENTS=0` off.

**Live:** 142 spawns / **~13.1M tok over 7d** (previously invisible) — the code-locator fleet (×7, ~606k) now measurable. This is the measurement that tells us whether the v0.40.1 spawn-guard works.

## B — concrete read-steer nudge
The H1 read nudge emitted a `<name>` placeholder; a ready-to-use call converts better (the grep-block lesson). The hook now reads the file (**only when the steer fires**, bounded) and passes the file's real top-level decl names; `policy.readSteerDecision` renders `read_symbol symbol="Foo"` calls (functions/classes before bare const). **policy.js stays PURE** — the new `topLevelDeclNames` is a pure string→names extractor; the hook supplies the text exactly like it already supplies `sizeBytes`. Extraction failure / no decls → the placeholder, unchanged (never breaks the Read).

**Live:** a Read of `policy.js` now names `shouldSuppressSteer` / `readSteerDecision` / … instead of `<name>`.

## Review points
- **Charter:** both local-only, nothing transmitted; A's output is redacted aggregates; B surfaces only symbol names already in the file being read. No embeddings.
- **Eval:** guard 91 (agent-spawn: exact completion-join + fleet/heavy/advisory + toggle), guard 80 extended (concrete render + placeholder fallback + `topLevelDeclNames`). Full suite green; lint clean.
- The async-spawn token shape was verified against real transcripts before coding (the design doc's "exact totalTokens on launch" assumption was wrong — it's the completion's `subagent_tokens`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
