### PR TITLE
feat: gate vs-search LOCATE tools to the local orchestrator (qvts) via PreToolUse hook

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -27,6 +27,15 @@
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/block-code-grep.js\""
           }
         ]
+      },
+      {
+        "matcher": "mcp__.*vs-search__(search_text|search_symbol|find_files|find_references|goto_definition|concept_search|def_search|document_symbols)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/orchestrator-redirect.js\""
+          }
+        ]
       }
     ]
   }

--- a/hooks/orchestrator-redirect.js
+++ b/hooks/orchestrator-redirect.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/*
+ * vs-token-safer — PreToolUse hook (matcher: the vs-search MCP LOCATE tools).
+ *
+ * When a LOCAL ORCHESTRATOR (qvts / vts-local-orchestrator) is present, a code-LOCATE call to the vs-search
+ * MCP tools is the orchestrator's job, NOT Claude's: delegating it keeps the raw search output in the local
+ * model and returns only a compact answer, saving Claude tokens. The orchestrator's SessionStart hint says
+ * "delegate", but a hint loses the routing fight on a SINGLE lookup (vs-token-safer's own hint permits a
+ * direct call there). A hint can't gate — only a hook can. So when orchestratorPresent(), this BLOCKS a
+ * locate-class vs-search call (exit 2) and hands back the ready `qvts` command. The model then delegates.
+ *
+ * SCOPE — only the LOCATE tools are gated:
+ *   search_text · search_symbol · find_files · find_references · goto_definition · concept_search ·
+ *   def_search · document_symbols
+ * NEVER gated (these stay Claude's direct tools):
+ *   read_symbol (the sanctioned "read the decl body yourself" after a delegated file:line — delegation
+ *   protocol step 1), hover, diagnostics, and ALL edits (insert_symbol / replace_symbol_body / rename /
+ *   safe_delete / vts_admin).
+ *
+ * FALLBACK SAFETY — strict, but never strands the model. The delegation protocol says: if the delegated
+ * answer is empty / no-match / error, retry the search yourself. A permanent block would forbid that retry.
+ * So a block is ONE-TIME per distinct (tool,args): the first sight is blocked (→ delegate); an identical
+ * call seen again within TTL is ALLOWED (it's the post-delegation fallback). The model: tries vs-search →
+ * blocked → runs qvts → qvts no-match → retries the SAME vs-search call → now passes.
+ *
+ *   orchestrator absent                      → no-op (standalone vts behaves exactly as before)
+ *   VTS_ORCH_BLOCK 0/false/off               → warn-only (allow + nudge), never blocks
+ *   VTS_ORCHESTRATOR_AWARE 0                  → orchestratorPresent() false → no-op
+ *   VTS_ENFORCE 0/false/off                  → master kill switch (matches block-code-grep) → no-op
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { orchestratorPresent } from "../server/policy.js";
+
+const off = (v) => /^(0|false|off|no)$/i.test(String(v ?? ""));
+
+const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(os.homedir(), ".vs-token-safer", "config.json");
+const readConfig = () => { try { return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8")) || {}; } catch { return {}; } };
+function uiLang() {
+  const v = String(process.env.VTS_LANG || readConfig().lang || "").toLowerCase();
+  if (v) return v.startsWith("ko") ? "ko" : "en";
+  try { return /^ko/i.test(Intl.DateTimeFormat().resolvedOptions().locale) ? "ko" : "en"; } catch { return "en"; }
+}
+const KO = uiLang() === "ko";
+
+// The vs-search LOCATE tools (suffix after the MCP server prefix). read_symbol / hover / diagnostics / edits
+// are intentionally absent — they are not delegated.
+const LOCATE_TOOLS = new Set([
+  "search_text", "search_symbol", "find_files", "find_references",
+  "goto_definition", "concept_search", "def_search", "document_symbols",
+]);
+const toolSuffix = (name) => String(name || "").replace(/^.*__/, ""); // mcp__plugin_vs-token-safer_vs-search__search_text → search_text
+
+const rootFor = (ti) =>
+  ti.projectPath || ti.project_path || process.env.VTS_PROJECT_PATH || readConfig().projectPath || process.cwd();
+
+// Build a natural-language locate task from the MCP tool args, so the handed-back qvts command is ready to run.
+function taskFor(suffix, ti) {
+  const q = String(ti.q ?? ti.query ?? "").trim();
+  const sym = String(ti.symbol ?? ti.name ?? q).trim();
+  const p = String(ti.path ?? ti.file ?? "").trim();
+  switch (suffix) {
+    case "search_symbol": return `where is symbol ${q || sym} declared`;
+    case "def_search": return `where is ${sym || q} defined`;
+    case "goto_definition": return `where is ${sym || "the symbol at this position"} defined`;
+    case "find_references": return `find all references and callers of ${sym || q}`;
+    case "find_files": return `find file named ${q || sym}`;
+    case "document_symbols": return `outline / list the symbols declared in ${p || "this file"}`;
+    case "concept_search": return q || sym;
+    case "search_text":
+    default: return `find ${q || sym} in code`;
+  }
+}
+
+const blockOn = () => !off(process.env.VTS_ORCH_BLOCK ?? "1");
+
+// One-time-per-query state so a post-delegation fallback retry isn't blocked again.
+const SEEN_FILE = path.join(os.homedir(), ".vs-token-safer", "orch-seen.json");
+const TTL_MS = (() => { const n = Number(process.env.VTS_ORCH_TTL_MS); return Number.isFinite(n) && n > 0 ? n : 180000; })();
+function seenRecently(key) {
+  let m = {};
+  try { m = JSON.parse(fs.readFileSync(SEEN_FILE, "utf8")) || {}; } catch { /* none yet */ }
+  // pass time in via the most recent stored stamp (no Date.now dependency in the hot decision is unnecessary
+  // here — a hook is a fresh process; Date.now is allowed in hooks, only workflow scripts forbid it).
+  const now = Date.now();
+  const last = m[key];
+  // prune expired
+  for (const k of Object.keys(m)) if (now - m[k] > TTL_MS) delete m[k];
+  const recent = typeof last === "number" && now - last <= TTL_MS;
+  m[key] = now;
+  try { fs.mkdirSync(path.dirname(SEEN_FILE), { recursive: true }); fs.writeFileSync(SEEN_FILE, JSON.stringify(m)); } catch { /* best effort */ }
+  return recent;
+}
+
+function msg(qvtsCmd) {
+  return KO
+    ? `✨ vs-token-safer: 로컬 오케스트레이터(qvts) 감지 — 이 locate는 위임하세요.\n→ ${qvtsCmd}\n   (로컬 모델이 vs-search를 돌리고 compact 답만 반환 — Claude 토큰 절약. answer의 file:line은 사실로 신뢰; 바디는 read_symbol로 직접 읽기.)\n이미 위임했는데 no-match/에러였으면 같은 호출 다시 하면 통과됩니다. warn전환: VTS_ORCH_BLOCK=0`
+    : `✨ vs-token-safer: local orchestrator (qvts) detected — delegate this locate.\n→ ${qvtsCmd}\n   (the local model runs vs-search and returns only a compact answer — saves Claude tokens. Trust the answer's file:line; read bodies yourself with read_symbol.)\nAlready delegated and got no-match/error? Re-issue the same call and it passes. Warn-only: VTS_ORCH_BLOCK=0`;
+}
+
+let input = "";
+process.stdin.on("data", (d) => (input += d));
+process.stdin.on("end", () => {
+  if (off(process.env.VTS_ENFORCE)) process.exit(0);
+  let j;
+  try { j = JSON.parse(input); } catch { process.exit(0); }
+  const suffix = toolSuffix(j.tool_name);
+  if (!LOCATE_TOOLS.has(suffix)) process.exit(0);          // not a locate tool → allow
+  if (!orchestratorPresent()) process.exit(0);             // standalone vts → unchanged behavior
+
+  const ti = j.tool_input || {};
+  const root = rootFor(ti);
+  const task = taskFor(suffix, ti).replace(/"/g, "'");     // keep the handed-back command shell-safe
+  const safeRoot = String(root).replace(/"/g, "'");
+  const qvtsCmd = `qvts -p "${safeRoot}" --json "${task}"`;
+
+  const key = `${suffix}:${JSON.stringify(ti)}`;
+  const fallbackRetry = seenRecently(key);
+
+  if (blockOn() && !fallbackRetry) {
+    process.stderr.write(msg(qvtsCmd) + "\n");
+    process.exit(2); // block — route this locate to the local orchestrator
+  }
+  // warn-only mode, OR a post-delegation fallback retry → allow, but surface the nudge.
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: { hookEventName: "PreToolUse", additionalContext: msg(qvtsCmd) },
+  }) + "\n");
+  process.exit(0);
+});

