### PR TITLE
release: v1.0.1 — honest parse errors (source-corruption fix) + CI actually tests the syntactic tier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,13 @@ jobs:
       - name: Install MCP server deps
         working-directory: server
         run: npm install --no-audit --no-fund
+      # The eval above runs BEFORE this install ON PURPOSE (it proves the core works dependency-free). But that
+      # means tree-sitter is absent there, so guard 81 — the whole SYNTACTIC tier, 36 languages — self-skips and
+      # prints a PASS. CI was therefore never testing that tier at all, which is how a grammar that silently
+      # drops declarations survived to 1.0. Run the eval a SECOND time now that the deps exist, so the tier is
+      # actually exercised. Cheap (mock LSP, no toolchain) and the only place it gets covered.
+      - name: Eval again WITH deps (exercises the tree-sitter SYNTACTIC tier the dep-free run skips)
+        run: node eval/run.mjs
       - name: MCP server boots + lists tools
         shell: bash
         run: node server/index.js < .github/smoke/mcp-init.jsonl

--- a/eval/fixtures/rank-corpus/auth/quarantine.ts
+++ b/eval/fixtures/rank-corpus/auth/quarantine.ts
@@ -1,0 +1,9 @@
+// Quarantine a credential flagged by the anomaly detector until an operator reviews it.
+export function quarantineCredential(user: string) {
+  return user.length > 0;
+}
+
+// Revoke a compromised token immediately and blocklist its fingerprint.
+export function revokeCompromisedToken(token: string) {
+  return !token;
+}

--- a/eval/rank-bench.mjs
+++ b/eval/rank-bench.mjs
@@ -14,6 +14,15 @@
 // apart from a source edit). A committed synthetic corpus makes every metric attributable to a RANKING change
 // alone. Synthetic names only (charter: no real paths/symbols).
 //
+// SURPRISE RUNG ("lost if surprise", adapted from the gist-compression failure study arXiv:2412.17483). Gist/
+// context COMPRESSION loses the SURPRISING (rare, high-information) token first — in code that is exactly the
+// identifier you were hunting. vts does not compress (it OMITS bodies and returns addresses), but its fuzzy
+// GATES could still lose a rare decl: a df=1 token can't be expanded through (minCooc 2 / df >= 2) and can't
+// become a PRF feedback term (minDocs 2). Measured, not assumed — and it does NOT reproduce: a rare identifier
+// ranks #1 on a direct match (idf REWARDS the rarity) and #1 even against common-token competitors; only a PURE
+// synonym gap onto a df=1 term demotes it (rank 4) — demoted, still inside the K budget, not lost. Scored as its
+// OWN rung so it never moves the fuzzy MRR gate (fuzzy MRR is 0.848 with and without this corpus extension).
+//
 // Backend-free by construction: the fuzzy rung (concept_search) never uses an LSP; the syntactic rung is tested
 // by calling tsSearchSymbols DIRECTLY (not search_symbol -> the LSP backend, which would intercept a multi-word
 // query before the syntactic fallback and confound the metric — that path is guarded deterministically in
