### PR TITLE
docs(bench): syntactic tier vs clangd — same location, ~530x faster cold

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -94,6 +94,32 @@ likely-query-first.
 **Takeaway:** tokens win massively and unconditionally (~97–99%). Wall-clock wins when the scope is
 large/unknown (Engine included) and the index is warm; a cold first query is the price you pay once.
 
+## Syntactic tier (tree-sitter) vs semantic (clangd) — the graceful-degradation payoff
+
+When clangd is **missing, cold, or still indexing**, vs-token-safer answers on the **SYNTACTIC** (tree-sitter)
+tier from a committable index instead of blocking — then climbs to EXACT once clangd is warm. Measured on a
+**second real Unreal Engine 5 game module** (3,143 files, 133,890 symbols — aggregate counts only; no paths or
+project symbol names reproduced):
+
+| | tree-sitter tier (SYNTACTIC) | clangd (EXACT) |
+| --- | ---: | ---: |
+| Locate latency | **~240 ms** | ~127 s (cold-to-first-answer) |
+| Position accuracy | reference | **identical — 4/4 sampled symbols, line delta 0** |
+| Index build | ~62 s one-time (133,890 symbols) | cold-index each cold session |
+
+- **Accuracy:** across a sample of unique class/struct declarations, the tree-sitter position matched clangd's
+  authoritative EXACT position **exactly** (line delta 0). For *declaration location*, the syntactic tier is as
+  correct as the semantic one — it just can't resolve overloads/types, which is what the EXACT rung is for.
+- **Latency:** the tree-sitter answer returns in ~240 ms; clangd's **first (cold)** answer on the same module
+  took ~127 s — a **~530×** gap that clangd's semantic power does not close for a plain locate. (In a warm
+  session clangd is sub-second; the point is you no longer wait for warm to get the location.)
+- **Token flood, same module:** on high-usage symbols, `search_symbol` (capped declarations) vs whole-tree
+  grep-and-paste (every usage) came out to **~43× fewer tokens (97.7% saved)** — grep dumps every
+  comment/usage/include line; the plugin returns the capped declaration list.
+
+This is why the ladder answers **tree-sitter-first** on a cold/large tree and climbs to EXACT once clangd is
+warm: you get the same `file:line` **now**, and semantic certainty **later**.
+
 ## Accuracy difference (and why)
 
 The two paths optimize differently — it is a **precision/recall trade**, not "one is simply correct":

--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ strings, unrelated identifiers); the plugin returns one `file:line` per semantic
 eval (`node eval/run.mjs`, no toolchain) gates this on every commit: `~57,308 → ~1,549 tok` = **97.3%**
 (53/53 checks).
 
+**Syntactic tier vs clangd — same location, no cold wait.** On a second real UE5 game module (3,143 files,
+133,890 symbols; aggregate counts only), the tree-sitter tier returned the **same `file:line`** as clangd's
+EXACT answer on every sampled symbol (line delta 0), in **~240 ms** vs clangd's **~127 s** cold-to-first-answer
+— a ~530× gap the semantic tier doesn't close for a *locate*. That's why the ladder answers tree-sitter-first
+while clangd warms, then climbs to EXACT. One-time index build ~62 s; details in [BENCHMARK.md](BENCHMARK.md).
+
 <details>
 <summary><b>Accuracy: precision/recall trade-off</b></summary>
 


### PR DESCRIPTION
Adds the graceful-degradation benchmark (real UE5 game module, aggregate counts only — no paths/symbols) to BENCHMARK.md + README:

- **Accuracy:** tree-sitter position == clangd EXACT position, 4/4 sampled symbols, line delta 0.
- **Latency:** tree-sitter ~240 ms vs clangd ~127 s cold-to-first-answer (~530×).
- **Token flood:** ~43× fewer than whole-tree grep on high-usage symbols (97.7% saved).
- Index build ~62 s one-time (133,890 symbols / 3,143 files).

Justifies the §9 tree-sitter-first ladder merged in #212. Privacy-safe per CONTRIBUTING (no source, paths, or project symbol names — aggregate only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)