### PR TITLE
feat: read_symbol tree-sitter fallback on crawl-risk clangd trees

### DIFF
--- a/server/core.js
+++ b/server/core.js
@@ -19,7 +19,7 @@ import { classifyDeclEdit } from "./edit-detect.js";
 import { counterfactualOn, relateSets, recordCounterfactual, grepKey, locKey, counterfactualReport } from "./counterfactual.js";
 import { recordEditEvent } from "./edit-ledger.js";
 import { compactGit, compactP4 } from "./compact.js";
-import { tsSearchSymbols, tsSearchReferences, tsFileDeclDocs, tsSupports, tsAvailable, htmlEmbeddedDecls, tsChunkEnd } from "./treesitter.js";
+import { tsSearchSymbols, tsSearchReferences, tsFileDeclDocs, tsSupports, tsAvailable, htmlEmbeddedDecls, tsChunkEnd, tsReadSymbol } from "./treesitter.js";
 import { searchSymIndex, buildSymIndex, symIndexPath, loadSymIndex } from "./symindex.js";
 import { splitIdent, tokenize, buildConceptModel, expandQuery, scoreSymbol, importSpecifiers, parseSynonyms, anchorConfident, prfTerms, parseConceptQuery } from "./concept.js";
 import { cochangeNeighbors } from "./cochange.js";