@@ -57,6 +66,20 @@ const GOLD = [
   { q: "remove old items from the cache", rung: "fuzzy", answers: ["evictEntry"] }, // remove~evict, old~stale; distractors clearCache/resizeCache
   { q: "log the user out", rung: "fuzzy", answers: ["logoutUser"] }, // direct
   { q: "renew an expired access token", rung: "fuzzy", answers: ["refreshToken"] }, // renew/expired~refresh
+  // --- surprise rung: "LOST IF SURPRISE" (the gist-compression failure mode, arXiv:2412.17483, adapted). A
+  // compressor loses the SURPRISING token first — in code that is exactly the rare identifier you were hunting.
+  // We don't compress (we omit bodies and return addresses), but our fuzzy GATES could still lose it: a df=1
+  // token can't be expanded through (minCooc 2 / df >= 2) and can't become a PRF feedback term (minDocs 2). So
+  // measure it directly, separately from the fuzzy MRR gate. auth/quarantine.ts holds the rare decls.
+  // (a) DIRECT: the rare token is IN the query -> idf should REWARD the rarity, not lose it.
+  { q: "quarantine a flagged credential", rung: "surprise", answers: ["quarantineCredential"] },
+  // (b) RARE-VS-COMMON: rare tokens compete with common-"token" decls (refreshToken/validateSession) -> does
+  // the high-idf rare decl still win the head of the list?
+  { q: "blocklist a compromised token", rung: "surprise", answers: ["revokeCompromisedToken"] },
+  // (c) BRIDGE: a PURE synonym gap onto a df=1 term (isolate~quarantine, suspicious~anomaly); only the common
+  // "credential" overlaps. Expansion CANNOT bridge it (the neighbour gates need df >= 2). This is the honest
+  // embedding-residual made measurable — a MISS here is a reported limit, not a regression.
+  { q: "isolate a suspicious credential", rung: "surprise", answers: ["quarantineCredential"] },
   // --- syntactic rung (tsSearchSymbols direct): exact + MULTI-WORD token coverage (the LocAgent capability) ---
   { q: "validateSession", rung: "syntactic", answers: ["validateSession"] },
   { q: "charge payment", rung: "syntactic", answers: ["chargePayment"] },
@@ -70,7 +93,7 @@ const SKIP = new Set(["node_modules", ".git"]);
 
 // Ordered list of result symbol NAMES for a gold query, per rung.
 async function resultNames(g) {
-  if (g.rung === "fuzzy") {
+  if (g.rung === "fuzzy" || g.rung === "surprise") {   // the surprise probes ride the same fuzzy path, scored apart
     const r = await runTool("concept_search", { q: g.q, projectPath: ROOT, maxResults: 20 });
     if (!r || r.isError) return [];
     return String(r.text)
@@ -106,6 +129,7 @@ function agg(items) {
 }
 const byRung = {
   fuzzy: agg(rows.filter((r) => r.rung === "fuzzy")),
+  surprise: agg(rows.filter((r) => r.rung === "surprise")),
   syntactic: agg(rows.filter((r) => r.rung === "syntactic")),
   all: agg(rows),
 };
@@ -113,7 +137,7 @@ const byRung = {
 const pct = (x) => (x * 100).toFixed(0).padStart(3) + "%";
 console.log(`\nrank-bench — frozen corpus eval/fixtures/rank-corpus (${rows.length} queries)\n`);
 console.log("rung        n   R@1   R@3   R@5  R@10   MRR   Cov");
-for (const k of ["fuzzy", "syntactic", "all"]) {
+for (const k of ["fuzzy", "surprise", "syntactic", "all"]) {
   const a = byRung[k];
   console.log(`${k.padEnd(10)} ${String(a.n).padStart(2)}  ${pct(a.recall[1])}  ${pct(a.recall[3])}  ${pct(a.recall[5])}  ${pct(a.recall[10])}  ${a.mrr.toFixed(3)}  ${pct(a.coverage)}`);
 }

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -29,6 +29,13 @@ process.env.VTS_TEE_DIR = TEE;
 const EDL = path.join(os.tmpdir(), `vts-eval-edl-${process.pid}.json`); // isolate the edit-adoption ledger
 process.env.VTS_EDIT_LEDGER = EDL; // so the symbolic-edit guards don't write the user's real adoption ledger
 process.env.VTS_LANG = "en"; // force English UI so message-marker assertions are deterministic regardless of OS locale
+// Pin the local-LLM ORCHESTRATOR off. Detection is ambient (a `qvts` on PATH, or ~/.vts-local/config.json), so a
+// maintainer who has the vts-local-orchestrator installed gets a DIFFERENT hook/tool behaviour than CI: the Bash
+// grep rewrite reroutes to `qvts` instead of the `vts` CLI these guards assert, and ~10 guards go red on their
+// machine only. Pinning it off makes the eval hermetic (CLAUDE.md tells every session to run it first, so it must
+// not depend on what else the developer has installed). The orchestrator-aware path deserves its OWN guard that
+// forces VTS_ORCHESTRATOR=1 rather than inheriting the ambient install.
+process.env.VTS_ORCHESTRATOR_AWARE = "0";
 const { runTool, disposeClients, prewarm } = await import("../server/core.js");
 
 const tok = (s) => Math.round(Buffer.byteLength(String(s), "utf8") / 4);
@@ -149,10 +156,18 @@ const hv = await runTool("hover", { path: someFile, line: 0, character: 0, backe
 // hover keeps the signature AND trims a pathological long line to ≤200 chars + "…" (per-line cap, not just
 // the ≤8-line cap) — a complex TS/C++ hover can be one multi-thousand-char type.
 const hoverOk = !hv.isError && /Foo/.test(hv.text) && /…/.test(hv.text) && !/T{250}/.test(hv.text);
+// Pin the SYNTACTIC PRE-EMPT off: this guard tests the BACKEND outline + its noise filter, and the pre-empt
+// (clangd + crawl-risk root + tree-sitter supports the file) would answer from tree-sitter instead — outlining
+// the REAL file rather than the mock's fixture symbols, so every assertion below silently tests the wrong path.
+// It only passed on CI because CI lacks the OPTIONAL tree-sitter deps; any dev machine with them went red.
+// The pre-empt itself is covered by guard 81; here it must be out of the way. (Same scoping as VTS_OUTLINE_RAW.)
+const spPrev = process.env.VTS_SYMBOL_PREEMPT;
+process.env.VTS_SYMBOL_PREEMPT = "0";
 const ds = await runTool("document_symbols", { path: someFile, backend: "clangd" });
 process.env.VTS_OUTLINE_RAW = "1";
 const dsRaw = await runTool("document_symbols", { path: someFile, backend: "clangd" });
 delete process.env.VTS_OUTLINE_RAW;
+if (spPrev === undefined) delete process.env.VTS_SYMBOL_PREEMPT; else process.env.VTS_SYMBOL_PREEMPT = spPrev;
 const docSymOk =
   !ds.isError && /Foo/.test(ds.text) && /:5/.test(ds.text) &&
   /keepMethod/.test(ds.text) &&                  // real method kept
@@ -2002,7 +2017,7 @@ const policyOk = supGen && supDotGen && supNodeMod && supReal && supOff && digOk
 // 81) SYNTACTIC tier: tree-sitter declaration extraction (treesitter.js) + the committable symbol index
 // (symindex.js). The zero-setup fallback that works on any repo with no toolchain — a real AST decl, not a
 // literal usage grep. Skips gracefully if the optional tree-sitter deps aren't installed (CI without them).
-const { tsFileSymbols, tsFileReferences, tsSearchSymbols, tsSearchReferences, tsAvailable } = await import("../server/treesitter.js");
+const { tsFileSymbols, tsFileReferences, tsSearchSymbols, tsSearchReferences, tsAvailable, tsReadSymbol } = await import("../server/treesitter.js");
 const { buildSymIndex, loadSymIndex, searchSymIndex, hasSymIndex } = await import("../server/symindex.js");
 let tsTierOk = true;
 if (tsAvailable()) {
@@ -2124,21 +2139,60 @@ if (tsAvailable()) {
   const luaSyms = await tsFileSymbols(path.join(tsDir, "sub", "mod.lua"));
   fs.writeFileSync(path.join(tsDir, "sub", "Token.sol"), "contract Token { uint public supply; function transfer() public {} event Sent(uint a); }\n");
   const solSyms = await tsFileSymbols(path.join(tsDir, "sub", "Token.sol"));
+  // NOTE: the Lua fixture's `local M = {}` is MIS-PARSED by the bundled tree-sitter-lua (a table constructor
+  // becomes an unterminated string: ERROR + MISSING _string_end). A `local function helper() end` after it is
+  // recovered only by ERROR RECOVERY, whose outcome shifts with how many grammars are resident in the process
+  // (0-5 loaded → found; 7+ → dropped). The old assertion that `helper` extracts therefore passed by LUCK and
+  // was testing grammar-load order, not our code. It is replaced by the honest contract below (parseHealthOk):
+  // the decls that DO survive are still returned, and the answer is REPORTED degraded.
   const newLangOk =
     cMacroSyms.some((s) => s.name === "MAX_LEN" && s.kind === "macro") &&
     cMacroSyms.some((s) => s.name === "SQUARE" && s.kind === "macro") &&
     cMacroSyms.some((s) => s.name === "RED" && s.kind === "const") &&
     luaSyms.some((s) => /doThing/.test(s.name) && s.kind === "func") &&
-    luaSyms.some((s) => s.name === "helper" && s.kind === "func") &&
     solSyms.some((s) => s.name === "Token" && s.kind === "class") &&
     solSyms.some((s) => s.name === "transfer" && s.kind === "func") &&
     solSyms.some((s) => s.name === "supply" && s.kind === "field") &&
     solSyms.some((s) => s.name === "Sent" && s.kind === "event");
-  tsTierOk = fileExtractOk && searchOk && rankOk && idxPresent && idxLoadOk && idxSearchOk && multiWordOk && partialFallbackOk && refOk && noBackendRefOk && tagsTierOk && incrOk && htmlInjectOk && chunkOk && newLangOk;
+  // (j) HONEST PARSE ERRORS: tree-sitter RECOVERS rather than throwing, so a grammar that can't parse a file
+  // silently drops decls. tsFileSymbols now REPORTS that (.parseError), and the SPAN-producing functions
+  // REFUSE (null) — a span from a recovered tree feeds replace_symbol_body/safe_delete and would splice the
+  // wrong lines, i.e. corrupt source. Read-only lists report; span producers refuse.
+  // The healthy-path assertions deliberately use TypeScript, not Lua: the bundled Lua grammar errors on more
+  // than the table constructor (even `local x = 1` followed by a `local function` reports a bad parse), so a
+  // Lua "clean" fixture would be testing the grammar's luck again. Lua is used ONLY as the degraded case.
+  const luaBad = await tsFileSymbols(path.join(tsDir, "sub", "mod.lua"));   // `local M = {}` → ERROR + MISSING
+  fs.writeFileSync(path.join(tsDir, "sub", "clean.ts"), "export function goodClean(){ return 1; }\n");
+  const tsClean = await tsFileSymbols(path.join(tsDir, "sub", "clean.ts"));
+  fs.writeFileSync(path.join(tsDir, "sub", "broken.ts"), "export function good(){ return 1; }\nfunction ((( {\n");
+  const brokenSyms = await tsFileSymbols(path.join(tsDir, "sub", "broken.ts"));
+  const parseHealthOk =
+    luaBad.parseError === true &&                       // the mis-parse is REPORTED, not hidden
+    luaBad.some((s) => /doThing/.test(s.name)) &&       // …and the decls that DID survive are still returned
+    brokenSyms.parseError === true &&                   // language-agnostic: not a Lua special case
+    !tsClean.parseError &&                              // a cleanly-parsed file is NOT falsely degraded
+    tsClean.some((s) => s.name === "goodClean") &&
+    (await tsReadSymbol(path.join(tsDir, "sub", "broken.ts"), "good")) === null &&        // span producer REFUSES
+    (await tsChunkEnd(path.join(tsDir, "sub", "broken.ts"), 0, 1, 1)) === null &&
+    (await tsReadSymbol(path.join(tsDir, "sub", "clean.ts"), "goodClean")) !== null;      // …but still serves a clean parse
+  tsTierOk = fileExtractOk && searchOk && rankOk && idxPresent && idxLoadOk && idxSearchOk && multiWordOk && partialFallbackOk && refOk && noBackendRefOk && tagsTierOk && incrOk && htmlInjectOk && chunkOk && newLangOk && parseHealthOk;
   try { fs.rmSync(tsDir, { recursive: true, force: true }); } catch { /* ignore */ }
 } else {
   console.log("  (tree-sitter deps absent — syntactic tier guard skipped, treated as pass)");
 }
+// The DEGRADED honesty contract is a PURE render, so assert it OUTSIDE the tsAvailable() gate above — CI runs
+// this eval BEFORE `npm install` (test.yml), so everything inside that gate is skipped and printed as a pass.
+// This keeps the contract enforced on CI even there: a degraded syntactic answer must SAY decls are missing
+// and name the re-certify command; a healthy one must be unchanged (no cost on the good path).
+const { completenessCert: cCert } = await import("../server/core.js");
+const certDegraded = cCert({ syntactic: true, shown: 3, parseError: 1 });
+const certPlain = cCert({ syntactic: true, shown: 3 });
+const certDegradedOk =
+  /DEGRADED/.test(certDegraded) && /MISSING/.test(certDegraded) && /search_text/.test(certDegraded) &&
+  /NOT absence/.test(certDegraded) &&                                   // a short list must not read as "none exist"
+  /2 file\(s\)/.test(cCert({ syntactic: true, shown: 3, parseError: 2 })) && // plural count surfaces
+  /SYNTACTIC rung/.test(certPlain) && !/DEGRADED/.test(certPlain) &&    // healthy path untouched
+  !/DEGRADED/.test(cCert({ semantic: true, shown: 3, parseError: 1 })); // parseError only degrades the SYNTACTIC rung
 
 // 82) Roslyn dotnet-host path is OS-aware (Mac mini C# regression): VS Code's globalStorage dir differs per
 // platform; a Windows-only hardcode made the Roslyn .NET host miss on macOS/Linux → system dotnet (too old
@@ -2505,6 +2559,7 @@ const rows = [
   ["symbolic editing: replace/insert/safe_delete by name (preview+apply+ref-guard)", symEditOk, "true", symEditOk],
   ["edit-steer: search EDIT_STEER (toggle) + discover counts whole-decl Edit", editSteerOk, "true", editSteerOk],
   ["discover: agent-spawn accounting (exact totalTokens + fleet/heavy/advisory, toggle)", agentDiscOk, "true", agentDiscOk],
+  ["honest parse errors: SYNTACTIC · DEGRADED cert names the missing decls + re-certify cmd (pure, runs dep-free)", certDegradedOk, "true", certDegradedOk],
   ["edit-steer hook: L1 warn (replace/insert) + L2 safe-insert escalation", editHookOk, "true", editHookOk],
   ["per-file-language backend (.py→pyright in a clangd-rooted mixed repo)", backendPathOk, "true", backendPathOk],
   ["census fallback: path-less search_symbol retries OTHER backends present in the mixed repo (census-desc, gated)", censusFallbackOk, "true", censusFallbackOk],

--- a/server/core.js
+++ b/server/core.js
@@ -1340,8 +1340,16 @@ function climbCommandFor(name) {
 }
 // truncated: falsy | "cap" | "time" | "scan". semantic=true → a language-server index answered (authoritative
 // 0); false → a bounded lexical scan. shown/total optional (total null = unknown upper bound).
-function completenessCert({ shown = 0, total = null, truncated = null, semantic = false, scoped = false, syntactic = false, fuzzy = false, section = false, stale = 0 } = {}) {
+function completenessCert({ shown = 0, total = null, truncated = null, semantic = false, scoped = false, syntactic = false, fuzzy = false, section = false, stale = 0, parseError = 0 } = {}) {
   if (!certOn()) return "";
+  // SYNTACTIC · DEGRADED — the grammar could not parse the source, so tree-sitter RECOVERED and the decl walk
+  // silently dropped whatever the error swallowed. Ranked ABOVE stale: stale means the positions may be off
+  // (recomputable), degraded means decls are MISSING (unnoticeable). Actionable like every cert — it names
+  // search_text, the literal rung BELOW, which no grammar can fool.
+  if (syntactic && parseError) {
+    const n = typeof parseError === "number" && parseError > 1 ? `${parseError} file(s)` : "this file";
+    return `\n[completeness: SYNTACTIC · DEGRADED — ${shown} decl(s); the grammar could not parse ${n}, so decls are MISSING (a short list is NOT absence). Re-certify: search_text q="<name>", or install a language server.]`;
+  }
   // SYNTACTIC · STALE — the committed index answered, but the freshness probe found source(s) changed since it
   // was built, so the file:line may be off (§4). Still returns the answer; the cert just downgrades honesty and
   // the caller pairs it with a `climb: vts index` ladder line. Takes precedence over the plain SYNTACTIC label.
@@ -3154,7 +3162,7 @@ export async function runTool(name, a = {}) {
           const capNote = tsyms.length > max ? `\n… ${tsyms.length - max} more — raise maxResults (now ${max}).` : "";
           let _base = tsyms; try { _base = fs.readFileSync(a.path, "utf8"); } catch { /* keep syms baseline */ }
           try { recordQueryResults(root, [a.path]); } catch { /* best-effort */ }
-          return finishOut(_base, `outline of ${a.path} (tree-sitter — clangd can't serve this tree fast):\n` + shown + capNote + completenessCert({ shown: Math.min(tsyms.length, max), total: tsyms.length, truncated: tsyms.length > max ? "cap" : null, syntactic: true }));
+          return finishOut(_base, `outline of ${a.path} (tree-sitter — clangd can't serve this tree fast):\n` + shown + capNote + completenessCert({ shown: Math.min(tsyms.length, max), total: tsyms.length, truncated: tsyms.length > max ? "cap" : null, syntactic: true, parseError: tsyms.parseError ? 1 : 0 }));
         }
       }
       c.didOpen(a.path, lang);

--- a/server/symindex.js
+++ b/server/symindex.js
@@ -220,7 +220,8 @@ async function buildSymIndexSingle(
     symbols = 0,
     timedOut = false,
     reused = 0,
-    reparsed = 0;
+    reparsed = 0,
+    parseErrors = 0; // files whose grammar could not parse them — recorded, not skipped (see below)
   const newHashes = {};
   // Stream symbol records to a temp file as we walk. A full UE Engine tree has MILLIONS of symbols; buffering
   // them in an array and joining with "\n" at the end exhausted the V8 heap (Zone OOM) even at 16 GB. A write
@@ -269,11 +270,13 @@ async function buildSymIndexSingle(
       const mt = Math.round(st.mtimeMs),
         sz = st.size;
       const pri = priorHashes[rel];
-      let recs, h;
+      let recs, h, bad;
       if (pri && pri.mt === mt && pri.sz === sz) {
         // unchanged by stat → reuse, no read, no parse (the fast path)
         recs = priorByFile.get(rel) || [];
         h = pri.h;
+        bad = pri.e; // a bad parse is BAKED IN: the fast path reuses records verbatim until the bytes change,
+        //             so the flag must ride along with them or the index silently launders the defect.
         reused++;
       } else {
         // stat changed (or new file): read + hash. If the content hash still matches, reuse (mtime jitter).
@@ -286,6 +289,7 @@ async function buildSymIndexSingle(
         h = fnv1a(src);
         if (pri && pri.h === h) {
           recs = priorByFile.get(rel) || [];
+          bad = pri.e;
           reused++;
         } else {
           let syms;
@@ -295,10 +299,15 @@ async function buildSymIndexSingle(
             continue;
           }
           recs = syms.map((s) => ({ f: rel, n: s.name, k: s.kind, l: s.line }));
+          // RECORD, don't skip: a partial parse still yields useful decls, and dropping the file would lose
+          // them AND the evidence. (Deliberately NOT folded into the 0-symbol abort below — that guard exists
+          // for a DEGENERATE build clobbering a good index; a partial parse is not degenerate.)
+          bad = syms.parseError ? 1 : undefined;
+          if (bad) parseErrors++;
           reparsed++;
         }
       }
-      newHashes[rel] = { mt, sz, h }; // remember every seen file (incl. empty) so it isn't re-read next time
+      newHashes[rel] = { mt, sz, h, e: bad }; // remember every seen file (incl. empty) so it isn't re-read next time
       if (!recs.length) continue;
       files++;
       for (const r of recs) {
@@ -329,6 +338,7 @@ async function buildSymIndexSingle(
     symbols,
     maxMtime: _maxMtimeOf(newHashes), // freshness watermark (S3 staleness probe)
     partial: timedOut || undefined,
+    parseErrors: parseErrors || undefined, // grammar couldn't parse N file(s) → their decls are incomplete
     h: newHashes,
   });
   // Final file = header line + the streamed temp body, joined by PIPE (not read-into-a-string) so a
@@ -348,7 +358,7 @@ async function buildSymIndexSingle(
   } catch {
     /* temp already gone */
   }
-  return { files, symbols, path: finalPath, partial: timedOut, reused, reparsed };
+  return { files, symbols, path: finalPath, partial: timedOut, reused, reparsed, parseErrors };
 }
 
 // ── Chunked, multi-process builder ──────────────────────────────────────────────────────────────────────────
@@ -839,5 +849,14 @@ export function searchSymIndex(root, q, { max = 40 } = {}) {
   if (hits.length > max) sliced.truncated = "cap";
   sliced.fromIndex = true;
   sliced.meta = idx.meta;
+  // Degrade PER-HIT, not per-index: a repo with 3 unparsable files must not stamp every unrelated answer
+  // DEGRADED. Only when a RETURNED record came from a file the manifest flagged (e:1) is this answer's decl
+  // set actually suspect.
+  const h = idx.meta && idx.meta.h;
+  if (h) {
+    const badFiles = new Set();
+    for (const s of sliced) { const rel = path.relative(root, s.file).replace(/\\/g, "/"); if (h[rel] && h[rel].e) badFiles.add(rel); }
+    if (badFiles.size) sliced.parseErrorFiles = badFiles.size;
+  }
   return sliced;
 }

--- a/server/treesitter.js
+++ b/server/treesitter.js
@@ -524,6 +524,11 @@ export async function tsFileSymbols(absPath, { maxBytes = 2_000_000 } = {}) {
   } catch {
     return [];
   }
+  // A recovered (ERROR/MISSING) tree still yields decls, but silently DROPS others — report it rather than
+  // hide it. Carried as a property on the returned array: the array-with-extra-property idiom this module
+  // already uses (tsSearchSymbols carries .truncated/.filesParsed/.unavailable; searchSymIndex carries
+  // .fromIndex), so every existing caller keeps working unchanged and only the cert-aware ones read it.
+  const health = parseHealth(tree);
   // Tags-query tier: a file-driven .scm extracts declarations for languages without a hand-tuned node config.
   if (cfg.tags) {
     const q = await defTagsQueryFor(wasmBase);
@@ -539,7 +544,9 @@ export async function tsFileSymbols(absPath, { maxBytes = 2_000_000 } = {}) {
     } catch {
       /* ignore */
     }
-    return defs.slice(0, 5000);
+    const tagged = defs.slice(0, 5000);
+    if (health.bad) { tagged.parseError = true; tagged.parseMissing = health.missing; }
+    return tagged;
   }
   const out = [];
   const decl = cfg.decl,
@@ -572,7 +579,31 @@ export async function tsFileSymbols(absPath, { maxBytes = 2_000_000 } = {}) {
   } catch {
     /* ignore */
   }
+  if (health.bad) { out.parseError = true; out.parseMissing = health.missing; }
   return out;
+}
+
+// PARSE HEALTH. tree-sitter never throws on input it can't parse — it RECOVERS, producing a tree with
+// ERROR/MISSING nodes, and a decl walk over that tree quietly returns whatever survived. That is a silently
+// incomplete answer with a confident label, the exact failure this project criticises grep for. Ask the
+// engine's own API instead: `hasError` covers ERROR and MISSING descendants; the bounded isMissing scan is
+// belt-and-braces for grammars where the flag doesn't propagate, and yields the `missing` count for the
+// message. Real case: the bundled tree-sitter-lua parses a table constructor `local M = {}` as an
+// unterminated string (ERROR + MISSING _string_end), and — because Lua's external scanner carries state in
+// wasm memory — the error RECOVERY shifts with how many grammars are resident, so a following decl is
+// dropped only sometimes. Not repairable from here (tree-sitter-wasms has no build past 0.1.13 and
+// web-tree-sitter 0.26 can't load those wasms at all), so the answer is honesty, not repair.
+function parseHealth(tree) {
+  const root = tree && tree.rootNode;
+  if (!root || !root.hasError) return { bad: false, missing: 0 };
+  let missing = 0, guard = 0;
+  const stack = [root];
+  while (stack.length && guard++ < 20000) {
+    const n = stack.pop();
+    if (n.isMissing) missing++;
+    for (let i = n.namedChildCount - 1; i >= 0; i--) stack.push(n.namedChild(i));
+  }
+  return { bad: true, missing };
 }
 
 // Resolve a symbol NAME to its FULL declaration span via tree-sitter — the read_symbol / edit twin of the
@@ -611,6 +642,12 @@ export async function tsReadSymbol(absPath, want, { line = null, maxBytes = 2_00
     return null;
   }
   try {
+    // REFUSE on a bad parse. This span is not a report — it feeds tsResolveForEdit → replace_symbol_body /
+    // safe_delete, which SPLICE THE FILE at it. A span computed from a recovered (wrong) tree overwrites the
+    // wrong lines, i.e. silently corrupts the user's source. A read-only decl list can be honestly degraded;
+    // a span cannot. Rule: read-only lists report, span-producing functions refuse. Null → the caller falls
+    // back to the LSP/other tiers exactly as it already does when tree-sitter is unavailable.
+    if (parseHealth(tree).bad) return null;
     const decl = cfg.decl, kindMap = cfg.kind || {};
     const hits = [];
     const stack = [tree.rootNode];
@@ -683,6 +720,10 @@ export async function tsChunkEnd(absPath, startRow, endRow, maxLines) {
     return null;
   }
   try {
+    // REFUSE on a bad parse — same rule as tsReadSymbol: this produces a SPAN, not a report. The whole point
+    // of a structural cut is that it lands on a complete child; computed from a recovered tree it can cut
+    // mid-statement, which is worse than the plain line-cap the caller falls back to on null.
+    if (parseHealth(tree).bad) return null;
     // Locate the declaration node: the smallest named node at the start position, climbed up to the largest
     // node that still begins at startRow and ends within the decl span (the function/class/etc. itself).
     let node = tree.rootNode.namedDescendantForPosition({ row: startRow, column: 0 });


### PR DESCRIPTION
Closes #221

First patch on 1.0.0. Three defects found by asking why `node eval/run.mjs` was red on a maintainer's machine while CI was green — the answer turned out to be that **CI was never testing the syntactic tier at all**.

## 1. Source-corruption fix (the severe one)
tree-sitter never throws on input it can't parse — it RECOVERS, producing an ERROR/MISSING tree. `treesitter.js` never asked (zero `hasError` references). For the two SPAN-producing functions that isn't an honesty problem, it's corruption: `tsReadSymbol`'s span flows through `tsResolveForEdit` into `replace_symbol_body` / `safe_delete`, which **splice the file at it** — a span from a recovered tree overwrites the wrong lines. That path is reached exactly on crawl-risk trees (the syntactic pre-empt), i.e. the big-repo case the tool exists for.

New `parseHealth(tree)` (the engine's own `hasError` + a bounded `isMissing` scan). **Rule: read-only decl lists report; span producers refuse.** `tsReadSymbol`/`tsChunkEnd` now return null on a bad parse; callers already handle null (LSP / plain line-cap), so it's fail-safe.

## 2. `SYNTACTIC · DEGRADED` — say when the grammar couldn't parse
A recovered parse silently drops decls and we stamped the normal `SYNTACTIC rung — N decl(s)` cert: a silently incomplete answer with a confident label — what this project criticises grep for. Now `tsFileSymbols` carries `.parseError` (the array-with-extra-property idiom already used by `tsSearchSymbols`/`searchSymIndex`) and the cert renders DEGRADED, ranked above `stale`, stating a short list is **NOT absence** and naming `search_text` (the literal rung below, which no grammar can fool). Zero cost on the healthy path. `symindex` records it per-file (`e:1`, rides the incremental reuse path — a bad parse was otherwise baked into `.vts-index` and shipped to teammates), counts it in the header, and degrades **per-hit** at query time.

## 3. CI was green on an illusion
`test.yml` ran the eval **before** `npm install`, so tree-sitter was absent, guard 81 self-skipped and printed `✓ true true`. The whole SYNTACTIC tier (36 languages) was never exercised on CI — which is how a grammar that silently drops declarations survived to 1.0. Now the eval runs a **second** time after the install (the dependency-free run stays; it proves the core needs no deps). Guard 81's Lua assertion, which passed only by error-recovery luck (grammar-load-order dependent), is replaced by the honest contract.

Also: the eval is now **hermetic** (it inherited the maintainer's `qvts` install and the syntactic pre-empt → 11 guards red on their machine only), and rank-bench gains a **"lost if surprise"** arm — the gist-compression failure mode does **not** reproduce here (rare identifiers rank #1; idf *rewards* rarity), which is evidence for addressing-over-compression.

## Known limits (stated, not hidden)
- The bundled `tree-sitter-lua` mis-parses `local M = {}` (table constructor → unterminated string). **Not repairable from here**: `tree-sitter-wasms` has no build past 0.1.13 and `web-tree-sitter@0.26` cannot load those wasms at all (dylink ABI break) — it would kill all 36 grammars. So Lua answers are now honestly DEGRADED rather than quietly wrong.
- `hasError` is coarse and file-level: a file with one stray error may still yield good decls and still be labelled DEGRADED (over-reporting, costs one redundant `search_text`). `hasError === false` is not a correctness proof (under-reporting residual). Honest-degraded beats silent-wrong.

## Verification
Full eval green on a machine WITH tree-sitter, qvts and a real p4 workspace; lint clean; rank-bench fuzzy MRR 0.848 (unmoved). CI 8/8 on #221 including the new second eval run — so the tier now passes on ubuntu+windows × node 18/20/22, not just locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
