### PR TITLE
fix: resolveSearchRoot prefers the target's own project root over a stale configured default

### DIFF
--- a/server/policy.js
+++ b/server/policy.js
@@ -89,8 +89,17 @@ export function resolveSearchRoot(target, configured) {
     if (!configured) return markerWalk(t);
     const c = path.resolve(String(configured));
     if (isWithin(t, c)) return c;          // target lives inside the configured project → keep it (narrow, correct)
-    // target is in a SIBLING sub-tree (Unreal Engine/ vs Game/, another monorepo package): scope to the nearest
-    // common ancestor so qvts covers BOTH the configured project and the target — that's the real parent root.
+    // target is OUTSIDE configured. If it has its OWN project marker, `configured` is very likely just a STALE
+    // global default (e.g. from a past `vts setup` in an unrelated repo) rather than a true sibling package —
+    // trust the target's own root instead of forcing a merge, which would otherwise widen to a huge, unrelated
+    // common ancestor (live dogfood: a stale UE-game default + a target in an unrelated JS repo widened all
+    // the way to the drive-level vault folder holding a dozen unconnected projects, so every suggested -p
+    // candidate list was garbage).
+    const own = markerWalk(t);
+    if (hasProjectMarker(own) && path.resolve(own).toLowerCase() !== c.toLowerCase()) return own;
+    // target is in a genuine SIBLING sub-tree with no marker of its own (Unreal Engine/ vs Game/, another
+    // monorepo package): scope to the nearest common ancestor so qvts covers BOTH the configured project and
+    // the target — that's the real parent root.
     return commonAncestor(c, t) || c;
   } catch { return configured || null; }
 }


### PR DESCRIPTION
## Summary

Live-dogfood fix for the PreToolUse hook's `-p` suggestions pointing at the wrong tree.

**Bug**: when a search target lies outside the configured project, `resolveSearchRoot` unconditionally widened to `commonAncestor(configured, target)`. With a stale global default (a past `vts setup` in an unrelated repo), that ancestor escalated to a drive/vault-level folder holding dozens of unconnected projects — so every hook-suggested `-p` candidate list was garbage, steering delegated searches to the wrong root.

**Fix**: if the target has its own project marker distinct from the configured root, trust the target's marker-detected root (the configured value is a stale default, not a sibling). Genuine markerless siblings — Unreal `Engine/` vs `Game/` under one root, monorepo packages — still widen to the common ancestor exactly as before.

## Verification
- `eslint` clean, `node --check` pass.
- Unit: stale-default + JS-repo target → target's own root (was: vault root). Inside-configured target → configured (unchanged). Real UE tree Engine-file target → shared UE root (unchanged widening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)