### PR TITLE
feat: scope qvts to the active project in a vault/monorepo (auto-track + multi-project nudge)

### DIFF
--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -36,7 +36,7 @@ import { splitSegments } from "../server/shell-split.js";
 // MEASURE; the adoption ledger is the live metric the steer is tuned against.
 import { classifyDeclEdit } from "../server/edit-detect.js";
 import { recordEditEvent, resetStreak, recordSteerShown, decideEscalation } from "../server/edit-ledger.js";
-import { shouldSuppressSteer, readSteerDecision, topLevelDeclNames, orchestratorPresent, resolveSearchRoot } from "../server/policy.js";
+import { shouldSuppressSteer, readSteerDecision, topLevelDeclNames, orchestratorPresent, resolveSearchRoot, recordActiveProject, readActiveProject, subprojectsUnder } from "../server/policy.js";
 
 const CONFIG_FILE = process.env.VTS_CONFIG_FILE || path.join(os.homedir(), ".vs-token-safer", "config.json");
 const readConfig = () => { try { return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8")) || {}; } catch { return {}; } };
@@ -59,18 +59,34 @@ const KO = uiLang() === "ko";
 const ORCH = orchestratorPresent() && !/^(0|false|off|no)$/i.test(process.env.VTS_ORCH_BLOCK ?? "1");
 const orchRoot = () => process.env.VTS_PROJECT_PATH || readConfig().projectPath || process.cwd();
 // `target` (the file/dir the search names) generalizes the root: a file in a sibling sub-tree of the configured
-// project (Unreal Engine/ vs Game/, a monorepo package, a web/python workspace) resolves UP to ITS repo root
-// so qvts scopes where the file actually lives, not the unrelated configured root.
+// project (Unreal Engine/ vs Game/, a monorepo package, a web/python workspace) resolves UP to ITS repo root.
+// (A) record the resolved project when there's a target; reuse the last active project when there isn't, so a
+// target-less code search scopes to where you've been working, not the broad vault/monorepo parent.
+function resolveRoot(target) {
+  const fb = orchRoot();
+  if (target) { const r = resolveSearchRoot(target, fb) || fb; recordActiveProject(r); return r; }
+  return readActiveProject() || fb;
+}
 function qvtsCmd(task, target) {
-  const root = String((target ? resolveSearchRoot(target, orchRoot()) : orchRoot()) || orchRoot()).replace(/"/g, "'");
+  const root = String(resolveRoot(target)).replace(/"/g, "'");
   const t = String(task || "").replace(/\s+/g, " ").replace(/"/g, "'").trim().slice(0, 200);
   return `qvts -p "${root}" --json "${t}"`;
 }
+// (B) when the chosen root is a broad PARENT holding ≥2 sub-projects, nudge to scope -p to the specific one.
+function subprojectHint(root) {
+  const subs = subprojectsUnder(root);
+  if (subs.length < 2) return "";
+  const list = subs.slice(0, 5).join(", ");
+  return KO
+    ? `\n참고: "${root}"는 여러 프로젝트 포함 상위 폴더 — 정확/빠른 결과 위해 -p로 구체 프로젝트 지정 (후보: ${list}).`
+    : `\nNote: "${root}" is a parent of multiple projects — pass -p the specific one for accurate/fast results (candidates: ${list}).`;
+}
 function orchMsg(task, target) {
   const cmd = qvtsCmd(task, target);
-  return KO
+  const hint = subprojectHint(resolveRoot(target));
+  return (KO
     ? `✨ vs-token-safer: 로컬 오케스트레이터(qvts) 감지 — 이 코드검색은 위임하세요 (직접 grep/Read 말고).\n→ ${cmd}\n   (로컬 모델이 검색하고 compact 답만 반환 — Claude 토큰 절약. 결과 file:line은 사실로 신뢰; 못 찾으면 같은 호출 다시 하면 직접검색 통과.)`
-    : `✨ vs-token-safer: local orchestrator (qvts) detected — delegate this code search (don't grep/Read directly).\n→ ${cmd}\n   (the local model searches; only a compact answer returns — saves Claude tokens. Trust the file:line; if it finds nothing, re-issue and direct search passes.)`;
+    : `✨ vs-token-safer: local orchestrator (qvts) detected — delegate this code search (don't grep/Read directly).\n→ ${cmd}\n   (the local model searches; only a compact answer returns — saves Claude tokens. Trust the file:line; if it finds nothing, re-issue and direct search passes.)`) + hint;
 }
 const notSetUp = () => { try { return !fs.existsSync(CONFIG_FILE); } catch { return false; } };
 const SETUP_LINE = "\nNot set up yet? Run /vs-token-safer:setup (or `vts setup --projectPath <root>`) to configure the project root + backend.";
@@ -698,6 +714,9 @@ process.stdin.on("end", () => {
   // (code ext, not generated, not an already-sliced read, size ≥ threshold). VTS_READ_STEER=0 / matcher-removal off.
   if (toolName === "Read") {
     const fp = ti && ti.file_path;
+    // (A) a Read tells us which project the agent is working in — record it so a later target-less qvts search
+    // scopes to THIS project, not the broad vault/monorepo parent. Best-effort; never blocks a Read.
+    if (ORCH && fp) { try { recordActiveProject(resolveSearchRoot(fp, orchRoot())); } catch { /* ignore */ } }
     if (fp) {
       let sz = 0; try { sz = fs.statSync(fp).size; } catch { /* unreadable → leave 0 (no steer) */ }
       const minB = Number(process.env.VTS_READ_STEER_MIN ?? 6000);

--- a/hooks/orchestrator-redirect.js
+++ b/hooks/orchestrator-redirect.js
@@ -32,7 +32,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { orchestratorPresent, resolveSearchRoot } from "../server/policy.js";
+import { orchestratorPresent, resolveSearchRoot, recordActiveProject, readActiveProject, subprojectsUnder } from "../server/policy.js";
 
 const off = (v) => /^(0|false|off|no)$/i.test(String(v ?? ""));
 
@@ -59,7 +59,8 @@ const toolSuffix = (name) => String(name || "").replace(/^.*__/, ""); // mcp__pl
 const rootFor = (ti) => {
   const configured = ti.projectPath || ti.project_path || process.env.VTS_PROJECT_PATH || readConfig().projectPath || process.cwd();
   const target = ti.path || ti.file || "";
-  return target ? (resolveSearchRoot(target, configured) || configured) : configured;
+  if (target) { const r = resolveSearchRoot(target, configured) || configured; recordActiveProject(r); return r; } // (A) remember
+  return readActiveProject() || configured; // (A) target-less search inherits the last active project, not the broad parent
 };
 
 // Build a natural-language locate task from the MCP tool args, so the handed-back qvts command is ready to run.
@@ -114,10 +115,20 @@ function fallbackWindowOpen() {
   } catch { return false; }
 }
 
-function msg(qvtsCmd) {
+// (B) when the chosen root is a broad PARENT holding multiple sub-projects, nudge the caller to scope -p.
+function subprojectHint(root) {
+  const subs = subprojectsUnder(root);
+  if (subs.length < 2) return "";
+  const list = subs.slice(0, 5).join(", ");
   return KO
+    ? `\n참고: "${root}"는 여러 프로젝트를 포함한 상위 폴더예요. 정확/빠른 결과를 위해 작업 중인 구체 프로젝트를 -p로 지정하세요 (후보: ${list}).`
+    : `\nNote: "${root}" is a parent holding multiple projects. For accurate/fast results pass -p the specific one you're working on (candidates: ${list}).`;
+}
+function msg(qvtsCmd, root) {
+  const hint = root ? subprojectHint(root) : "";
+  return (KO
     ? `✨ vs-token-safer: 로컬 오케스트레이터(qvts) 감지 — 이 locate는 위임하세요.\n→ ${qvtsCmd}\n   (로컬 모델이 vs-search를 돌리고 compact 답만 반환 — Claude 토큰 절약. answer의 file:line은 사실로 신뢰; 바디는 read_symbol로 직접 읽기.)\n이미 위임했는데 no-match/에러였으면 같은 호출 다시 하면 통과됩니다. warn전환: VTS_ORCH_BLOCK=0`
-    : `✨ vs-token-safer: local orchestrator (qvts) detected — delegate this locate.\n→ ${qvtsCmd}\n   (the local model runs vs-search and returns only a compact answer — saves Claude tokens. Trust the answer's file:line; read bodies yourself with read_symbol.)\nAlready delegated and got no-match/error? Re-issue the same call and it passes. Warn-only: VTS_ORCH_BLOCK=0`;
+    : `✨ vs-token-safer: local orchestrator (qvts) detected — delegate this locate.\n→ ${qvtsCmd}\n   (the local model runs vs-search and returns only a compact answer — saves Claude tokens. Trust the answer's file:line; read bodies yourself with read_symbol.)\nAlready delegated and got no-match/error? Re-issue the same call and it passes. Warn-only: VTS_ORCH_BLOCK=0`) + hint;
 }
 
 let input = "";
@@ -141,12 +152,12 @@ process.stdin.on("end", () => {
   const fallbackWindow = fallbackWindowOpen(); // qvts recently came up dry → any direct search is the fallback
 
   if (blockOn() && !fallbackRetry && !fallbackWindow) {
-    process.stderr.write(msg(qvtsCmd) + "\n");
+    process.stderr.write(msg(qvtsCmd, root) + "\n");
     process.exit(2); // block — route this locate to the local orchestrator
   }
   // warn-only mode, OR a post-delegation fallback retry → allow, but surface the nudge.
   process.stdout.write(JSON.stringify({
-    hookSpecificOutput: { hookEventName: "PreToolUse", additionalContext: msg(qvtsCmd) },
+    hookSpecificOutput: { hookEventName: "PreToolUse", additionalContext: msg(qvtsCmd, root) },
   }) + "\n");
   process.exit(0);
 });

--- a/server/policy.js
+++ b/server/policy.js
@@ -95,6 +95,58 @@ export function resolveSearchRoot(target, configured) {
   } catch { return configured || null; }
 }
 
+// ---- active-project tracking (A) + multi-project guidance (B) ---------------------------------------
+// When working IN a vault/monorepo parent, a search with NO file target falls back to the configured root,
+// which may be the broad parent (everything) rather than the specific project. (A) remembers the LAST root we
+// resolved from a real target/file, so a later target-less search inherits it — e.g. once you touch a file in
+// .../SGE/Game, symbol searches scope to .../SGE/Game until you move to another project (TTL-bounded). (B)
+// when a root is a broad PARENT (no project marker of its own but ≥2 marked sub-projects), we surface those so
+// the caller can pass `-p <the specific one>`.
+const ACTIVE_FILE = path.join(os.homedir(), ".vts-local", "active-project.json");
+const ACTIVE_TTL = (() => { const n = Number(process.env.VTS_ACTIVE_PROJECT_TTL_MS); return Number.isFinite(n) && n > 0 ? n : 1800000; })(); // 30 min
+export function recordActiveProject(root) {
+  try {
+    if (!root) return;
+    const r = String(root);
+    if (!hasProjectMarker(r)) return; // only remember a REAL project root, never a bare parent/vault
+    fs.mkdirSync(path.dirname(ACTIVE_FILE), { recursive: true });
+    fs.writeFileSync(ACTIVE_FILE, JSON.stringify({ root: r, ts: Date.now() }));
+  } catch { /* best effort */ }
+}
+export function readActiveProject() {
+  try { const m = JSON.parse(fs.readFileSync(ACTIVE_FILE, "utf8")); if (m && m.root && Date.now() - m.ts <= ACTIVE_TTL) return m.root; } catch { /* none */ }
+  return null;
+}
+// Does `dir` itself look like a project root (a build/manifest marker directly inside it)?
+export function hasProjectMarker(dir) {
+  try { return fs.readdirSync(dir).some((e) => /\.(uproject|sln)$/i.test(e) || ROOT_MARKER_FILES.has(e) || e === "compile_commands.json"); }
+  catch { return false; }
+}
+// Sub-projects under a broad parent (dirs that ARE project roots, scanning up to 2 levels for UE-style nesting
+// where the marker sits a level below). Returns up to `max` relative paths; [] if `root` is itself a project.
+export function subprojectsUnder(root, max = 6) {
+  const out = [];
+  try {
+    if (hasProjectMarker(root)) return []; // root itself is a project → no need to disambiguate
+    const skip = /^(\.|node_modules$|Binaries$|Intermediate$|Saved$|build$|dist$|out$|obj$)/i;
+    const top = fs.readdirSync(root, { withFileTypes: true }).filter((e) => e.isDirectory() && !skip.test(e.name));
+    for (const e of top) {
+      const p1 = path.join(root, e.name);
+      if (hasProjectMarker(p1)) { out.push(e.name); }
+      else { // one level deeper (UE: parent/<X>/Game/*.uproject)
+        try {
+          for (const f of fs.readdirSync(p1, { withFileTypes: true })) {
+            if (f.isDirectory() && !skip.test(f.name) && hasProjectMarker(path.join(p1, f.name))) out.push(`${e.name}/${f.name}`);
+            if (out.length >= max) break;
+          }
+        } catch { /* ignore */ }
+      }
+      if (out.length >= max) break;
+    }
+  } catch { /* ignore */ }
+  return out;
+}
+
 // Generated code / build output / vendored deps — a semantic index adds nothing here; CC-native is fine.
 const SUPPRESS_DIR = /(^|[/\\])(Intermediate|Binaries|Saved|DerivedDataCache|node_modules|build|dist|out|obj|\.git)([/\\]|$)/i;
 const GENERATED = /\.(generated\.[a-z0-9]+|g\.cs|designer\.cs|pb\.(go|cc|h)|min\.js)$/i;


### PR DESCRIPTION
Patch. Helps a vault/monorepo parent route a target-less search to the **specific** project being worked on, not the broad parent.

### (A) Active-project auto-tracking
`recordActiveProject` / `readActiveProject` (`~/.vts-local/active-project.json`, 30-min TTL): any **Read** or **target-bearing** search records the resolved **real** project root (one with a build/manifest marker — `.uproject`/`.sln`/`package.json`/`pyproject.toml`/`go.mod`/`Cargo.toml`/`compile_commands.json`). A later **target-less** search inherits it, so it scopes to where you're working instead of the parent — and switches automatically as you move between projects.

### (B) Multi-project nudge
`subprojectsUnder` + a hint line: when the chosen root is a broad parent holding ≥2 sub-projects, the redirect message lists candidates and tells the caller to pass `-p` the specific one.

Wired into `orchestrator-redirect` and `block-code-grep` (the latter records the active project on a Read, too).

Tested: record TSGame → read back; `subprojectsUnder` lists vault sub-projects; syntax green; standalone vts unaffected (only active when qvts present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)