### PR TITLE
fix(search): enforce the PowerShell search channel; stop a narrow root reading as "not found"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,6 +352,29 @@ repo while config pinned clangd for a UE tree) > forced `VTS_BACKEND`/config `ba
   clamped `[base,VTS_WARM_CAP_MAX]`; explicit `VTS_*_OPEN_CAP` wins), and `prewarmBackends(root,picked)`
   (`VTS_PREWARM_BACKENDS` auto→[dominant] / `all`→every detected lang dominant-first / comma-list). `index.js`
   boot warms each selected backend with its adaptive cap → a multi-lang repo warms in language proportion.
+- `server/psearch.js` + the `PowerShell` matcher entry — THE SECOND SHELL. This environment exposes a
+  `PowerShell` tool ALONGSIDE `Bash`; the PreToolUse matcher listed only `Bash|Grep|Glob|Edit|MultiEdit|Read`,
+  so `Select-String -Path <src> -Pattern "A|B|C"` ran fully unenforced AND uncounted (discover's "share routed
+  through vts" was computed over a channel set that excluded it — it read high for the wrong reason). Found
+  live on a UE tree. `classifyPowerShellSearch(cmd)` is PURE (shared by the hook and `matchBypass`, like
+  `shell-split.js`) → `null | {kind:"content"|"files", pattern, target, symbol}`. It **never rewrites** — a
+  naive PowerShell parser (backtick escapes, `$d` interpolation, `-Pat` prefix binding, positional args) would
+  silently rewrite into a DIFFERENT search, which is worse than not intervening; the hook emits a READY
+  `search_symbol`/`search_text`/`find_files` call instead. Quiet by construction: a piped `… | Select-String`
+  (filtering another command's output), a log/doc/config target, any mutating cmdlet in the command
+  (Copy-Item/Remove-Item/… — a file list feeding a file-op must never be steered to a CAPPED list), a
+  non-recursive `Get-ChildItem`, `-NotMatch` (an inverted match — any call we suggest would return the
+  COMPLEMENT of what was asked), and every SCRIPTED-VALUE shape (`-Quiet`, `.LineNumber`/`.Count`,
+  `$x = (Select-String …)`, an `if (…)` test) — those put no bulk text in context, so there is nothing to save,
+  and no vts tool can return a value into a PowerShell variable. The pattern must BE a symbol, not merely
+  CONTAIN one (`"// TODO: FixMe later"` is prose; `symbolIn` requires every `|` alternative to be a whole
+  identifier / `Foo::Bar` / `struct Foo`) — the Grep tool's whole-pattern rule. **WARN-ONLY by default**
+  (`VTS_PS_BLOCK=1` opts into blocking a symbol hunt): the channel was invisible until now so there is no
+  conversion data, and this project already learned that a wall the agent can't satisfy makes it fight rather
+  than switch (`VTS_EDIT_BLOCK_AFTER` defaults to 0 for the same reason). With qvts installed it still blocks —
+  there a working alternative demonstrably exists. Eval guard 98 asserts BOTH halves — the classifier AND that
+  hooks.json is actually wired to the tool (the wiring is the half that failed silently and no behavioural test
+  sees it). Known, accepted: `Get-Content F.cpp | Select-String X` is piped, so ignored by design.
 - `hooks/block-code-grep.js` + `hooks.json` — grep-block. A Bash code search (grep/rg/ack/ag/findstr/
   `git grep`/`find -name`) that is a SINGLE safe segment is REWRITTEN to the equivalent `vts` CLI command via
   PreToolUse `updatedInput` (token-capped, flow unbroken); anything ambiguous (pipeline, unsafe pattern,
@@ -414,6 +437,26 @@ repo while config pinned clangd for a UE tree) > forced `VTS_BACKEND`/config `ba
   orphan launch: 44 console/terminal processes per run without the flag, 0 with it). Eval guard 96 scans every
   spawn site — it under-detected at first because quote-blanking mis-paired on a regex literal like `/^"|"$/`,
   so it now blanks only comments + template literals. Verify a guard FAILS before trusting it.
+- **A miss must never look like an absence.** A path-less query keeps the CONFIGURED root by design (only a
+  query carrying a `path` resolves elsewhere), so a `projectPath` pinned at `<depot>/TSGame` makes every symbol
+  living in `<depot>/Engine` empty FOREVER — which reads as "vts can't find things" and is exactly what sends
+  an agent back to raw grep (live: `search_symbol FConeConstraint` empty at the module root, 5 correct hits one
+  level up). `core.js widenRootHint(root)` appends one line to an empty symbol result naming the enclosing
+  project root (`findProjectRoot(dirname(root))`), leading with the PER-CALL `projectPath=` (reversible) and
+  offering the permanent `vts setup --projectPath` second (it repoints `dbDirFor` and drops a relative scope).
+  GATED: the parent must carry a real project marker (`.sln`/`.uproject`/`compile_commands.json`/`package.json`/
+  …), never merely a `.git` — findProjectRoot falls back to a repo boundary, which climbs into a notes vault or
+  a checkout-of-checkouts, and pointing there would widen across foreign repos. Silent when already outermost.
+  `VTS_WIDEN_HINT=0`. Eval guard 99. Also added UE/P4 depot markers to `ROOT_FILE_MARKERS`
+  (`GenerateProjectFiles.bat|.sh`, `Setup.bat|.sh`, `.p4config`): a freshly-synced Perforce depot has no `.git`
+  and no `UE5.sln` until GenerateProjectFiles has run, so a path under `Engine/Source/…` resolved to null.
+  **REJECTED (do not re-propose): retrying an empty path-less `search_symbol` at the enclosing root.** Critic-
+  verified against source: `getClient` keys on `${backend}|${root}`, so the retry spawns a SECOND clangd at a
+  root with no compile DB; `VTS_MAX_BACKENDS` (2) can then LRU-evict the WARM one; the new client has no
+  persisted index so `symbolReady` takes the COLD blocking path (the 369s problem); and `scopeDirs` resolves a
+  relative `scope` against the NEW root → `[]` → whole-tree, silently voiding a deliberate narrowing. All that
+  to re-answer queries whose empty result was already CORRECT (typos, DCE reachability, `safe_delete`'s
+  reference guard). The information deficit is fixed with text, not behaviour.
 - **Unattended work stays bounded, deduped and stoppable.** `ensureAutoIndex` (symindex.js) starts a DETACHED
   `vts index` on any locate over an un-indexed tree — deliberately outliving the session so the next cold start
   is instant. It had a FLOOR (`autoIndexTreeLikely`, ≥`VTS_AUTOINDEX_MIN_FILES` 400) but no CEILING, so a UE

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -2571,6 +2571,115 @@ const statusStaleOk =
   /STALE: 7 file\(s\)/.test(stNote({ stale: true, changed: 7 })) &&       // stale → names the count
   /\/vs-token-safer:update/.test(stNote({ stale: true, changed: 7 }));    // → points at the refresh command
 