@@ -2913,9 +2913,31 @@ export async function runTool(name, a = {}) {
       // READ-side twin of replace_symbol_body: name a symbol → return ONLY that symbol's source (its outline
       // span), never the whole file. Kills the whole-file Read that precedes most edits (measured ~468k tok/30d
       // in the savings ledger). Reuses resolveSymbolForEdit verbatim; signatureOnly trims to the declaration head.
-      const c = await getClient(root, backendName);
-      const r = await resolveSymbolForEdit(c, root, backendName, a);
-      if (r.error) return err(r.error);
+      //
+      // SYNTACTIC FALLBACK: resolveSymbolForEdit calls clangd's documentSymbol, which on a crawl-risk tree
+      // times out or returns an empty/flat outline — so read_symbol dead-ended with no tree-sitter recourse
+      // (live: 6 consecutive failures → the model gave up and Read the whole 70-line span by hand). Tree-sitter
+      // reads ONE file with no backend and yields the full decl span, so try it FIRST when clangd can't serve
+      // fast, and as a fallback whenever the LSP path errors. Needs a file to parse: an explicit `path`, else
+      // the declaration file resolved from the committed index.
+      let synResolved = null;
+      const tryTsRead = async () => {
+        let f = a.path ? String(a.path) : null;
+        if (!f) { const syn = await syntacticSymbols(root, String(a.symbol || ""), 3); if (syn && syn.lines.length) f = syn.lines[0].split(/:\d+:/)[0]; }
+        if (!f || !a.symbol) return null;
+        const ts = await tsReadSymbol(f, String(a.symbol), { line: a.line != null ? Number(a.line) + 1 : null });
+        return ts ? { file: f, ds: { range: { start: { line: ts.startRow }, end: { line: ts.endRow } }, kind: 0 }, ambiguous: ts.matches, kindLabel: ts.kind, syntactic: true } : null;
+      };
+      const preferTs = backendName === "clangd" && clangdCrawlLikely(root).crawl &&
+        !/^(0|false|off|no)$/i.test(String(process.env.VTS_SYMBOL_PREEMPT ?? "1"));
+      let r;
+      if (preferTs) { synResolved = await tryTsRead(); }
+      if (!synResolved) {
+        const c = await getClient(root, backendName);
+        r = await resolveSymbolForEdit(c, root, backendName, a);
+        if (r.error) { synResolved = await tryTsRead(); if (!synResolved) return err(r.error); }
+      }
+      if (synResolved) r = synResolved;
       const sLine = r.ds.range.start.line, eLine = r.ds.range.end.line;
       const all = fs.readFileSync(r.file, "utf8").split(/\r?\n/);
       const sigOnly = a.signatureOnly === true || a.signatureOnly === "true";
@@ -2939,7 +2961,9 @@ export async function runTool(name, a = {}) {
       // #4 read-avoidance framing (Semble's "combined with file reading"): read_symbol's real win is the
       // WHOLE-FILE Read it replaces, so the savings baseline is the whole file (not the tiny {file,range}) —
       // the ledger then credits the avoided read, not ~0. (search/refs keep their index baseline.)
-      return finishOut(all.join("\n"), backendAdvisory(backendName, root) + `${SYMBOL_KIND[r.ds.kind] || "symbol"} "${a.symbol}" @ ${fp}:${sLine + 1}-${eLine + 1}${ambl} (backend: ${backendName}):\n` + body + note);
+      const kindLabel = r.syntactic ? (r.kindLabel || "symbol") : (SYMBOL_KIND[r.ds.kind] || "symbol");
+      const via = r.syntactic ? "tree-sitter (syntactic — clangd can't serve this tree fast)" : backendName;
+      return finishOut(all.join("\n"), (r.syntactic ? "" : backendAdvisory(backendName, root)) + `${kindLabel} "${a.symbol}" @ ${fp}:${sLine + 1}-${eLine + 1}${ambl} (backend: ${via}):\n` + body + note);
     }
     if (name === "rename") {
       if (!a.path || a.line == null || a.character == null || !a.newName) return err("rename needs path, line, character (0-based), newName.");

--- a/server/treesitter.js
+++ b/server/treesitter.js
@@ -517,6 +517,80 @@ export async function tsFileSymbols(absPath, { maxBytes = 2_000_000 } = {}) {
   return out;
 }
 
+// Resolve a symbol NAME to its FULL declaration span via tree-sitter — the read_symbol / edit twin of the
+// LSP documentSymbol range, but with zero backend. Needed because read_symbol previously went STRAIGHT to
+// clangd's documentSymbol: on a huge UE tree clangd can't serve fast, so the call timed out / returned an
+// empty outline and read_symbol dead-ended (live: 6 failures in a row → the model gave up and Read the
+// whole file). This mirrors the committed-index tier the search tools already fall back to.
+//   name match: exact (`Foo`) OR trailing-qualified (`UAssetManager::Foo` matches a query of `Foo`), so a
+//   bare method name resolves to its out-of-class definition. `line` (1-based, optional) disambiguates
+//   same-named decls by nearest start. Returns { startRow, endRow (0-based, inclusive), name, kind, matches }
+//   or null (deps absent / unsupported / too big / parse fail / no match).
+export async function tsReadSymbol(absPath, want, { line = null, maxBytes = 2_000_000 } = {}) {
+  const ext = extOf(absPath);
+  const entry = EXT_MAP[ext];
+  if (!entry || !want) return null;
+  const [wasmBase, cfgIn] = entry;
+  const cfg = cfgIn || GENERIC;
+  if (!cfg.decl) return null; // tags-query langs don't carry node ranges here — LSP/structure tier handles them
+  let src;
+  try {
+    const st = fs.statSync(absPath);
+    if (st.size > maxBytes) return null;
+    src = fs.readFileSync(absPath, "utf8");
+  } catch {
+    return null;
+  }
+  const lang = await loadLanguage(wasmBase);
+  if (!lang) return null;
+  const TS = _TS;
+  let parser, tree;
+  try {
+    parser = new TS.Parser();
+    parser.setLanguage(lang);
+    tree = parser.parse(src);
+  } catch {
+    return null;
+  }
+  try {
+    const decl = cfg.decl, kindMap = cfg.kind || {};
+    const hits = [];
+    const stack = [tree.rootNode];
+    let guard = 0;
+    while (stack.length && guard++ < 200000) {
+      const node = stack.pop();
+      if (decl.has(node.type)) {
+        const nm = nameOf(node);
+        // exact, or the query is the trailing segment of a qualified name (Class::method, ns::fn)
+        if (nm && (nm === want || nm.endsWith("::" + want) || nm.split("::").pop() === want)) {
+          hits.push({ startRow: node.startPosition.row, endRow: node.endPosition.row, name: nm.slice(0, 120), kind: kindMap[node.type] || node.type });
+        }
+      }
+      for (let i = node.namedChildCount - 1; i >= 0; i--) stack.push(node.namedChild(i));
+    }
+    if (!hits.length) return null;
+    // Prefer a match whose name is EXACTLY the query (a bare-name decl over a coincidental qualified one),
+    // then — when a line hint is given — the nearest start; otherwise the LARGEST span (the definition with a
+    // body beats a one-line forward declaration).
+    hits.sort((a, b) => {
+      const ax = a.name === want ? 0 : 1, bx = b.name === want ? 0 : 1;
+      if (ax !== bx) return ax - bx;
+      if (line != null) return Math.abs(a.startRow - (line - 1)) - Math.abs(b.startRow - (line - 1));
+      return (b.endRow - b.startRow) - (a.endRow - a.startRow);
+    });
+    return { ...hits[0], matches: hits.length };
+  } catch {
+    return null;
+  } finally {
+    try {
+      tree.delete && tree.delete();
+      parser.delete && parser.delete();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
 // cAST-inspired structural chunking (migrated from "cAST: Structural Chunking via AST", arXiv:2506.15655):
 // when a declaration body exceeds a line budget, cut at a STRUCTURAL boundary (the end of a complete child
 // node — a member/statement) instead of mid-statement, so read_symbol returns syntactically whole output


### PR DESCRIPTION
## Summary
`read_symbol` resolved bodies ONLY via clangd's documentSymbol — on a huge UE tree clangd can't serve fast, so the call timed out / returned an empty outline and read_symbol dead-ended (live: **6 consecutive failures → the model gave up and Read the whole 70-line span by hand** — the exact whole-file read this tool exists to kill).

- **`tsReadSymbol(path, name, {line})`** (new, treesitter.js): parses one file, matches the decl by name — exact OR trailing-qualified (bare `GetPrimaryAssetIdForObject` → `UAssetManager::GetPrimaryAssetIdForObject`) — returns the full decl span, no backend.
- read_symbol tries tree-sitter FIRST when clangd is crawl-likely (shared `clangdCrawlLikely`), and as a fallback on any LSP error. File comes from explicit `path` or the committed-index declaration file.
- Healthy backends untouched — verified read_symbol on the JS repo still uses the `typescript` LSP path.

## Measured
read_symbol `UAssetManager::GetPrimaryAssetIdForObject` on the UE cluster: 6-failures-then-manual-Read → the 5-line body instantly, both with an explicit path and via committed-index file resolution.

eslint + node --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)