### PR TITLE
fix(index): report staleness in vts index --status so /vs-token-safer:update step 1 works as documented

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -2560,6 +2560,17 @@ const stalenessOk =
   /\/vs-token-safer:update/.test(stLine({ stale: true, changed: 5 })) &&  // points at the one-command refresh
   /오래됐/.test(stLine({ stale: true, changed: 3 }, { ko: true }));       // ko localization
 
+// 96) `vts index --status` STALENESS note (core.indexStatusStaleNote) — closes the v1.1.1 doc gap: the
+// /vs-token-safer:update command's step 1 promised `status` reports staleness, but the handler printed only the
+// build date. PURE suffix from the SAME indexFreshness the STALE cert uses: null → "" (no signal), fresh →
+// "current (no files changed)", stale → names the changed-file count + the /vs-token-safer:update refresh.
+const { indexStatusStaleNote: stNote } = await import("../server/core.js");
+const statusStaleOk =
+  stNote(null) === "" &&                                                  // no freshness signal → silent
+  /current \(no files changed/.test(stNote({ stale: false, changed: 0 })) && // fresh → "current"
+  /STALE: 7 file\(s\)/.test(stNote({ stale: true, changed: 7 })) &&       // stale → names the count
+  /\/vs-token-safer:update/.test(stNote({ stale: true, changed: 7 }));    // → points at the refresh command
+
 const rows = [
   ["LSP client handshake + symbol", lspOk, "true", lspOk],
   ["symbol → file:line (no bodies)", fmtOk, "true", fmtOk],
@@ -2657,6 +2668,7 @@ const rows = [
   ["detect_changes risk model: diff→hunks (binary excluded) + 4-channel deterministic risk (leaf LOW/widely-called HIGH, test dampens) + worst-band summary (pure)", detectRiskOk, "true", detectRiskOk],
   ["tree-sitter symbol graph: buildSymbolGraph files+import edges, loadGraph contract (unique ids, no dangling, syntactic, min.js excluded)", symbolGraphOk, "true", symbolGraphOk],
   ["index-staleness SessionStart cue: stalenessLine silent-when-fresh + names changed count + /vs-token-safer:update refresh (en/ko)", stalenessOk, "true", stalenessOk],
+  ["vts index --status staleness note (indexStatusStaleNote): null→silent, fresh→current, stale→N files + /vs-token-safer:update", statusStaleOk, "true", statusStaleOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/core.js
+++ b/server/core.js
@@ -207,6 +207,16 @@ export function altSymbols(q) {
   if (!branches.some((b) => /[a-z][A-Z]|[a-z0-9]_[a-z]/.test(b))) return null;  // no CamelCase/snake cue → keyword alternation, leave it
   return [...new Set(branches)];
 }
+// PURE staleness suffix for `vts index --status` — mirrors what the SYNTACTIC · STALE cert reports (same
+// indexFreshness), so `--status` tells you exactly what `/vs-token-safer:update` would act on. That command's
+// step 1 documented this; the handler only printed the build date, so this closes the doc-vs-behavior gap.
+// Takes the {stale,changed} object (the handler does the fs read + try/catch); "" only on a null/absent signal.
+export function indexStatusStaleNote(fresh) {
+  if (!fresh) return "";
+  return fresh.stale
+    ? `\n  — STALE: ${fresh.changed} file(s) changed since it was built; refresh: /vs-token-safer:update (incremental — re-parses only changed files).`
+    : "\n  — current (no files changed since it was built).";
+}
 const textSteerOn = () => !/^(0|false|off|no)$/i.test(String(process.env.VTS_TEXT_STEER ?? "1"));
 // Build the one-line steer, or "" — fires only on a clear symbol hunt that would actually benefit: the
 // scan was TRUNCATED (completeness now matters) OR the query carries a `<>`/`::` code cue. A bare CamelCase
@@ -2396,7 +2406,12 @@ export async function runTool(name, a = {}) {
         const idx = loadSymIndex(root);
         if (!idx) return out(`No committed symbol index at ${symIndexPath(root)}. Build one: vts index  (commit .vts-index/ to share it with the team / speed cold starts).`);
         const built = idx.meta.built ? new Date(idx.meta.built).toISOString() : "unknown";
-        return out(`Committed symbol index: ${symIndexPath(root)}\n  ${idx.entries.length} symbol(s) over ${idx.meta.files ?? "?"} file(s), built ${built}${idx.meta.partial ? " (PARTIAL — time-boxed; rebuild for full coverage)" : ""}.\n  Used as the instant cold-start tier for search_symbol when no language server has indexed yet.`);
+        // Staleness: the same indexFreshness the SYNTACTIC · STALE cert keys off, so `--status` reports what
+        // /vs-token-safer:update would act on (the command's step 1 promised this). fs walk → guarded; a
+        // hiccup just drops the note, never breaks status.
+        let staleNote = "";
+        try { staleNote = indexStatusStaleNote(indexFreshness(root)); } catch { /* freshness unavailable → omit */ }
+        return out(`Committed symbol index: ${symIndexPath(root)}\n  ${idx.entries.length} symbol(s) over ${idx.meta.files ?? "?"} file(s), built ${built}${idx.meta.partial ? " (PARTIAL — time-boxed; rebuild for full coverage)" : ""}.${staleNote}\n  Used as the instant cold-start tier for search_symbol when no language server has indexed yet.`);
       }
       if (!tsAvailable()) return err(`vts index needs the tree-sitter grammars (web-tree-sitter + tree-sitter-wasms). They install with the plugin; if missing, run \`npm install\` in the server dir.`);
       const dirs = scopeDirsFor(root);


### PR DESCRIPTION
## Gap

v1.1.1's `/vs-token-safer:update` command (step 1) says `vts_admin {op:index, params:{status:true}}` reports whether the index is stale — but the `vts_index` status handler printed only the build date + symbol/file counts. Found live: ran the command on a 5-day-old UE index and `status` gave no staleness signal, so step 1 couldn't decide fresh-vs-stale.

## Fix

`status` now appends a staleness line from the **same `indexFreshness`** the `SYNTACTIC · STALE` cert keys off, so `--status` reports exactly what `/vs-token-safer:update` would act on:
- fresh → `— current (no files changed since it was built).`
- stale → `— STALE: N file(s) changed since it was built; refresh: /vs-token-safer:update`

Factored into a pure `indexStatusStaleNote(fresh)` (exported, **eval guard 96**); the handler wraps `indexFreshness` in try/catch so an fs hiccup drops the note without breaking status.

## Verification

Live on the UE index (7,553 files, just rebuilt): `status` now prints `— current (no files changed since it was built).` eval green (guard 96: null→silent, fresh→current, stale→names count + command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