--- a/server/policy.js
+++ b/server/policy.js
@@ -21,7 +21,7 @@ import path from "node:path";
 // VTS_ORCHESTRATOR_AWARE=0; force on with VTS_ORCHESTRATOR=1. Detection: qvts on PATH, or the orchestrator's
 // global config (~/.vts-local/config.json). Cached for the process.
 let _orchCache;
-function orchestratorPresent() {
+export function orchestratorPresent() {
   if (_orchCache !== undefined) return _orchCache;
   _orchCache = (() => {
     if (/^(0|false|off|no)$/i.test(process.env.VTS_ORCHESTRATOR_AWARE || "")) return false;


### PR DESCRIPTION
## Why
When the local orchestrator (`qvts` / vts-local-orchestrator) is installed, code-LOCATE is its job — delegating keeps the raw search output in the local model and returns only a compact answer, saving Claude tokens. But the existing mechanism is just an injected **hint**, and vts-token-safer's own SessionStart hint explicitly permits a direct `vs-search` call for a **single lookup**. So single locates kept going straight to vts, defeating the orchestrator. A hint can't gate — only a hook can.

## What
New `hooks/orchestrator-redirect.js` (PreToolUse), matcher on the vs-search MCP **LOCATE** tools:
`search_text · search_symbol · find_files · find_references · goto_definition · concept_search · def_search · document_symbols`

When `orchestratorPresent()`:
- **BLOCK** the locate (exit 2) and return a ready `qvts -p "<root>" --json "<task>"` built from the tool args → the model delegates.
- **Never gated:** `read_symbol` (the sanctioned read-the-body-yourself after a delegated file:line), `hover`, `diagnostics`, and all edit tools (`insert_symbol`/`replace_symbol_body`/`rename`/`safe_delete`/`vts_admin`).
- **Fallback-safe:** a block is one-time per distinct `(tool,args)`; an identical call within TTL (`VTS_ORCH_TTL_MS`, default 180s) is allowed — the post-delegation no-match/error retry the delegation protocol calls for.

## Safety / opt-out
- Standalone vts unchanged — orchestrator absent → **no-op**.
- `VTS_ORCH_BLOCK=0` → warn-only. `VTS_ENFORCE=0` master kill switch honored. `VTS_ORCHESTRATOR_AWARE=0` disables detection.
- The orchestrator's own daemon calls vs-search via the SDK, not the CC MCP layer, so this hook does not gate the delegation path itself.

`policy.js`: `orchestratorPresent` is now exported (reuses existing detection).

## Tested
block (search_text/find_references) · fallback-allow on repeat · read_symbol pass-through · `VTS_ORCH_BLOCK=0` warn · `VTS_ENFORCE=0` no-op · orchestrator-absent no-op — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)