### PR TITLE
fix: scope qvts to the target's real repo root (split-root / monorepo aware)

### DIFF
--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -36,7 +36,7 @@ import { splitSegments } from "../server/shell-split.js";
 // MEASURE; the adoption ledger is the live metric the steer is tuned against.
 import { classifyDeclEdit } from "../server/edit-detect.js";
 import { recordEditEvent, resetStreak, recordSteerShown, decideEscalation } from "../server/edit-ledger.js";
-import { shouldSuppressSteer, readSteerDecision, topLevelDeclNames, orchestratorPresent } from "../server/policy.js";
+import { shouldSuppressSteer, readSteerDecision, topLevelDeclNames, orchestratorPresent, resolveSearchRoot } from "../server/policy.js";
 
 const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(os.homedir(), ".vs-token-safer", "config.json");
 const readConfig = () => { try { return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8")) || {}; } catch { return {}; } };
@@ -58,13 +58,16 @@ const KO = uiLang() === "ko";
 // here (that only taught the bypass). Opt out with VTS_ORCH_BLOCK=0 (then the normal vts steer/rewrite runs).
 const ORCH = orchestratorPresent() && !/^(0|false|off|no)$/i.test(process.env.VTS_ORCH_BLOCK ?? "1");
 const orchRoot = () => process.env.VTS_PROJECT_PATH || readConfig().projectPath || process.cwd();
-function qvtsCmd(task) {
-  const root = String(orchRoot()).replace(/"/g, "'");
+// `target` (the file/dir the search names) generalizes the root: a file in a sibling sub-tree of the configured
+// project (Unreal Engine/ vs Game/, a monorepo package, a web/python workspace) resolves UP to ITS repo root
+// so qvts scopes where the file actually lives, not the unrelated configured root.
+function qvtsCmd(task, target) {
+  const root = String((target ? resolveSearchRoot(target, orchRoot()) : orchRoot()) || orchRoot()).replace(/"/g, "'");
   const t = String(task || "").replace(/\s+/g, " ").replace(/"/g, "'").trim().slice(0, 200);
   return `qvts -p "${root}" --json "${t}"`;
 }
-function orchMsg(task) {
-  const cmd = qvtsCmd(task);
+function orchMsg(task, target) {
+  const cmd = qvtsCmd(task, target);
   return KO
     ? `✨ vs-token-safer: 로컬 오케스트레이터(qvts) 감지 — 이 코드검색은 위임하세요 (직접 grep/Read 말고).\n→ ${cmd}\n   (로컬 모델이 검색하고 compact 답만 반환 — Claude 토큰 절약. 결과 file:line은 사실로 신뢰; 못 찾으면 같은 호출 다시 하면 직접검색 통과.)`
     : `✨ vs-token-safer: local orchestrator (qvts) detected — delegate this code search (don't grep/Read directly).\n→ ${cmd}\n   (the local model searches; only a compact answer returns — saves Claude tokens. Trust the file:line; if it finds nothing, re-issue and direct search passes.)`;
@@ -223,6 +226,18 @@ function extractGrepPattern(segment, isGit) {
 function extractFindName(segment) {
   const m = segment.match(/\s-i?name\s+("([^"]+)"|'([^']+)'|(\S+))/);
   return m ? (m[2] || m[3] || m[4] || "") : null;
+}
+// The file/dir a grep names (`grep pat <file>`), so the orchestrator root can be generalized from it (a file in
+// a sibling sub-tree resolves to ITS repo root). The last bare token that looks like a path (has a separator or
+// a file extension) and isn't the pattern. Best-effort; null when the grep has no explicit path operand.
+function extractSearchFile(segment) {
+  const toks = segment.trim().split(/\s+/).slice(1); // drop the executable
+  for (let i = toks.length - 1; i >= 0; i--) {
+    const t = stripQuotes(toks[i]);
+    if (!t || t.startsWith("-")) continue;
+    if (/[\\/]/.test(t) || /\.[A-Za-z0-9_]+$/.test(t)) return t;
+  }
+  return null;
 }
 // `find [path] -name X` — the FIRST operand (before any `-predicate`) is the search directory. Honor it so
 // the rewrite searches the tree the command names, not the configured root — dropping it made a
@@ -643,7 +658,7 @@ process.stdin.on("end", () => {
     // qvts present → a code/symbol Grep is the orchestrator's job: block and hand back the qvts command (a
     // log/text-target Grep is left to the normal steer below).
     if (ORCH && !isLogGrepTool(ti) && notTextLogTarget(ti) && (isCodeGrepTool(ti) || isSymbolHuntGrep(ti))) {
-      process.stderr.write(orchMsg(`find ${String(ti.pattern || "").slice(0, 120)} in code`) + "\n");
+      process.stderr.write(orchMsg(`find ${String(ti.pattern || "").slice(0, 120)} in code`, ti.path) + "\n");
       process.exit(2);
     }
     if (isLogGrepTool(ti)) emitWarn(LOG_NUDGE + setup);
@@ -667,7 +682,7 @@ process.stdin.on("end", () => {
   // ignored — the model kept Glob-ing a huge UE tree instead of switching. VTS_GREP_BLOCK=0 reverts to warn-only.
   if (toolName === "Glob") {
     if (ORCH && isCodeGlobTool(ti)) {
-      process.stderr.write(orchMsg(`find file named ${globBasename(ti.pattern)}`) + "\n");
+      process.stderr.write(orchMsg(`find file named ${globBasename(ti.pattern)}`, ti.path || globRootHint(ti)) + "\n");
       process.exit(2);
     }
     if (grepBlockOn() && isBlockableGlob(ti)) {
@@ -746,19 +761,20 @@ process.stdin.on("end", () => {
       const seg = codeSegs[0];
       const pat = extractGrepPattern(seg, execOf(seg) === "git") || extractFindName(seg) || "";
       const task = pat ? `find ${pat} in code` : "locate the searched symbol/string in code";
+      const target = extractSearchFile(seg) || extractFindDir(seg); // a file/dir the command names → generalize the root
       if (segments.length === 1) {
         process.stdout.write(JSON.stringify({
           hookSpecificOutput: {
             hookEventName: "PreToolUse",
             permissionDecision: "allow",
             permissionDecisionReason: "Rerouted code search → local orchestrator (qvts): the raw search stays in the local model, only a compact answer returns to Claude.",
-            updatedInput: { ...ti, command: qvtsCmd(task) },
-            additionalContext: orchMsg(task),
+            updatedInput: { ...ti, command: qvtsCmd(task, target) },
+            additionalContext: orchMsg(task, target),
           },
         }) + "\n");
         process.exit(0);
       }
-      process.stderr.write(orchMsg(task) + "\n");
+      process.stderr.write(orchMsg(task, target) + "\n");
       process.exit(2);
     }
     // #1 transparent rewrite: a whole command that is exactly one code-search segment, where we can build

--- a/hooks/orchestrator-redirect.js
+++ b/hooks/orchestrator-redirect.js
@@ -32,7 +32,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { orchestratorPresent } from "../server/policy.js";
+import { orchestratorPresent, resolveSearchRoot } from "../server/policy.js";
 
 const off = (v) => /^(0|false|off|no)$/i.test(String(v ?? ""));
 
@@ -53,8 +53,14 @@ const LOCATE_TOOLS = new Set([
 ]);
 const toolSuffix = (name) => String(name || "").replace(/^.*__/, ""); // mcp__plugin_vs-token-safer_vs-search__search_text → search_text
 
-const rootFor = (ti) =>
-  ti.projectPath || ti.project_path || process.env.VTS_PROJECT_PATH || readConfig().projectPath || process.cwd();
+// The configured/explicit root, then GENERALIZED: if the call names a file/dir target (search_text path,
+// document_symbols path) that lives in a sibling sub-tree of the configured root (Unreal Engine/ vs Game/,
+// a monorepo package, …), resolve UP to that target's real repo root so qvts scopes where the file actually is.
+const rootFor = (ti) => {
+  const configured = ti.projectPath || ti.project_path || process.env.VTS_PROJECT_PATH || readConfig().projectPath || process.cwd();
+  const target = ti.path || ti.file || "";
+  return target ? (resolveSearchRoot(target, configured) || configured) : configured;
+};
 
 // Build a natural-language locate task from the MCP tool args, so the handed-back qvts command is ready to run.
 function taskFor(suffix, ti) {

--- a/server/policy.js
+++ b/server/policy.js
@@ -39,6 +39,62 @@ export function orchestratorPresent() {
   return _orchCache;
 }
 
+// Resolve the right SEARCH ROOT for a target the search names, generally — not just the configured project.
+// Many repos split a parent root into sub-trees: Unreal (parent/{Engine, MyGame}), monorepos (repo/{packages/*}),
+// web/python workspaces, etc. If the configured projectPath is one sub-tree (e.g. .../MyGame) but the search
+// targets a file in a SIBLING tree (e.g. .../Engine/...), scoping qvts to the configured root would miss it.
+// So when the search has an explicit file/dir target, walk UP to the enclosing repo root and scope there:
+//   1) the nearest ancestor containing `.git` (the most general monorepo/parent-root marker), else
+//   2) the nearest ancestor with a project marker (*.uproject / *.sln / package.json / pyproject.toml /
+//      setup.py / go.mod / Cargo.toml), else
+//   3) the target's own directory.
+// With no target, fall back to the configured root. Best-effort; never throws.
+const ROOT_MARKER_FILES = new Set(["package.json", "pyproject.toml", "setup.py", "go.mod", "Cargo.toml", "CMakeLists.txt"]);
+const isWithin = (child, parent) => {
+  const rel = path.relative(parent, child);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+};
+// Nearest common ancestor directory of two absolute paths, or null if they share no prefix (e.g. diff drives).
+function commonAncestor(a, b) {
+  const sa = a.split(/[\\/]/), sb = b.split(/[\\/]/);
+  const out = [];
+  for (let i = 0; i < Math.min(sa.length, sb.length); i++) {
+    if (sa[i].toLowerCase() !== sb[i].toLowerCase()) break;
+    out.push(sa[i]);
+  }
+  if (out.length === 0 || (out.length === 1 && out[0] === "")) return null;
+  return out.join(path.sep);
+}
+// Walk up from a path to the nearest PROJECT marker (preferred), else a .git — used only when there's no
+// configured root to anchor on. Project markers are preferred over .git so an UMBRELLA repo (a whole workspace
+// /vault that happens to be one git repo) doesn't over-broaden the scope.
+function markerWalk(start) {
+  let cur = start, gitRoot = null;
+  for (let i = 0; i < 40 && cur; i++) {
+    let ents = [];
+    try { ents = fs.readdirSync(cur); } catch { /* keep climbing */ }
+    if (ents.some((e) => /\.(uproject|sln)$/i.test(e) || ROOT_MARKER_FILES.has(e))) return cur; // closest project marker wins
+    if (!gitRoot && ents.includes(".git")) gitRoot = cur;
+    const parent = path.dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  return gitRoot || start;
+}
+export function resolveSearchRoot(target, configured) {
+  try {
+    if (!target) return configured || null;
+    let t = path.resolve(String(target));
+    try { if (fs.statSync(t).isFile()) t = path.dirname(t); } catch { t = path.dirname(t); }
+    if (!configured) return markerWalk(t);
+    const c = path.resolve(String(configured));
+    if (isWithin(t, c)) return c;          // target lives inside the configured project → keep it (narrow, correct)
+    // target is in a SIBLING sub-tree (Unreal Engine/ vs Game/, another monorepo package): scope to the nearest
+    // common ancestor so qvts covers BOTH the configured project and the target — that's the real parent root.
+    return commonAncestor(c, t) || c;
+  } catch { return configured || null; }
+}
+
 // Generated code / build output / vendored deps — a semantic index adds nothing here; CC-native is fine.
 const SUPPRESS_DIR = /(^|[/\\])(Intermediate|Binaries|Saved|DerivedDataCache|node_modules|build|dist|out|obj|\.git)([/\\]|$)/i;
 const GENERATED = /\.(generated\.[a-z0-9]+|g\.cs|designer\.cs|pb\.(go|cc|h)|min\.js)$/i;


### PR DESCRIPTION
Patch. Generalizes the qvts `-p` root so a delegated search hits the tree where the **target file actually lives** — not just the configured project.

### Problem
The redirect hardcoded the configured `projectPath`. But roots are often **split**: Unreal = `parent/{Engine, MyGame}` (config = `.../MyGame`, yet a search may target `.../Engine/...`); monorepos = `repo/{packages,libs}`; web/python workspaces likewise. A delegated search for a **sibling-subtree** file ran against the wrong root → found nothing.

### Fix — `policy.resolveSearchRoot(target, configured)`
- target **inside** the configured project → keep it (narrow, correct).
- target in a **sibling** sub-tree → nearest **common ancestor** of (configured, target) = the real parent root covering both (e.g. `.../MyRepo/{Engine,Game}` → `.../MyRepo`). Not the configured `.../Game`, and **not** an outer umbrella git repo.
- **no** configured root → walk up to the nearest **project marker** (`*.uproject`/`*.sln`/`package.json`/`pyproject.toml`/`setup.py`/`go.mod`/`Cargo.toml`), then `.git` last (markers preferred so a whole-workspace umbrella git repo doesn't over-broaden).
- different drive / no shared prefix → fall back to configured.

Wired into both the `orchestrator-redirect` hook (`ti.path`/`file`) and `block-code-grep`'s qvts redirect (Grep `path`, Glob `path`/dir-prefix, new `extractSearchFile()` for the Bash grep file operand).

### Tested
engine file (sibling) → `.../MyRepo` ✓ · game file (inside) → `.../MyRepo/MyGame` ✓ · no target → configured ✓ · different drive → configured ✓ · Bash grep + MCP search_text path both resolve to the parent root. Syntax green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)