### PR TITLE
chore: replace internal project names with generic placeholders in docs/eval/comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,10 +35,10 @@ Visual-Studio / IDE-agnostic sibling of `rider-mcp-enforcer`. Local-only. Ships 
   `{success:false}`, void reqs→null, unknown→MethodNotFound -32601); a timed-out request sends
   `$/cancelRequest`; client declares `synchronization` + `workspace.configuration` capabilities.
 - `server/scope.js` — INDEXING SCOPE (cold-latency attack): index a SUBTREE not the whole monorepo. Config
-  `scope` / `VTS_SCOPE` (comma-list of dirs rel to root); `vts setup --scope "TSGame,Plugins"` persists it.
+  `scope` / `VTS_SCOPE` (comma-list of dirs rel to root); `vts setup --scope "MyGame,Plugins"` persists it.
   `scopeDirs`/`inScope`/`scopedCdb` (writes a FILTERED compile_commands.json of only in-scope TUs to the
   out-of-tree dir → clangd `--compile-commands-dir` points there → it background-indexes far fewer TUs;
-  live UE5: `VTS_SCOPE=TSGame` = 3,377 of 26,488 TUs (13%), ~7.8× cut) / `scopeStats`. UNIVERSAL: every
+  live UE5: `VTS_SCOPE=MyGame` = 3,377 of 26,488 TUs (13%), ~7.8× cut) / `scopeStats`. UNIVERSAL: every
   backend's afterInit warm walk is scope-filtered too (no tsconfig/sln edit). `backends/index.js`
   `effectiveCdbDir(root)` = scoped CDB when scope set, else `resolveCdbDir`; `scopeDirsFor(root)`. clangd
   STATIC PREINDEX: `clangd-indexer` (full LLVM release bundles it; `VTS_CLANGD_INDEXER_CMD`/next-to-clangd/

--- a/README.ko.md
+++ b/README.ko.md
@@ -286,10 +286,10 @@ clangd는 비동기로 인덱싱하므로 *첫* 검색은 일회성 워밍업을
 
 ```bash
 vts scope --projectPath /path/to/UE        # 현재 스코프, 유지/전체 TU 수, 고를 수 있는 최상위 디렉터리 표시
-vts setup --scope "TSGame,Plugins"         # 영속화(또는 VTS_SCOPE="TSGame,Plugins"); 이후 reload/재시작
+vts setup --scope "MyGame,Plugins"         # 영속화(또는 VTS_SCOPE="MyGame,Plugins"); 이후 reload/재시작
 ```
 
-그러면 clangd가 스코프 내 번역 단위만 인덱싱하고(실측 UE5: `TSGame` → 26,488 중 3,377 TU, **13%**), 모든
+그러면 clangd가 스코프 내 번역 단위만 인덱싱하고(실측 UE5: `MyGame` → 26,488 중 3,377 TU, **13%**), 모든
 백엔드의 워밍도 함께 스코프됩니다. 스코프 미설정 = 기존 전체 트리 동작 그대로.
 
 **2. 사전 인덱싱 — 첫 질의 전에 인덱스를 빌드.**

--- a/README.md
+++ b/README.md
@@ -292,10 +292,10 @@ one real cost. Two opt-in levers cut it — both stay local, nothing is transmit
 
 ```bash
 vts scope --projectPath /path/to/UE        # shows current scope, kept/total TUs, and top-level dirs to pick
-vts setup --scope "TSGame,Plugins"         # persist it (or set VTS_SCOPE="TSGame,Plugins"); then reload/restart
+vts setup --scope "MyGame,Plugins"         # persist it (or set VTS_SCOPE="MyGame,Plugins"); then reload/restart
 ```
 
-clangd then indexes only the in-scope translation units (live UE5: `TSGame` → 3,377 of 26,488 TUs, **13%**),
+clangd then indexes only the in-scope translation units (live UE5: `MyGame` → 3,377 of 26,488 TUs, **13%**),
 and every backend's warm-up is scoped with it. No scope set = whole-tree behavior, unchanged.
 
 **2. Pre-index — build the index ahead of the first query.**

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -1184,7 +1184,7 @@ const editHookOk = editWarnOk && editEscalateOk;
 // `backend:"clangd"`-pinned global server → `-32001 invalid AST`) > forced BACKEND > path backend > "" (→ pickBackend).
 const { backendForPath, preferBackend } = await import("../server/core.js");
 const backendPathOk =
-  backendForPath("Plugins/TSEditorBridge/Python/trace_core.py") === "pyright" &&
+  backendForPath("Plugins/MyEditorPlugin/Python/trace_core.py") === "pyright" &&
   backendForPath("src/App.tsx") === "typescript" && backendForPath("a/b.mjs") === "typescript" &&
   backendForPath("Source/Foo.cpp") === "clangd" && backendForPath("Bar.h") === "clangd" &&
   backendForPath("Svc.cs") === "roslyn" &&
@@ -1965,7 +1965,7 @@ const { shouldSuppressSteer, routingDigest, suppressOn, readSteerDecision, topLe
 const supGen = shouldSuppressSteer("/p/Intermediate/Build/Foo.gen.cpp") === true;   // build output → suppress
 const supDotGen = shouldSuppressSteer("/p/Source/Foo.generated.h") === true;        // generated header → suppress
 const supNodeMod = shouldSuppressSteer("/p/node_modules/x/y.js") === true;          // vendored dep → suppress
-const supReal = shouldSuppressSteer("/p/Source/TSGame/Weapon.cpp") === false;       // real source → steer as usual
+const supReal = shouldSuppressSteer("/p/Source/MyGame/Weapon.cpp") === false;       // real source → steer as usual
 const supTogglePrev = process.env.VTS_SUPPRESS;
 process.env.VTS_SUPPRESS = "0";
 const supOff = shouldSuppressSteer("/p/Intermediate/Build/Foo.gen.cpp") === false && suppressOn() === false; // toggle off

--- a/server/viz.js
+++ b/server/viz.js
@@ -164,7 +164,7 @@ export function buildVizData(root) {
   // GLOBAL across every repo touched) + (2) a live, root-scoped IMPORT graph for JS/TS/Py (whose edges the
   // cache lacks). Ranking puts the DASHBOARD ROOT's files FIRST, then fan-in — so the repo you pointed the
   // dashboard at always appears instead of being drowned by a huge unrelated cached tree (the live-found
-  // "viz only shows TSGame, not my JS repo" gap). Capped to VTS_VIZ_MAX_NODES; links to dropped nodes pruned.
+  // "viz only shows MyGame, not my JS repo" gap). Capped to VTS_VIZ_MAX_NODES; links to dropped nodes pruned.
   const graph = (() => {
     const g = readJson(GRAPH_FILE);
     const entries = Object.entries(g).filter(([, e]) => e && Array.isArray(e.i));


### PR DESCRIPTION
Docs (README/README.ko/CLAUDE.md scope examples), one eval fixture path, and one code comment carried internal project/plugin names as examples. Replaced with generic placeholders (`MyGame` / `MyEditorPlugin`). Measurements and assertions unchanged — the eval checks backend routing by path shape (`Plugins/.../Python/*.py` → pyright), not by name. Full-history commit-message scan for stronger identifiers: clean on both repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)