### PR TITLE
fix(win): stop the console-window storm — windowsHide on every child spawn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,6 +406,14 @@ repo while config pinned clangd for a UE tree) > forced `VTS_BACKEND`/config `ba
 - **No proprietary leak.** Never put real paths/symbols/company names in the repo or commits; sanitize;
   scan tree + git log before any push. Eval/docs use synthetic names only.
 - **Security/local-only.** No network calls; nothing transmitted. PRIVACY.md says so.
+- **No console windows (Windows).** EVERY `spawn`/`execFile*`/`execSync` in `server/` MUST pass `windowsHide: true`.
+  The MCP server (host-launched) and the DETACHED auto-index builder (`symindex.js maybeAutoIndex`) have no
+  console of their own, so Windows allocates a FRESH console per child — a conhost that Win11 hands to Windows
+  Terminal as a window/tab. The chunked index spawns one worker PER CHUNK, so on a UE-size tree that was a
+  terminal window every ~0.8s for a 10-minute build (reported by two users; reproduced with a forced-chunk
+  orphan launch: 44 console/terminal processes per run without the flag, 0 with it). Eval guard 96 scans every
+  spawn site — it under-detected at first because quote-blanking mis-paired on a regex literal like `/^"|"$/`,
+  so it now blanks only comments + template literals. Verify a guard FAILS before trusting it.
 - **Release/branch workflow — gitflow.** Branches: **`main`** = production (tagged releases ONLY, always
   shippable) · **`dev`** = develop/integration · **`feature/<slug>`** (off `dev`) · **`hotfix/<slug>`** (off
   `main`) · optional **`release/<x.y>`** (stabilize before a big minor/major). **Bump level is decided by

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -2571,6 +2571,47 @@ const statusStaleOk =
   /STALE: 7 file\(s\)/.test(stNote({ stale: true, changed: 7 })) &&       // stale → names the count
   /\/vs-token-safer:update/.test(stNote({ stale: true, changed: 7 }));    // → points at the refresh command
 
+// ── Windows console storm: no child process of ours may pop a console ────────────────────────────────────
+// The MCP server (host-launched) and the detached auto-index builder have NO console of their own, so on
+// Windows every child they spawn gets a FRESH console allocated — a conhost, which Win11 hands to Windows
+// Terminal as a window/tab. The chunked index spawns one worker per chunk, so on a big tree that was a
+// terminal window every ~0.8s for the whole build (measured on a forced-chunk orphan repro: 44 console/
+// terminal processes per run without windowsHide, 0 with it). Guard EVERY spawn site so a new one can't
+// reintroduce it — the failure is invisible in CI (it only shows on Windows, from a console-less parent).
+const spawnSitesMissingHide = (() => {
+  const dir = new URL("../server/", import.meta.url);
+  const files = [
+    ...fs.readdirSync(dir).filter((f) => /\.(js|mjs)$/.test(f)),
+    ...fs
+      .readdirSync(new URL("backends/", dir))
+      .filter((f) => /\.js$/.test(f))
+      .map((f) => "backends/" + f),
+  ];
+  const blank = (m) => m.replace(/[^\n]/g, " "); // keep line numbering while removing content
+  const bad = [];
+  for (const f of files) {
+    // Blank comments and TEMPLATE literals only, so prose like `${n} spawn(s)` is not read as a call site.
+    // Deliberately NOT quote-blanking: a quote inside a regex literal (`/^"|"$/`) mis-pairs the scan and
+    // silently blanks the rest of the file — the first version of this guard did exactly that and went blind
+    // to warmset.js and half of core.js while still printing a pass. Under-detection is the failure mode to
+    // design against here, so keep the lexing minimal and let a stray quoted "spawn(" be a loud false alarm.
+    const src = fs
+      .readFileSync(new URL(f, dir), "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, blank)
+      .replace(/\/\/[^\n]*/g, blank)
+      .replace(/`(?:\\.|[^`\\])*`/g, blank);
+    const lines = src.split("\n");
+    lines.forEach((l, i) => {
+      if (!/(?:^|[^.\w])(spawn|spawnSync|execFile|execFileSync|execSync)\s*\(/.test(l)) return;
+      // Look behind too: a call may pass a shared options object declared just above (core.js's UBT opts).
+      if (!/windowsHide\s*:\s*true/.test(lines.slice(Math.max(0, i - 6), i + 12).join(" "))) bad.push(`${f}:${i + 1}`);
+    });
+  }
+  return bad;
+})();
+const noConsoleWindowOk = spawnSitesMissingHide.length === 0;
+if (!noConsoleWindowOk) console.error(`  spawn sites missing windowsHide: ${spawnSitesMissingHide.join(", ")}`);
+
 const rows = [
   ["LSP client handshake + symbol", lspOk, "true", lspOk],
   ["symbol → file:line (no bodies)", fmtOk, "true", fmtOk],
@@ -2669,6 +2710,7 @@ const rows = [
   ["tree-sitter symbol graph: buildSymbolGraph files+import edges, loadGraph contract (unique ids, no dangling, syntactic, min.js excluded)", symbolGraphOk, "true", symbolGraphOk],
   ["index-staleness SessionStart cue: stalenessLine silent-when-fresh + names changed count + /vs-token-safer:update refresh (en/ko)", stalenessOk, "true", stalenessOk],
   ["vts index --status staleness note (indexStatusStaleNote): null→silent, fresh→current, stale→N files + /vs-token-safer:update", statusStaleOk, "true", statusStaleOk],
+  ["no Windows console storm: every child-process spawn sets windowsHide (console-less MCP / detached indexer → a console+terminal window per child)", noConsoleWindowOk, "true", noConsoleWindowOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -40,7 +40,7 @@ let _clangdMajorCache, _clangdAvailCache;
 export function clangdMajor(cmd) {
   if (_clangdMajorCache !== undefined) return _clangdMajorCache;
   try {
-    const out = execFileSync(cmd, ["--version"], { encoding: "utf8", timeout: 10000 });
+    const out = execFileSync(cmd, ["--version"], { encoding: "utf8", timeout: 10000, windowsHide: true });
     _clangdAvailCache = true;
     _clangdMajorCache = parseClangdMajor(out);
   } catch { _clangdAvailCache = false; _clangdMajorCache = null; }
@@ -214,7 +214,7 @@ let _indexerOk;
 export function hasClangdIndexer() {
   if (!indexerEnabled()) return false; // explicit kill switch — don't even probe
   if (_indexerOk !== undefined) return _indexerOk;
-  try { execFileSync(clangdIndexerCmd(), ["--help"], { encoding: "utf8", timeout: 8000, stdio: ["ignore", "ignore", "ignore"] }); _indexerOk = true; }
+  try { execFileSync(clangdIndexerCmd(), ["--help"], { encoding: "utf8", timeout: 8000, stdio: ["ignore", "ignore", "ignore"], windowsHide: true }); _indexerOk = true; }
   catch { _indexerOk = false; }
   return _indexerOk;
 }
@@ -238,7 +238,7 @@ export function buildStaticIndex(root) {
   try {
     fs.mkdirSync(path.dirname(out), { recursive: true });
     // clangd-indexer writes the index to stdout; capture it to the file. all-TUs = index every entry in the DB.
-    const buf = execFileSync(clangdIndexerCmd(), [`--executor=all-TUs`, cc], { maxBuffer: 1 << 30, timeout: envInt("VTS_INDEXER_TIMEOUT_MS", 1800000) });
+    const buf = execFileSync(clangdIndexerCmd(), [`--executor=all-TUs`, cc], { maxBuffer: 1 << 30, timeout: envInt("VTS_INDEXER_TIMEOUT_MS", 1800000), windowsHide: true });
     fs.writeFileSync(out, buf);
   } catch (e) { return { error: `clangd-indexer failed: ${e.message}` }; }
   return { ok: true, path: out, tus, ms: Date.now() - t0 };

--- a/server/cochange.js
+++ b/server/cochange.js
@@ -58,11 +58,11 @@ export function parseCoChange(logText, { maxFilesPerCommit = 30, boundary = SEP 
 export function cochangeNeighbors(root, { maxCommits = 500, maxFilesPerCommit = 30, minWeight = 2 } = {}) {
   let top, out;
   try {
-    top = execFileSync("git", ["-C", root, "rev-parse", "--show-toplevel"], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    top = execFileSync("git", ["-C", root, "rev-parse", "--show-toplevel"], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], windowsHide: true }).trim();
     out = execFileSync(
       "git",
       ["-C", root, "log", "--name-only", "--no-renames", `--pretty=format:${SEP}`, "-n", String(maxCommits)],
-      { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] },
+      { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"], windowsHide: true },
     );
   } catch {
     return new Map(); // no git / not a repo → no co-change edges (graceful)

--- a/server/core.js
+++ b/server/core.js
@@ -136,7 +136,7 @@ export function ensureWritableForEdit(file) {
   if (/^(0|false|off|no)$/i.test(String(process.env.VTS_P4_EDIT ?? "1"))) return "";
   const p4 = process.env.VTS_P4_CMD || "p4";
   try {
-    execSync(`${p4} edit ${JSON.stringify(file)}`, { stdio: "ignore", timeout: envInt("VTS_P4_TIMEOUT_MS", 15000), cwd: path.dirname(file) });
+    execSync(`${p4} edit ${JSON.stringify(file)}`, { stdio: "ignore", timeout: envInt("VTS_P4_TIMEOUT_MS", 15000), cwd: path.dirname(file), windowsHide: true });
     fs.accessSync(file, fs.constants.W_OK); // only claim success if the file is now writable
     return " (p4 edit'd for checkout)";
   } catch { return ""; }
@@ -1125,9 +1125,9 @@ export function ensureDbIgnored(root, patterns = DB_IGNORES) {
   const probe = (patterns[0] || ".cache/").replace(/\/$/, ""); // a representative entry for check-ignore
   // git: inside a work tree and the artifact not ignored → append to the project-root .gitignore.
   try {
-    execFileSync("git", ["-C", root, "rev-parse", "--is-inside-work-tree"], { stdio: "ignore", timeout: 5000 });
+    execFileSync("git", ["-C", root, "rev-parse", "--is-inside-work-tree"], { stdio: "ignore", timeout: 5000, windowsHide: true });
     let ignored = true;
-    try { execFileSync("git", ["-C", root, "check-ignore", "-q", probe], { stdio: "ignore", timeout: 5000 }); }
+    try { execFileSync("git", ["-C", root, "check-ignore", "-q", probe], { stdio: "ignore", timeout: 5000, windowsHide: true }); }
     catch { ignored = false; }
     if (ignored) notes.push(`git: ${probe} already ignored.`);
     else {
@@ -2439,7 +2439,7 @@ export async function runTool(name, a = {}) {
         // RunUBT is a .bat on Windows — Node refuses to spawn .bat/.cmd directly (EINVAL, CVE-2024-27980
         // hardening), so that path goes through the shell using the already-quoted cmdline. The .sh path
         // (and any direct binary) keeps the safer no-shell execFileSync.
-        const opts = { stdio: "ignore", timeout: envInt("VTS_UBT_TIMEOUT_MS", 1800000) };
+        const opts = { stdio: "ignore", timeout: envInt("VTS_UBT_TIMEOUT_MS", 1800000), windowsHide: true };
         if (/\.(bat|cmd)$/i.test(plan.runUbt)) execSync(plan.cmdline, opts);
         else execFileSync(plan.runUbt, plan.args, opts);
         // UBT writes compile_commands.json to the engine root; our clangd backend looks under the project

--- a/server/ensure-deps.mjs
+++ b/server/ensure-deps.mjs
@@ -33,7 +33,7 @@ try {
   // Deps grew (typescript + typescript-language-server + pyright ≈ 50 MB), so a stalled registry could
   // otherwise block this SessionStart hook indefinitely. Bound it; on timeout the catch drops the marker
   // so the next session retries.
-  execSync(`${npm} install --no-audit --no-fund --loglevel=error`, { cwd: DATA, stdio: "ignore", timeout: 300000 });
+  execSync(`${npm} install --no-audit --no-fund --loglevel=error`, { cwd: DATA, stdio: "ignore", timeout: 300000, windowsHide: true });
 } catch (e) {
   // Surface the reason on stderr (visible in hook logs) instead of failing completely silently;
   // the MCP server self-heals at spawn, but a logged cause speeds diagnosis when even that can't.

--- a/server/lsp.js
+++ b/server/lsp.js
@@ -87,7 +87,10 @@ export class LspClient {
     // user override with spaces should quote inside VTS_TS_CMD/VTS_PY_CMD.
     const cmd = this.shell ? [this.cmd, ...this.args].join(" ") : this.cmd;
     const args = this.shell ? [] : this.args;
-    this.proc = spawn(cmd, args, { cwd: this.cwd, env: this.env, stdio: ["pipe", "pipe", "pipe"], shell: this.shell });
+    // windowsHide: the MCP server is launched by the host with NO console of its own, so on Windows every child
+    // it spawns gets a brand-new console allocated (conhost, handed off to Windows Terminal as a window/tab).
+    // Language servers are long-lived, so this is one stray window per backend per session.
+    this.proc = spawn(cmd, args, { cwd: this.cwd, env: this.env, stdio: ["pipe", "pipe", "pipe"], shell: this.shell, windowsHide: true });
     this.proc.stdout.on("data", (d) => this._onData(d));
     this.proc.stderr.on("data", (d) => { this.stderr += d.toString(); if (this.stderr.length > 20000) this.stderr = this.stderr.slice(-20000); });
     this.proc.on("error", (e) => this._failAll(new Error(this.friendlyMissing || `failed to spawn ${this.cmd}: ${e.message}`)));

--- a/server/sdk.js
+++ b/server/sdk.js
@@ -61,6 +61,7 @@ function installIntoData() {
       cwd: DATA,
       stdio: ["ignore", "ignore", "inherit"],
       timeout: 300000, // deps grew to ~50 MB (ts + pyright); bound the synchronous install so a stalled registry can't wedge the server spawn
+      windowsHide: true,
     });
   } catch (e) {
     console.error(`[${TAG}] dependency install failed:`, e?.message || e);

--- a/server/serve.js
+++ b/server/serve.js
@@ -109,7 +109,7 @@ export function openBrowser(url) {
   try {
     const cmd = process.platform === "win32" ? "cmd" : process.platform === "darwin" ? "open" : "xdg-open";
     const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
-    const c = spawn(cmd, args, { detached: true, stdio: "ignore" });
+    const c = spawn(cmd, args, { detached: true, stdio: "ignore", windowsHide: true });
     c.on("error", () => {}); c.unref();
   } catch { /* best-effort */ }
 }

--- a/server/symindex.js
+++ b/server/symindex.js
@@ -476,7 +476,11 @@ export async function buildSymIndexChunked(
     new Promise((resolve) => {
       const symsPath = path.join(partDir, `part-${i}.jsonl`);
       const args = [`--max-old-space-size=${heapMb}`, WORKER_PATH, root, c.dir, symsPath, c.shallow ? "1" : "0"];
-      execFile(process.execPath, args, { maxBuffer: 512 * 1024 * 1024 }, (err, stdout) => {
+      // windowsHide: when the BUILDER itself has no console (a detached / background / orphaned `vts index`),
+      // Windows gives every child its OWN console — one conhost per chunk, which Win11 hands off to Windows
+      // Terminal, so a big tree pops a window per chunk for the whole build. Measured on a forced-chunk repro:
+      // console-parented builder → 0 consoles for 12 workers; detached builder → 24 consoles for 24 workers.
+      execFile(process.execPath, args, { maxBuffer: 512 * 1024 * 1024, windowsHide: true }, (err, stdout) => {
         done++;
         // A worker can finish ALL its parsing (valid JSON already flushed to stdout) and still exit non-zero —
         // e.g. a libuv teardown assertion crash on process.exit() after tree-sitter WASM cleanup (observed on
@@ -592,7 +596,7 @@ function ensureGrammar() {
   const npm = fs.existsSync(local) ? `"${local}"` : "npm";
   process.stderr.write("[vts index] tree-sitter grammar missing or incompatible — installing web-tree-sitter@^0.25 + tree-sitter-wasms (one-time)…\n");
   try {
-    execSync(`${npm} install web-tree-sitter@^0.25 tree-sitter-wasms --no-audit --no-fund --no-save --loglevel=error`, { cwd: here, stdio: "ignore", timeout: 300000 });
+    execSync(`${npm} install web-tree-sitter@^0.25 tree-sitter-wasms --no-audit --no-fund --no-save --loglevel=error`, { cwd: here, stdio: "ignore", timeout: 300000, windowsHide: true });
   } catch (e) {
     process.stderr.write(`[vts index] grammar auto-install failed (${e && e.message}). Run manually in ${here}: npm i web-tree-sitter@^0.25 tree-sitter-wasms\n`);
   }

--- a/server/warmset.js
+++ b/server/warmset.js
@@ -100,7 +100,7 @@ function addOrder(rank, order) {
 // git: recently-touched files (most recent first). Empty if not a git repo / no git.
 function gitRecent(root, rank) {
   try {
-    const out = execFileSync("git", ["-C", root, "log", "--name-only", "--format=", "-n", "80"], { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"] });
+    const out = execFileSync("git", ["-C", root, "log", "--name-only", "--format=", "-n", "80"], { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"], windowsHide: true });
     const order = []; const seen = new Set();
     for (const line of out.split(/\r?\n/)) {
       const t = line.trim();
@@ -116,7 +116,7 @@ function gitRecent(root, rank) {
 function workingFiles(root) {
   const set = new Set();
   try {
-    const out = execFileSync("git", ["-C", root, "status", "--porcelain", "--untracked-files=all"], { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"] });
+    const out = execFileSync("git", ["-C", root, "status", "--porcelain", "--untracked-files=all"], { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"], windowsHide: true });
     for (const line of out.split(/\r?\n/)) {
       let t = line.slice(3).trim(); // drop the 2-char XY status + space
       if (!t) continue;
@@ -125,7 +125,7 @@ function workingFiles(root) {
     }
   } catch { /* no git */ }
   try {
-    const out = execFileSync("p4", ["-ztag", "opened", "-m", "500"], { cwd: root, encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"] });
+    const out = execFileSync("p4", ["-ztag", "opened", "-m", "500"], { cwd: root, encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"], windowsHide: true });
     for (const line of out.split(/\r?\n/)) {
       const m = /^\.\.\. clientFile (.+)$/.exec(line.trim());
       if (m) set.add(norm(m[1]));


### PR DESCRIPTION
## What

Two users reported vs-token-safer spawning a flood of terminal windows for tens of minutes while they worked on Unreal projects. Reproduced locally and fixed.

## Cause (measured)

1. The MCP server finds a project with no committable index and calls `symindex.js maybeAutoIndex`, which spawns `vts index` **detached and unref'd**. The launcher is hidden, so nothing shows at start, and the build outlives the session that started it.
2. That builder therefore has **no console of its own**. On Windows, a child spawned from a console-less parent gets a **fresh console allocated** — a conhost, which Windows 11 hands to Windows Terminal as a window/tab.
3. `buildSymIndexChunked` runs **one worker process per chunk** by design (memory isolation — a single process OOMs on a full UE tree). On a large depot that is ~1.25 spawns/sec, so a terminal window appears roughly every 0.8s for the whole ten-plus-minute build.

## Repro

Forced chunking (`VTS_INDEX_CHUNK_THRESHOLD=1`, `FILECAP=1`), detached launch, 70-file synthetic tree:

| arm | workers | console/terminal processes created |
| --- | ---: | ---: |
| parent **with** a console | 12 | **0** |
| detached parent, `windowsHide` absent | 44 | **44** |
| detached parent, `windowsHide: true` | — | **0** (index built intact) |

The repro's window title matches the one users reported verbatim (`C:\Program Files\nodejs\node.exe`), and the leaked `OpenConsole.exe` processes never exit, so they accumulate for the session.

## Fix

`windowsHide` was already set on the launcher and on `runExternal`, but not on the worker spawn or most other children. Because the MCP server is itself console-less, the same defect applied to everything it spawns — so the flag now goes on all of them:

- the chunked-index worker (`symindex.js`) — the storm
- the language-server spawn (`lsp.js`: clangd / Roslyn / tsserver / pyright)
- git and p4 probes (`warmset.js`, `cochange.js`, `core.js`)
- clangd and clangd-indexer probes (`backends/index.js`)
- npm dependency installs (`sdk.js`, `ensure-deps.mjs`, `symindex.js`)
- the dashboard browser launch (`serve.js`)

## Guard

Eval guard 96 scans every spawn site in `server/` and fails if one omits the flag.

**The first version of that guard could not fail.** It blanked quoted strings before scanning; a quote inside a regex literal (`/^"|"$/` in `warmset.js`) mis-paired the scan and silently blanked the rest of the file, hiding half the call sites while still printing a pass. It now blanks only comments and template literals, and the failure path was verified by removing the flag from one site (`EVAL FAILED`).

## Review points

- The guard is a source scan, so it is deterministic and runs on CI — but the defect it guards only manifests on Windows from a console-less parent, which CI does not exercise. That is exactly why it is a static assertion rather than a behavioural test.
- `serve.js openBrowser` uses `cmd /c start`; hiding the `cmd` window does not affect the browser it launches.

## Not addressed here

The auto-index still starts a multi-minute background build on a large depot without asking, and survives the session that triggered it. That is a separate design question, not a Windows bug.

## Verification

- `node eval/run.mjs` → `EVAL PASSED` (guard 96 green; verified red when a site regresses)
- `npm run lint` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
