### PR TITLE
release: /vs-token-safer:update — index-refresh command + staleness cue (v1.1.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,7 +391,12 @@ repo while config pinned clangd for a UE tree) > forced `VTS_BACKEND`/config `ba
   ("re-run with the vts tool matching the intent" + the concrete call), with a brief human-facing reassurance
   that the red box is a redirect ("hold on"), not a failure — the hook output is consumed by the MODEL, which
   is the one that re-runs, not a human picking from a menu.
-- `skills/vs-search/SKILL.md` — routing. `commands/{setup,savings}.md`.
+- `skills/vs-search/SKILL.md` — routing. `commands/{setup,savings,update}.md`. `commands/update.md` = `/vs-token-safer:update`
+  — one-command REFRESH of a STALE committable `.vts-index` (op `vts_admin{op:index}` = incremental `buildSymIndex`,
+  re-parses only stat/hash-changed files). Surfaced two ways: the `SYNTACTIC · STALE` cert (core.js) now names
+  `/vs-token-safer:update`, and `hooks/edit-report.js` (SessionStart) emits a `policy.js stalenessLine(indexFreshness(root))`
+  cue INDEPENDENT of the adoption gate (a stale index matters on a fresh session too; en/ko; only when a
+  committable index exists + it's stale). Eval guard 95. `VTS_STALE_CHECK=0` off.
 - `eval/run.mjs` + `eval/_mock-lsp.mjs` — mock-LSP eval (no toolchain). Add a guard for every new path.
 - Config dir `~/.vs-token-safer`, env prefix `VTS_`. MCP server name `vs-search`.
 

--- a/commands/update.md
+++ b/commands/update.md
@@ -1,0 +1,42 @@
+---
+description: Refresh the committable tree-sitter symbol index (.vts-index) when it has gone STALE — one incremental re-index so the syntactic tier answers CURRENT code, not the state it was built at. Use when search_symbol shows "SYNTACTIC · STALE", after a big branch switch / pull / large refactor, or when the file:line answers look out of date.
+---
+
+# Update the vs-token-safer index
+
+The committable tree-sitter index (`.vts-index/symbols.jsonl`) powers the **SYNTACTIC tier** — instant symbol
+search with no language server, shareable with the team by committing it. It is built once; after the code
+moves a lot it goes **STALE** and its `file:line` answers drift from where symbols actually are. This command
+brings it current in ONE incremental re-index: only stat/hash-changed files are re-parsed, the rest are reused
+verbatim, so even a long-stale index refreshes fast.
+
+Do this:
+
+1. **Check staleness first** — call the `vts_admin` MCP tool with a status probe (no rebuild):
+
+   `vts_admin { "op": "index", "params": { "status": true } }`
+
+   It reports the index's build date, file/symbol counts, and whether it is stale (how many files changed
+   since it was built). If it reports **fresh (0 changed)**, tell the user the index is already current and
+   STOP — a rebuild would do nothing.
+
+2. **Rebuild incrementally** — if it is stale (or no index exists yet), call:
+
+   `vts_admin { "op": "index" }`
+
+   This re-parses ONLY the changed files, reuses the rest, and writes the updated `.vts-index/symbols.jsonl`.
+   Report the `re-parsed N, reused M` counts back to the user so they see exactly what was refreshed.
+
+3. **Remind to commit it** — `.vts-index/` is committable and team-shared. Tell the user to
+   `git add .vts-index && git commit` so teammates get the fresh index too (that is the whole point of the
+   committable tier — one person re-indexes, everyone benefits).
+
+Notes:
+- This refreshes ONLY the tree-sitter (syntactic) tier — the tier that goes stale because it is a *stored*
+  snapshot. The clangd/LSP **semantic** index re-indexes itself on file changes (file-watch + background), so
+  it does not need this. If you *also* want to warm the semantic tier (e.g. a fresh clone), run `vts preindex`
+  separately — that is a different concern from index staleness.
+- `detect_changes` and the dashboard symbol graph run **live** (git + LSP + tree-sitter), so they are never
+  stale and need no refresh — this command is specifically for the committed `.vts-index` symbol search.
+
+$ARGUMENTS

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -2547,6 +2547,19 @@ try {
   }
 } catch (e) { symbolGraphOk = false; console.log("  guard 94 symbol graph FAILED:", e && e.message); }
 
+// 95) INDEX-STALENESS SessionStart cue (policy.stalenessLine) — when the committed .vts-index has gone stale,
+// the SessionStart digest (hooks/edit-report.js, independent of the adoption gate) points the user at the
+// one-command refresh `/vs-token-safer:update`. PURE line formatter (the hook does the fs/config read + calls
+// symindex.indexFreshness): fresh/null → "" (silent), stale → names the changed-file count + the command; en/ko.
+const { stalenessLine: stLine } = await import("../server/policy.js");
+const stalenessOk =
+  stLine({ stale: false, changed: 0 }) === "" &&                          // fresh → silent (no nag)
+  stLine(null) === "" &&                                                  // no freshness signal → silent
+  /STALE/.test(stLine({ stale: true, changed: 5 })) &&                    // stale → flags it
+  /5 file\(s\)/.test(stLine({ stale: true, changed: 5 })) &&              // names the changed-file count
+  /\/vs-token-safer:update/.test(stLine({ stale: true, changed: 5 })) &&  // points at the one-command refresh
+  /오래됐/.test(stLine({ stale: true, changed: 3 }, { ko: true }));       // ko localization
+
 const rows = [
   ["LSP client handshake + symbol", lspOk, "true", lspOk],
   ["symbol → file:line (no bodies)", fmtOk, "true", fmtOk],
@@ -2643,6 +2656,7 @@ const rows = [
   ["structure tier: section outline/read/edit for md/toml/yaml/html/css/scss/… via the symbol tools (no backend, by heading/selector/rule/function)", structOk, "true", structOk],
   ["detect_changes risk model: diff→hunks (binary excluded) + 4-channel deterministic risk (leaf LOW/widely-called HIGH, test dampens) + worst-band summary (pure)", detectRiskOk, "true", detectRiskOk],
   ["tree-sitter symbol graph: buildSymbolGraph files+import edges, loadGraph contract (unique ids, no dangling, syntactic, min.js excluded)", symbolGraphOk, "true", symbolGraphOk],
+  ["index-staleness SessionStart cue: stalenessLine silent-when-fresh + names changed count + /vs-token-safer:update refresh (en/ko)", stalenessOk, "true", stalenessOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/hooks/edit-report.js
+++ b/hooks/edit-report.js
@@ -5,15 +5,52 @@
 // when-to-use-what policy, behavior shifts, the next session measures again (the SkillOpt textual-gradient
 // cadence — a static rule can't self-improve, a re-injected live metric + policy can). Quiet until there's
 // enough activity to be worth a line of context.
+//
+// ALSO (independent of adoption): if the committed tree-sitter index (.vts-index) has gone STALE, surface the
+// one-command refresh. This is decoupled from the adoption gate below — a stale index matters even on a fresh
+// session with no edit history, so it must not be suppressed by `total < 3`.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { readEditLedger, adoptionPct } from "../server/edit-ledger.js";
-import { routingDigest } from "../server/policy.js";
+import { routingDigest, stalenessLine } from "../server/policy.js";
+import { hasSymIndex, indexFreshness } from "../server/symindex.js";
+
+// Best-effort locale for the staleness line: explicit VTS_LANG wins, else the config's lang, else the OS locale.
+function wantKo() {
+  try {
+    const v = String(process.env.VTS_LANG || "").toLowerCase();
+    if (v === "ko" || v === "en") return v === "ko";
+    const cfgPath = process.env.VTS_CONFIG_FILE || path.join(os.homedir(), ".vs-token-safer", "config.json");
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
+    if (cfg && typeof cfg.lang === "string") return cfg.lang.toLowerCase() === "ko";
+  } catch { /* fall through */ }
+  const loc = (process.env.LANG || process.env.LC_ALL || process.env.LC_MESSAGES || Intl.DateTimeFormat().resolvedOptions().locale || "").toLowerCase();
+  return /^ko\b|[-_]kr\b|^ko[-_]/.test(loc);
+}
+
+// Staleness of the committed index for the configured project — an fs walk, so gated to run only when an index
+// actually exists (nothing to be stale otherwise) and VTS_STALE_CHECK isn't off. Returns "" if fresh/absent.
+function stalePart() {
+  try {
+    const cfgPath = process.env.VTS_CONFIG_FILE || path.join(os.homedir(), ".vs-token-safer", "config.json");
+    let root = process.env.VTS_PROJECT_PATH || "";
+    if (!root) { try { root = (JSON.parse(fs.readFileSync(cfgPath, "utf8")) || {}).projectPath || ""; } catch { /* no config */ } }
+    if (!root || !hasSymIndex(root)) return ""; // no committed index → nothing can be stale
+    return stalenessLine(indexFreshness(root), { ko: wantKo() });
+  } catch { return ""; }
+}
 
 try {
   const o = readEditLedger();
   const pct = adoptionPct(o);
   const total = (o.builtin || 0) + (o.symbol || 0);
-  if (pct === null || total < 3) process.exit(0); // too little data — don't nag on a fresh/idle session
-  const msg = routingDigest(o);
+  const parts = [];
+  const stale = stalePart();
+  if (stale) parts.push(stale);
+  if (pct !== null && total >= 3) parts.push(routingDigest(o)); // adoption posture only when there's data
+  if (!parts.length) process.exit(0); // nothing worth a line of context
+  const msg = parts.join("\n\n");
   process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: msg } }) + "\n");
 } catch { /* best-effort — never break session start */ }
 process.exit(0);

--- a/server/core.js
+++ b/server/core.js
@@ -1356,7 +1356,7 @@ function completenessCert({ shown = 0, total = null, truncated = null, semantic 
   // the caller pairs it with a `climb: vts index` ladder line. Takes precedence over the plain SYNTACTIC label.
   if (syntactic && stale) {
     const n = typeof stale === "number" && stale > 0 ? `${stale} file(s) changed` : "source changed";
-    return `\n[completeness: SYNTACTIC · STALE — ${shown} decl(s), but ${n} since the index was built (positions may be off); rebuild: vts index.]`;
+    return `\n[completeness: SYNTACTIC · STALE — ${shown} decl(s), but ${n} since the index was built (positions may be off); refresh: /vs-token-safer:update (incremental — re-parses only changed files), or vts index.]`;
   }
   // ONE label names BOTH which precision RUNG answered AND how complete the set is (the unified precision
   // label). The four ladder rungs — exact (semantic LSP) / syntactic (tree-sitter) / fuzzy (concept dictionary)

--- a/server/policy.js
+++ b/server/policy.js
@@ -243,6 +243,18 @@ export function topLevelDeclNames(text, file, max = 8) {
   return out;
 }
 
+// PURE staleness line for the SessionStart digest: when the committed tree-sitter index (.vts-index) has gone
+// STALE, point the user at the one-command refresh. Takes the freshness object from symindex.indexFreshness
+// (the hook does the fs/config read and passes it in — policy.js stays pure/testable). Returns "" when fresh
+// (or no freshness signal), so the digest only mentions it when a rebuild is actually worth it.
+export function stalenessLine(fresh, { ko = false } = {}) {
+  if (!fresh || !fresh.stale) return "";
+  const n = fresh.changed > 0 ? `${fresh.changed} file(s)` : "source";
+  return ko
+    ? `[vs-token-safer] 커밋된 인덱스(.vts-index)가 오래됐습니다 — 빌드 후 ${n} 변경됨(심볼 검색이 옛 위치를 가리킬 수 있음). 갱신: /vs-token-safer:update (증분 재인덱싱 — 바뀐 파일만 재파싱). 이후 .vts-index 커밋.`
+    : `[vs-token-safer] the committed index (.vts-index) is STALE — ${n} changed since it was built (symbol search may point at old locations). Refresh: /vs-token-safer:update (incremental — re-parses only changed files). Commit .vts-index after.`;
+}
+
 // The single routing digest. Always emits the decision tree (the integrative guidance); appends the live
 // adoption posture + adaptive-controller state when there is enough data.
 export function routingDigest(o = readEditLedger()) {


### PR DESCRIPTION
## v1.1.1 — one-command refresh for a stale `.vts-index`

The committable tree-sitter symbol index is a stored snapshot that goes STALE as code moves; there was no easy way to bring it current, and no cue that it had drifted. This adds both.

- **`/vs-token-safer:update`** (`commands/update.md`): checks staleness, and if stale runs the **incremental** re-index (only changed files re-parsed), then reminds to commit `.vts-index`.
- **Discovery**: the `SYNTACTIC · STALE` cert now names the command, and a SessionStart cue (`hooks/edit-report.js`, independent of the adoption gate) surfaces it when the committed index is stale (en/ko).
- Reuses existing `indexFreshness` + `vts_index` (incremental `buildSymIndex`) — no new heavy code. Plugin-code version drift is not detectable from the running server (hardcoded version, no marker), so index staleness is the real lever.

Verified live (built index → staled a file → `{stale:true,changed:1}` → hook surfaces the STALE line). eval guard 95; suite green 44/44 on Ubuntu+Windows, Node 18/20/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