+// ── PowerShell is an enforced, counted search channel ─────────────────────────────────────────────────────
+// This environment exposes a `PowerShell` tool ALONGSIDE `Bash`. The PreToolUse matcher listed only
+// Bash|Grep|Glob|Edit|MultiEdit|Read, so `Select-String -Path <src> -Pattern "A|B|C"` ran completely
+// unenforced — and `vts discover` could not count it either, so the reported share of search routed through
+// vts was computed over a channel set that excluded it. TWO halves must hold: the classifier must be right,
+// AND the hook must actually be WIRED to the tool (the wiring is the half that failed silently, and no
+// behavioural test can see it — hence the static matcher assertion).
+const psearchOk = await (async () => {
+  const { classifyPowerShellSearch, symbolIn } = await import("../server/psearch.js");
+  const kind = (c) => { const r = classifyPowerShellSearch(c); return r ? r.kind : null; };
+  // Real bypasses (shapes observed live on an Unreal tree) must be caught…
+  const caught =
+    kind(String.raw`$d="G:\p\Engine\Source\Runtime\Engine\Classes\PhysicsEngine"; Select-String -Path "$d\ShapeElem.h" -Pattern "GetName|SetName|EAggCollisionShape"`) === "content" &&
+    kind(String.raw`Select-String -Path "$d\ConstraintTypes.h","$d\ConstraintDrives.h" -Pattern "struct FConeConstraint" -ErrorAction SilentlyContinue`) === "content" &&
+    kind(String.raw`sls -Pat "FConeConstraint" -Path src\Physics.cpp`) === "content" &&   // alias + abbreviated param
+    kind(String.raw`Get-ChildItem -Recurse "C:\repo\Source" -Filter "*.h"`) === "files" &&
+    kind(String.raw`gci -Recurse -Include *.cpp C:\repo\Source`) === "files";
+  // …and every NON-search shape must stay silent. A false positive here blocks real work, so these matter
+  // more than the catches: piped filtering of another command's output, logs/docs, a plain listing, and any
+  // command whose file list feeds a file OPERATION (steering that to a token-capped list would drop files).
+  const quiet =
+    kind(`git log --oneline | Select-String "fix"`) === null &&
+    kind(`Get-Content build.log | sls "error"`) === null &&
+    kind(String.raw`Select-String -Path "Saved\Logs\App.log" -Pattern "Error"`) === null &&
+    kind(String.raw`Select-String -Path "README.md" -Pattern "install"`) === null &&
+    kind(String.raw`Get-ChildItem "C:\repo\Source"`) === null &&
+    kind(`ls`) === null &&
+    kind(String.raw`Get-ChildItem -Recurse -Filter "*.cpp" C:\repo | Copy-Item -Destination D:\backup`) === null &&
+    kind(String.raw`Get-ChildItem -Recurse -Filter "*.cpp" C:\repo\Intermediate`) === null &&
+    kind(`Get-CimInstance Win32_Process | Where-Object { $_.Name -eq 'node.exe' }`) === null &&
+    kind(`Select-String -Pattern "foo"`) === null &&
+    // The shapes a review of 1,170 real PowerShell commands surfaced as false positives. Each is a SCRIPTED
+    // VALUE or an inverted match, never a search whose bulk output would reach the model — so there are no
+    // tokens to save, no vts tool returns a value into a PowerShell variable, and speaking up only breaks a
+    // working script (or, for -NotMatch, offers a call returning the COMPLEMENT of what was asked).
+    kind(String.raw`Select-String -Path src\a.cpp -Pattern "myVar" -NotMatch`) === null &&
+    kind(String.raw`Select-String -Path src\a.cpp -Pattern "Foo" -Quiet`) === null &&
+    kind(String.raw`$n = (Select-String -Path src\a.cpp -Pattern "Foo").LineNumber`) === null &&
+    kind(String.raw`(Select-String -Path src\a.cpp -Pattern "Foo").Count`) === null &&
+    kind(String.raw`if (Test-Path $f) { Select-String -Path src\a.cpp -Pattern "Foo" }`) === null;
+  // The symbol cue admits the Unreal prefix convention (FFoo/UBar/ATest) and rejects keyword alternations —
+  // and the pattern must BE a symbol, not merely CONTAIN one: `"// TODO: FixMe later"` is prose, and offering
+  // search_symbol q="FixMe" for it answers a different question than the one asked.
+  const symOk =
+    symbolIn("struct FConeConstraint") === "FConeConstraint" &&
+    symbolIn("GetName|SetName") === "GetName" &&
+    symbolIn("TODO|FIXME") === "" &&
+    symbolIn("// TODO: FixMe later") === "" &&
+    symbolIn("float Limit;") === "";
+  // A non-Unreal, non-Windows shape must classify too — every other positive fixture here is a UE/drive-letter
+  // path, so a regression that only broke ordinary repos would otherwise pass.
+  const portableOk =
+    kind(String.raw`Select-String -Path "/home/me/app/src/handlers.py" -Pattern "parse_request"`) === "content" &&
+    kind(String.raw`Get-ChildItem -Recurse ./src -Filter "*.ts"`) === "files";
+  // WIRING: the hook is useless if the tool never reaches it.
+  const hooksJson = JSON.parse(fs.readFileSync(new URL("../hooks/hooks.json", import.meta.url), "utf8"));
+  const matchers = (hooksJson.hooks?.PreToolUse || []).map((h) => String(h.matcher || ""));
+  const wired = matchers.some((m) => /\bPowerShell\b/.test(m) && /\bBash\b/.test(m));
+  // MEASUREMENT: discover must know the channel too, or adoption keeps reading high for the wrong reason.
+  const coreSrc = fs.readFileSync(new URL("../server/core.js", import.meta.url), "utf8");
+  const counted = /classifyPowerShellSearch/.test(coreSrc) && /name === "PowerShell"/.test(coreSrc);
+  return caught && quiet && symOk && portableOk && wired && counted;
+})();
+
+// ── widen-root hint: a too-narrow configured root must not read as "the symbol does not exist" ─────────────
+// The reported failure was a `projectPath` pinned to a module inside a bigger tree: every by-name query for a
+// symbol outside that module came back empty forever (path-less queries keep the configured root by design),
+// which reads as "vts can't find things" and sends an agent back to raw grep. The hint is TEXT ONLY — it must
+// fire when a real enclosing PROJECT exists, stay silent when the searched root is already outermost, and
+// stay silent when the only thing above is a version-controlled container of unrelated repos (naming THAT
+// would widen across foreign projects, void a relative scope, and orphan the compile-DB dir).
+const widenHintOk = await (async () => {
+  const { widenRootHint } = await import("../server/core.js");
+  const base = path.join(os.tmpdir(), `vts-eval-widen-${process.pid}`);
+  const mk = (p) => fs.mkdirSync(p, { recursive: true });
+  const save = process.env.VTS_WIDEN_HINT;
+  try {
+    // (a) module inside a real project → fires and names the parent
+    const proj = path.join(base, "proj");
+    const mod = path.join(proj, "Module");
+    mk(mod);
+    fs.writeFileSync(path.join(proj, "App.sln"), "");
+    fs.writeFileSync(path.join(mod, "package.json"), "{}");
+    const fires = widenRootHint(mod);
+    const firesOk = fires.includes(proj) && /projectPath=/.test(fires);
+    // (b) the parent is only a VCS container of unrelated things → silent
+    const vault = path.join(base, "vault");
+    const solo = path.join(vault, "solo");
+    mk(path.join(vault, ".git"));
+    mk(solo);
+    fs.writeFileSync(path.join(solo, "package.json"), "{}");
+    const vaultQuiet = widenRootHint(solo) === "";
+    // (c) already outermost → silent
+    const top = path.join(base, "top");
+    mk(top);
+    fs.writeFileSync(path.join(top, "package.json"), "{}");
+    const topQuiet = widenRootHint(top) === "";
+    // (d) kill switch
+    process.env.VTS_WIDEN_HINT = "0";
+    const offQuiet = widenRootHint(mod) === "";
+    return firesOk && vaultQuiet && topQuiet && offQuiet;
+  } catch {
+    return false;
+  } finally {
+    if (save === undefined) delete process.env.VTS_WIDEN_HINT; else process.env.VTS_WIDEN_HINT = save;
+    try { fs.rmSync(base, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+})();
+
 // ── auto-index bounds: an UNATTENDED build must be capped, liveness-deduped, and stoppable ────────────────
 // ensureAutoIndex starts `vts index` detached on any locate over an un-indexed tree. It had a FLOOR (only trees
 // big enough to be worth indexing) but no CEILING, so a UE-size depot got a tens-of-minutes, one-process-per-
@@ -2770,6 +2879,8 @@ const rows = [
   ["vts index --status staleness note (indexStatusStaleNote): null→silent, fresh→current, stale→N files + /vs-token-safer:update", statusStaleOk, "true", statusStaleOk],
   ["no Windows console storm: every child-process spawn sets windowsHide (console-less MCP / detached indexer → a console+terminal window per child)", noConsoleWindowOk, "true", noConsoleWindowOk],
   ["auto-index bounds: size ceiling refuses an unattended build on a huge tree, lock held by pid LIVENESS (not a TTL), stop/status are honest", autoIndexBoundsOk, "true", autoIndexBoundsOk],
+  ["PowerShell search channel: Select-String/Get-ChildItem classified (aliases, abbreviated params, non-Windows paths), scripted-value/-NotMatch/prose shapes silent, hook WIRED to the tool, counted by discover", psearchOk, "true", psearchOk],
+  ["widen-root hint: names a real enclosing PROJECT on an empty symbol miss, silent when outermost / when the parent is only a VCS container, toggle", widenHintOk, "true", widenHintOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/hooks/block-code-grep.js
+++ b/hooks/block-code-grep.js
@@ -32,6 +32,7 @@ import { fileURLToPath } from "node:url";
 // inside quotes is part of a grep pattern — `grep "FooA|FooB" src/x.cpp` used to split into two
 // non-matching segments and sail through the hook entirely (the top bypass `vts discover` surfaced).
 import { splitSegments } from "../server/shell-split.js";
+import { classifyPowerShellSearch } from "../server/psearch.js";
 // Whole-declaration edit detector, shared with discover (core.js) so the set we STEER matches the set we
 // MEASURE; the adoption ledger is the live metric the steer is tuned against.
 import { classifyDeclEdit } from "../server/edit-detect.js";
@@ -799,6 +800,44 @@ process.stdin.on("end", () => {
       }
       if (s) emitWarn(s + setup);
     }
+    process.exit(0);
+  }
+
+  // PowerShell — the OTHER shell tool. This environment exposes it alongside Bash, and it was missing from the
+  // PreToolUse matcher entirely, so `Select-String -Path <src> -Pattern "A|B|C"` ran completely unenforced (and
+  // uncounted by `vts discover`, which quietly inflated the reported share of search routed through vts).
+  // Unlike the Bash path this NEVER rewrites the command — see the header of server/psearch.js: a naive
+  // PowerShell parser would silently rewrite into a DIFFERENT search, which is worse than not intervening. So
+  // it classifies and hands back a ready call for the model to run itself.
+  if (toolName === "PowerShell" || toolName === "Powershell") {
+    const ps = classifyPowerShellSearch(ti.command || "");
+    if (!ps) process.exit(0);
+    if (ORCH) {
+      const task = ps.kind === "files" ? `find file named ${ps.pattern}` : `find ${ps.pattern} in code`;
+      process.stderr.write(orchMsg(task, ps.target) + "\n");
+      process.exit(2);
+    }
+    const call = ps.kind === "files"
+      ? `find_files q="${ps.pattern}"`
+      : ps.symbol
+        ? `search_symbol q="${ps.symbol}"`
+        : `search_text q="${clip(ps.pattern, 60)}"`;
+    const msg = KO
+      ? `✨ vs-token-safer: PowerShell 코드검색 감지 — \`${clip(ti.command || "", 70)}\`\n→ 대신 ${call} 로 다시 실행하세요 — file:line로 토큰캡(보통 ~90%↓), grep 거짓양성 없음.\n(PowerShell은 자동 변환하지 않습니다 — 잘못된 변환이 다른 결과를 조용히 되돌려주기 때문. 끄기: VTS_ENFORCE=0)`
+      : `✨ vs-token-safer: PowerShell code search detected — \`${clip(ti.command || "", 70)}\`\n→ re-run as ${call} — token-capped to file:line (~90% smaller), no grep false positives.\n(PowerShell is never auto-rewritten — a wrong rewrite would silently return a different result. Disable: VTS_ENFORCE=0)`;
+    // WARN-ONLY BY DEFAULT for the first release of this channel (VTS_PS_BLOCK=1 opts into blocking a named-
+    // symbol hunt, the way the Grep tool already does). Reasoning: for a user whose language server is not set
+    // up, a block is a wall with less behind it than what it blocked, and this project already learned that
+    // shape — VTS_EDIT_BLOCK_AFTER defaults to 0 because a wall the agent cannot satisfy makes it fight rather
+    // than switch. The channel was invisible until now, so there is no conversion data yet; warn first, let
+    // `vts discover` measure the newly-visible channel, then decide on evidence. (With the local orchestrator
+    // installed the block above still applies — there a working alternative demonstrably exists.)
+    const psBlock = /^(1|true|on|yes)$/i.test(String(process.env.VTS_PS_BLOCK || ""));
+    if (psBlock && grepBlockOn() && ps.kind === "content" && ps.symbol) {
+      process.stderr.write(msg + setup + "\n");
+      process.exit(2);
+    }
+    emitWarn(msg + setup);
     process.exit(0);
   }
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -20,7 +20,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash|Grep|Glob|Edit|MultiEdit|Read",
+        "matcher": "Bash|PowerShell|Grep|Glob|Edit|MultiEdit|Read",
         "hooks": [
           {
             "type": "command",

--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -498,6 +498,11 @@ export function pickBackend(root) {
 const ROOT_FILE_MARKERS = [
   "compile_commands.json", "tsconfig.json", "jsconfig.json", "package.json",
   "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile",
+  // Unreal / Perforce depot roots. A UE source depot carries `UE5.sln` only AFTER GenerateProjectFiles has
+  // run, and a Perforce workspace has no `.git` to fall back on — so a freshly-synced depot matched NOTHING
+  // and a path under Engine/Source/… climbed to the filesystem root and resolved to null. These are the
+  // files that sit at a depot root by construction.
+  "GenerateProjectFiles.bat", "GenerateProjectFiles.sh", "Setup.bat", "Setup.sh", ".p4config",
 ];
 const ROOT_GLOB_MARKERS = [/\.uproject$/i, /\.sln$/i, /\.csproj$/i];
 export function findProjectRoot(startPath) {

--- a/server/core.js
+++ b/server/core.js
@@ -15,6 +15,7 @@ import { pickBackend, BACKENDS, clangdAdvisory, clangdAvailable, clangdMissingAd
 import { scopeStats, inScope } from "./scope.js";
 import { recordQueryResults, languageCensus, histRank } from "./warmset.js";
 import { splitSegments } from "./shell-split.js";
+import { classifyPowerShellSearch } from "./psearch.js";
 import { classifyDeclEdit } from "./edit-detect.js";
 import { counterfactualOn, relateSets, recordCounterfactual, grepKey, locKey, counterfactualReport } from "./counterfactual.js";
 import { recordEditEvent } from "./edit-ledger.js";
@@ -175,6 +176,37 @@ const EMPTY_HINT =
   " Empty can mean: JUST-edited (index lags the save — retry or search_text), a DEFINITIONS-only match " +
   "(not every reference), or a LOG (not indexed — use gamedev-log).";
 const LOG_EMPTY_HINT = " Looking for something in a LOG? Logs aren't indexed for code search — use gamedev-log for log content.";
+// A miss whose real cause is a TOO-NARROW configured root reads exactly like "the symbol does not exist", and
+// that is the failure that makes an agent abandon the plugin: `projectPath` pinned at <depot>/TSGame, the
+// symbol living in <depot>/Engine, every by-name query empty forever (a path-less query keeps the configured
+// root by design — only a query carrying a `path` can resolve elsewhere). Measured: `search_symbol
+// FConeConstraint` empty at the module root, 5 correct hits one level up. So when an enclosing project root
+// EXISTS above the one we searched, say so and name the command that widens it. Text only, no behaviour
+// change; silent when the searched root is already the outermost project. VTS_WIDEN_HINT=0 hides it.
+export function widenRootHint(root) {
+  if (/^(0|false|off|no)$/i.test(String(process.env.VTS_WIDEN_HINT ?? "1"))) return "";
+  try {
+    const here = path.resolve(String(root || ""));
+    const parent = path.dirname(here);
+    if (!parent || parent === here) return "";
+    const up = findProjectRoot(parent);
+    if (!up || path.resolve(up) === here) return "";
+    // Only name a parent that is a PROJECT, not merely a directory that happens to be under version control.
+    // findProjectRoot stops at `.git` as a repo-boundary fallback, and a `.git` alone climbs into things like a
+    // notes vault or a checkout-of-checkouts holding unrelated siblings — pointing the user at THAT would widen
+    // the search across foreign repos, void a relative `scope` (scopeDirs resolves against root → missing → the
+    // whole tree), and orphan the existing clangd index (dbDirFor is keyed by root). Require a real build/
+    // project marker up there before suggesting it.
+    const STRONG = [/\.sln$/i, /\.uproject$/i, /\.csproj$/i, /^compile_commands\.json$/i, /^package\.json$/i, /^pyproject\.toml$/i, /^CMakeLists\.txt$/i, /^go\.mod$/i, /^Cargo\.toml$/i];
+    let names = [];
+    try { names = fs.readdirSync(up, { withFileTypes: true }).filter((e) => e.isFile()).map((e) => e.name); } catch { return ""; }
+    if (!names.some((n) => STRONG.some((re) => re.test(n)))) return "";
+    // Lead with the PER-CALL widening: it is reversible and scoped to this question. A `vts setup` re-pin is
+    // permanent and has side effects (it repoints the compile-DB directory and drops a relative scope), so it
+    // is offered second, as the deliberate choice it is.
+    return `\n↪ Only ${here} was searched (the configured projectPath). The enclosing project is ${up} — a symbol outside this module (engine, vendored deps, a sibling module) can never match here. Try it on this call: projectPath="${up}". To make it permanent: vts setup --projectPath "${up}" (re-pins the compile-DB dir and drops a relative scope).`;
+  } catch { return ""; /* best-effort hint — never break a result */ }
+}
 // search_text → symbol steer (dogfood-found): a TEXT query that is really a SYMBOL/CLASS usage hunt — a
 // template arg `Foo<Bar>`, a `::` scope, or a dominant CamelCase/snake identifier — is answered better by
 // find_references / search_symbol: the LSP index is COMPLETE (no 4s time-box) and ~10–20× smaller. The
@@ -469,6 +501,14 @@ function matchBypass(name, input) {
       }
     }
     return null;
+  }
+  // The OTHER shell tool. It was absent from this matcher AND from the hook's PreToolUse matcher, so a
+  // PowerShell `Select-String` over source was neither enforced nor COUNTED — which is worse than it sounds:
+  // discover's headline ("share of search tokens routed through vts") was computed over a channel set that
+  // excluded the channel some users search with, so the number read high for a reason that was not adoption.
+  if (name === "PowerShell" || name === "Powershell") {
+    const ps = classifyPowerShellSearch(String(input.command || ""));
+    return ps ? { tool: ps.kind === "files" ? "Get-ChildItem" : "Select-String", q: cleanQ(input.command || "") } : null;
   }
   if (name === "Grep") {
     const glob = String(input.glob || "").toLowerCase();
@@ -2879,7 +2919,7 @@ export async function runTool(name, a = {}) {
       if (syn) { const scopeTag = syn.scoped ? ` in ${syn.scoped}` : ""; return finishOut(syn.lines, `No language-server backend for ${root} — ${syn.source} declaration matches for "${a.q}"${scopeTag}:\n` + syn.lines.join("\n") + symScopeNote(syn, a.q) + completenessCert({ shown: syn.lines.length, total: syn.total, truncated: syn.truncated, syntactic: true })); }
       const hits = scanTextUnder(root, String(a.q), Math.min(max, 60));
       if (hits.length) return finishOut(hits, `No language-server backend resolved for ${root} — literal text matches for "${a.q}" (file:line, not a semantic decl):\n` + hits.join("\n"));
-      return finishOut([], `No backend resolved and no text match for "${a.q}" under ${root}.` + EMPTY_HINT);
+      return finishOut([], `No backend resolved and no text match for "${a.q}" under ${root}.` + EMPTY_HINT + widenRootHint(root));
     }
     // find_references with NO backend (a Go/Rust/… repo we have no language server for): the SYNTACTIC
     // reference fallback (tree-sitter call sites, then a literal scan) — the SAME tier search_symbol uses
@@ -2897,7 +2937,7 @@ export async function runTool(name, a = {}) {
       }
       const hits = scanTextUnder(root, want, fmax);
       if (hits.length) return finishOut(hits, `No language-server backend for ${root} — literal usage matches for "${want}" (file:line of the name, not semantic references):\n` + hits.join("\n"));
-      return finishOut([], `No backend resolved and no tree-sitter/text reference for "${want}" under ${root}.` + EMPTY_HINT);
+      return finishOut([], `No backend resolved and no tree-sitter/text reference for "${want}" under ${root}.` + EMPTY_HINT + widenRootHint(root));
     }
     if (!backendName) return err(`No backend resolved. Pass backend=clangd|roslyn|typescript|pyright, set VTS_BACKEND, or ensure the project root has compile_commands.json (C++), a .sln/.csproj (C#), a tsconfig/package.json (JS/TS), or a pyproject.toml/*.py (Python).`);
     const max = Number(a.maxResults) || MAX_RESULTS;
@@ -2965,7 +3005,7 @@ export async function runTool(name, a = {}) {
             : ladder;
           const hits = scanTextUnder(root, String(a.q), Math.min(pmax, 60));
           if (hits.length) return finishOut(hits, `clangd can't serve this tree fast (${why}) — literal text matches for "${a.q}" (file:line, not a semantic decl):\n` + hits.join("\n") + buildHint + autoNote + descend);
-          return finishOut([], `clangd can't serve this tree fast (${why}) and no syntactic/text match for "${a.q}" under ${root}.` + buildHint + autoNote + descend + EMPTY_HINT);
+          return finishOut([], `clangd can't serve this tree fast (${why}) and no syntactic/text match for "${a.q}" under ${root}.` + buildHint + autoNote + descend + EMPTY_HINT + widenRootHint(root));
         }
       }
       // Render a successful symbol hit set — shared by the primary path and the census fallback below, so a
@@ -3041,7 +3081,7 @@ export async function runTool(name, a = {}) {
         const intentSteer = process.env.VTS_CONCEPT_STEER !== "0" && /\S\s+\S/.test(String(a.q).trim())
           ? `\n[ladder: that reads like an INTENT, not a symbol name. Descend to the fuzzy rung — concept_search q="${a.q}" (repo-mined concept dictionary, no embeddings, still file:line).]`
           : "";
-        return finishOut([], adv + `No symbols matching "${a.q}" (backend: ${backendName}).` + EMPTY_HINT + clangdIndexAdvisory(backendName, root, null) + emptyCert + intentSteer);
+        return finishOut([], adv + `No symbols matching "${a.q}" (backend: ${backendName}).` + EMPTY_HINT + clangdIndexAdvisory(backendName, root, null) + emptyCert + intentSteer + widenRootHint(root));
       }
       // confidence-adaptive focus + steers + cert (shared with the census fallback above).
       return renderFoundSymbols(syms, backendName, adv);

--- a/server/psearch.js
+++ b/server/psearch.js
@@ -1,0 +1,180 @@
+/*
+ * psearch.js — recognise a POWERSHELL code search. PURE (string in, verdict out; no fs, no spawn) so the
+ * enforcement hook and `vts discover` classify the same command the same way, and so it is unit-testable.
+ *
+ * Why this exists: this Claude Code environment exposes a `PowerShell` tool ALONGSIDE `Bash`. The PreToolUse
+ * matcher listed only `Bash|Grep|Glob|Edit|MultiEdit|Read`, so a code search run as
+ * `Select-String -Path <dir>\Foo.h -Pattern "A|B|C"` never reached the hook at all — and even fed in directly
+ * the hook exited 0, because it only parses grep/rg/ack/ag/findstr/`git grep`/`find -name`. So the whole
+ * channel was unenforced AND uncounted: the "share of search tokens routed through vts" that discover reports
+ * was computed over a channel set that excluded it.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO: rewrite the command. The Bash path rewrites a safe single segment into
+ * the equivalent `vts` call, which works because `shell-split.js` understands POSIX quoting. PowerShell is a
+ * different language — backtick escapes, `$d` interpolation, `$(...)` subexpressions, abbreviated parameters
+ * (`-Pat` binds to `-Pattern`), positional binding, `@(...)` arrays. A parser good enough to rewrite safely is
+ * a real PowerShell parser; a naive one silently rewrites into a DIFFERENT search, and a wrong answer the
+ * model believes is worse than no interception. So this only ever classifies, and the caller emits a
+ * ready-to-use vts call for the model to run itself.
+ */
+
+// Code-file extensions worth intercepting — kept in step with the Bash side's CODE_FILE_TOKEN.
+const CODE_EXT = "c|cc|cxx|cpp|h|hpp|hh|hxx|inl|ipp|tpp|cs|ts|tsx|mts|cts|js|jsx|mjs|cjs|py|pyi|go|rs|java|kt|rb|php|swift|scala|m|mm";
+const CODE_EXT_RE = new RegExp(`\\.(${CODE_EXT})\\b`, "i");
+const CODE_GLOB_RE = new RegExp(`\\*\\.(${CODE_EXT})\\b`, "i");
+// Paths that are NOT source: logs, build output, dependencies. A search there is legitimately raw.
+// The directory alternative is end-anchored as well as separator-terminated: a target may NAME the excluded
+// directory as its last segment (`... -Filter *.cpp C:\repo\Intermediate`), which a `[\\/]dir[\\/]` pattern
+// alone misses — and that is precisely the build-output case we must not intercept.
+const TEXT_TARGET_RE = /\.(log|jsonl|txt|md|csv|xml|json|ya?ml|ini|cfg|toml)\b|[\\/](logs?|saved|intermediate|binaries|build|dist|out|obj|bin|node_modules|\.git|deriveddatacache)([\\/"']|\s|$)/i;
+
+// Cmdlets (and aliases) that SEARCH CONTENT / LIST FILES.
+const CONTENT_CMDLETS = /(^|[\s;(|{])(select-string|sls)(\s|$)/i;
+const FILE_CMDLETS = /(^|[\s;(|{])(get-childitem|gci|ls|dir)(\s|$)/i;
+
+// Cmdlets that MUTATE or move files. Their presence means the command is doing file-ops plumbing (a backup, a
+// copy, a cleanup) and any file list it builds feeds that op — intercepting it would be wrong, and steering it
+// to a token-CAPPED listing would silently drop files from the operation. Same reasoning as the Bash
+// `hasFileOpsContext` guard, which was added after a real UE-depot backup got blocked.
+const FILE_OPS_RE =
+  /(^|[\s;(|{])(copy-item|move-item|remove-item|rename-item|new-item|set-content|add-content|out-file|compress-archive|expand-archive|robocopy|xcopy|start-process|invoke-webrequest|export-csv|set-acl|clear-content)(\s|$)/i;
+
+// Is the search cmdlet being fed by a PIPE? `<something> | Select-String foo` filters the OUTPUT of another
+// command (a build log, `git log`, a CSV) — that is ordinary text filtering, not a code search, and vts has
+// nothing better to offer. Only a Select-String that reads FILES ITSELF is in scope.
+function pipedInto(cmd, cmdletRe) {
+  // Look for a `|` that appears before the cmdlet with no intervening `;` (a new statement resets the pipeline).
+  const m = cmdletRe.exec(cmd);
+  if (!m) return false;
+  const before = cmd.slice(0, m.index);
+  const lastSemi = Math.max(before.lastIndexOf(";"), before.lastIndexOf("{"));
+  return before.slice(lastSemi + 1).includes("|");
+}
+
+// The value of a named parameter, tolerating PowerShell's prefix binding (`-Pat` → `-Pattern`) and both quote
+// styles. Returns "" when absent. Only the FIRST value is taken — an array (`-Path a,b`) yields the first,
+// which is enough to decide "is this source code", never to rebuild the command.
+function paramValue(cmd, full, minLen) {
+  const alt = [];
+  for (let n = minLen; n <= full.length; n++) alt.push(full.slice(0, n));
+  const re = new RegExp(`-(?:${alt.join("|")})\\s+("([^"]*)"|'([^']*)'|([^\\s,;|]+))`, "i");
+  const m = re.exec(cmd);
+  if (!m) return "";
+  return (m[2] ?? m[3] ?? m[4] ?? "").trim();
+}
+
+// Anything that looks like a filesystem target in the command: an explicit -Path/-LiteralPath, else a quoted
+// or bare token carrying a code extension or a path separator. Used only to decide whether the search is
+// aimed at SOURCE — not to reconstruct a scope.
+function targetsOf(cmd) {
+  const out = [];
+  for (const p of [["path", 2], ["literalpath", 2]]) {
+    const v = paramValue(cmd, p[0], p[1]);
+    if (v) out.push(v);
+  }
+  const tok = /("([^"]*[\\/][^"]*)"|'([^']*[\\/][^']*)'|([\w.$:{}\\/-]*[\\/][\w.${}\\/-]+))/g;
+  let m;
+  while ((m = tok.exec(cmd))) {
+    const v = (m[2] ?? m[3] ?? m[4] ?? "").trim();
+    if (v && !out.includes(v)) out.push(v);
+  }
+  return out;
+}
+
+// The hunted pattern: -Pattern when named, else the first quoted string that is not a path. Best-effort — it
+// is shown back to the model in the suggested call, never executed.
+function patternOf(cmd) {
+  const named = paramValue(cmd, "pattern", 3);
+  if (named) return named;
+  const q = /"([^"]+)"|'([^']+)'/g;
+  let m;
+  while ((m = q.exec(cmd))) {
+    const v = (m[1] ?? m[2] ?? "").trim();
+    if (v && !/[\\/]/.test(v) && !/^\$/.test(v)) return v;
+  }
+  return "";
+}
+
+// A CamelCase / snake_case identifier in the pattern makes this a named-symbol hunt (search_symbol territory)
+// rather than freeform text. Mirrors the Bash side's symbol-hunt cue; an ALL-CAPS keyword alternation
+// (`TODO|FIXME`, `GET|POST`) carries no such signal and stays freeform on purpose.
+// The `[A-Z]+[a-z0-9]+[A-Z]` alternative (not `[A-Z][a-z0-9]+[A-Z]`) is what admits the Unreal prefix
+// convention — FConeConstraint, UStaticMesh, ATestActor, IInterface, TArray — where two capitals lead.
+const IDENT_RE = /\b([a-z]+[A-Z][A-Za-z0-9]*|[A-Z]+[a-z0-9]+[A-Z][A-Za-z0-9]*|[a-z][a-z0-9]*_[a-z0-9_]+)\b/;
+
+// The pattern must BE a symbol, not merely CONTAIN one. Containment was too loose in exactly the way the Bash
+// side already guards against: `"// TODO: FixMe later"` is prose, and offering `search_symbol q="FixMe"` for it
+// answers a different question. So every alternative of the pattern must itself be an identifier, an optionally
+// scoped one (`Foo::Bar`), or a structural declaration cue (`struct FConeConstraint`) — mirroring
+// isSymbolHuntGrep's whole-pattern rule on the Grep tool.
+const WHOLE_SYM_RE = /^(?:(?:struct|class|enum|union|namespace|typedef|interface)\s+)?[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*$/;
+export function symbolIn(pattern) {
+  const raw = String(pattern || "").trim();
+  if (!raw) return "";
+  const parts = raw.split("|").map((p) => p.trim()).filter(Boolean);
+  if (!parts.length) return "";
+  if (!parts.every((p) => WHOLE_SYM_RE.test(p))) return ""; // any prose/regex alternative → not a symbol hunt
+  for (const p of parts) {
+    const m = IDENT_RE.exec(p);
+    if (m) return m[1]; // the first alternative carrying a real identifier shape names the hunt
+  }
+  return "";
+}
+
+/**
+ * Classify a PowerShell command. Returns null when it is not a code search we should speak up about, else
+ * { kind: "content"|"files", pattern, target, symbol } — `symbol` non-empty when it reads as a named-symbol
+ * hunt. Conservative by construction: every ambiguity resolves to null (stay quiet).
+ */
+export function classifyPowerShellSearch(command) {
+  const cmd = String(command || "");
+  if (!cmd.trim()) return null;
+  // Cheap pre-check before any parsing: this hook runs on EVERY PowerShell call, and in a real transcript
+  // corpus the overwhelming majority are Set-Location / Stop-Process / Get-Process / Add-Type — nothing to
+  // classify. One substring test skips the regex work for them.
+  if (!/select-string|\bsls\b|get-childitem|\bgci\b|\bdir\b|\bls\b/i.test(cmd)) return null;
+  if (FILE_OPS_RE.test(cmd)) return null; // plumbing for a file operation, not a search-to-read
+  // INVERTED match: `-NotMatch` returns the lines that do NOT match. Any call we suggest would return the
+  // complement of what was asked — a wrong answer the model would believe, which is the precise hazard this
+  // module exists to avoid. Never speak up.
+  if (/-notmatch\b/i.test(cmd)) return null;
+  // SCRIPTED VALUE, not a search-to-read: `-Quiet` yields a boolean, `.LineNumber`/`.Count`/`.Matches` pull a
+  // field, `$x = (Select-String …)` captures into a variable, and an `if (…)` uses it as a test. No bulk text
+  // ever reaches the context window, so there are no tokens to save — and none of the vts tools can return a
+  // value INTO a PowerShell variable, so steering would just break a working script. Same lesson as the Bash
+  // side's file-ops guard, which exists because a real depot backup got blocked.
+  if (/-quiet\b/i.test(cmd)) return null;
+  if (/\)\s*\.\s*(linenumber|count|matches|line|path|filename)\b/i.test(cmd)) return null;
+  if (/\$\w+\s*=\s*\(?\s*(select-string|sls|get-childitem|gci)\b/i.test(cmd)) return null;
+  if (/\bif\s*\(/i.test(cmd)) return null;
+
+  const targets = targetsOf(cmd);
+  const codeTarget = targets.some((t) => CODE_EXT_RE.test(t) || CODE_GLOB_RE.test(t));
+  const textTarget = targets.some((t) => TEXT_TARGET_RE.test(t)) || TEXT_TARGET_RE.test(cmd);
+
+  if (CONTENT_CMDLETS.test(cmd)) {
+    if (pipedInto(cmd, CONTENT_CMDLETS)) return null; // filtering another command's output
+    if (textTarget) return null; // a log/doc/config search is legitimately raw
+    // Needs SOME filesystem target: a bare `Select-String -Pattern x` with nothing to read is not ours.
+    if (!targets.length) return null;
+    // A path with no code extension can still be a source DIRECTORY; require either a code file, a code glob,
+    // or a directory-looking target combined with a code-ish pattern. Otherwise stay quiet.
+    const pattern = patternOf(cmd);
+    const dirTarget = targets.some((t) => /[\\/]/.test(t) && !/\.\w{1,5}$/.test(t));
+    if (!codeTarget && !dirTarget) return null;
+    return { kind: "content", pattern, target: targets[0] || "", symbol: symbolIn(pattern) };
+  }
+
+  if (FILE_CMDLETS.test(cmd)) {
+    // Only a RECURSIVE listing filtered to code files is a find_files case. A plain `ls` / `Get-ChildItem` of
+    // one directory is how anyone looks around — never intercept that.
+    if (!/-r(ec|ecu|ecur|ecurs|ecurse)?\b/i.test(cmd)) return null;
+    const filt = paramValue(cmd, "filter", 3) || paramValue(cmd, "include", 3);
+    const glob = CODE_GLOB_RE.test(filt) ? filt : CODE_EXT_RE.test(filt) ? filt : "";
+    if (!glob) return null;
+    if (textTarget) return null;
+    return { kind: "files", pattern: glob, target: targets[0] || "", symbol: "" };
+  }
+
+  return null;
+}


### PR DESCRIPTION
A user's agent was searching an Unreal tree with raw `PowerShell Select-String -Path ... -Pattern "A|B|C"` instead of the plugin, repeatedly. Two independent causes, both reproduced before any code was written.

## Cause 1 — the hook never saw PowerShell

This environment exposes a `PowerShell` tool **alongside** `Bash`. The PreToolUse matcher was `Bash|Grep|Glob|Edit|MultiEdit|Read`, so the hook was never invoked for it — and fed a `Select-String` payload directly it exited 0, because it only parses grep/rg/ack/ag/findstr/`git grep`/`find -name`. `Select-String` appeared nowhere in `server/` either, so **`vts discover` could not count the channel**: the reported share of search routed through vts was computed over a channel set that excluded the channel some users actually search with.

### What landed

New pure module `server/psearch.js`, shared by the hook and `matchBypass` (same pattern as `shell-split.js`). It **classifies only and never rewrites** — PowerShell has backtick escapes, `$d` interpolation, `-Pat` prefix binding and positional args, so a naive parser would silently rewrite into a *different* search, and a wrong answer the model believes is worse than no interception. The hook emits a ready `search_symbol` / `search_text` / `find_files` call instead.

Quiet by construction: piped `... | Select-String` (filtering another command's output), log/doc/config targets, any mutating cmdlet in the command, non-recursive `Get-ChildItem`, `-NotMatch`, and every scripted-value shape (`-Quiet`, `.LineNumber`/`.Count`, `$x = (...)`, `if (...)`). The pattern must **be** a symbol, not merely contain one.

**Warn-only by default** (`VTS_PS_BLOCK=1` opts into blocking a symbol hunt).

## Cause 2 — the configured root was narrower than where the user worked

`projectPath` pinned to `<depot>/TSGame`; symbols in `<depot>/Engine`. A path-less query keeps the configured root by design, so every by-name engine query was empty **forever** — which reads as "the plugin cannot find things".

```
vts symbol --q FConeConstraint                       -> EMPTY
vts symbol --q FConeConstraint --projectPath <depot> -> ConstraintTypes.h:71: struct FConeConstraint  (5 hits)
```

`widenRootHint(root)` appends one line to an empty symbol result naming the enclosing project root: per-call `projectPath=` first (reversible), permanent `vts setup` second (it repoints `dbDirFor` and drops a relative scope). **Gated** — the parent must carry a real project marker, never merely a `.git`, because `findProjectRoot` falls back to a repo boundary and that climbs into a notes vault or a checkout-of-checkouts.

Verified live: fires on the UE module → names the depot; **silent** on this repo (parent is a vault with only `.git`); silent at the outermost root.

Also adds UE/Perforce depot markers to `ROOT_FILE_MARKERS` — a freshly synced P4 depot has no `.git` and no `UE5.sln` until GenerateProjectFiles has run.

## Deliberately NOT done

Retrying an empty path-less `search_symbol` at the enclosing root. An adversarial review verified against source that: `getClient` keys on `${backend}|${root}` → the retry spawns a **second clangd** at a root with no compile DB; `VTS_MAX_BACKENDS` (2) can then LRU-evict the **warm** one; the new client has no persisted index so `symbolReady` takes the cold **blocking** path; and `scopeDirs` resolves a relative scope against the new root → `[]` → whole tree, silently voiding a deliberate narrowing. All to re-answer queries whose empty result was already **correct** (typos, dead-code reachability, `safe_delete`'s reference guard). Recorded in CLAUDE.md so it is not re-proposed.

## Review points

- The review also found, on a corpus of 1,170 real PowerShell commands, that an earlier draft blocked 40 scripted-value shapes that save zero tokens. Those are now silent, and are pinned by guard 98.
- Two of the review's findings did **not** survive checking, and the code was left alone: it reported `widenRootHint` as wired only into the "no backend resolved" branches (it is also at `:2995` and `:3071`, and a live run prints it from `:2995`), and reported the hint as silent on Perforce depots (a UE depot carries `UE5.sln`, which already matched — the real gap was the pre-GenerateProjectFiles state, which the new markers cover).
- `Get-Content F.cpp | Select-String X` is piped, so ignored by design. Accepted trade — the pipe guard is what keeps build-log and `git log` filtering silent.
- Guard 98 asserts the classifier **and** the hooks.json wiring; the wiring is the half that failed silently here and no behavioural test can see it.

## Verification

- `node eval/run.mjs` → `EVAL PASSED`; guards 98 and 99 each verified **red** when deliberately broken, green after restore
- Hook driven end-to-end on 9 command shapes x 2 modes (with and without the local orchestrator)
- `npm run lint` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
