### PR TITLE
fix(orch): never redirect a vs-search call that already names one file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,6 +437,15 @@ repo while config pinned clangd for a UE tree) > forced `VTS_BACKEND`/config `ba
   orphan launch: 44 console/terminal processes per run without the flag, 0 with it). Eval guard 96 scans every
   spawn site — it under-detected at first because quote-blanking mis-paired on a regex literal like `/^"|"$/`,
   so it now blanks only comments + template literals. Verify a guard FAILS before trusting it.
+- **Never WIDEN a call that is already scoped.** The Bash path lets a `find <subdir> -name X` run natively and
+  the Glob path lets a subdir-scoped glob through, because delegating them LOSES the scope. `hooks/
+  orchestrator-redirect.js` never got that rule: `rootFor` lifted the root out of a `path` but `taskFor`
+  rendered `find X in code`, so `search_text q=X path=<one header>` — instant and COMPLETE — was handed back as
+  `qvts -p <depot root> --json "find X in code"`, a whole-tree scan replacing a single-header read. Now a call
+  naming an existing FILE is exempt from the redirect outright (silent pass-through), and a call naming a DIR
+  still delegates but carries `under <dir>` into the task. The token mandate is about keeping BULK output out
+  of context — a file-scoped, token-capped answer already does that. Eval guard 100; `VTS_ORCH_SEEN_FILE`
+  overrides the one-shot dedupe store for tests.
 - **A miss must never look like an absence.** A path-less query keeps the CONFIGURED root by design (only a
   query carrying a `path` resolves elsewhere), so a `projectPath` pinned at `<depot>/TSGame` makes every symbol
   living in `<depot>/Engine` empty FOREVER — which reads as "vts can't find things" and is exactly what sends

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import http from "node:http";
+import { fileURLToPath } from "node:url";
 
 process.env.VTS_CLANGD_CMD = process.execPath;
 process.env.VTS_CLANGD_ARGS = new URL("./_mock-lsp.mjs", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
@@ -2680,6 +2681,51 @@ const widenHintOk = await (async () => {
   }
 })();
 
+// ── orchestrator redirect must not WIDEN a call that is already scoped ────────────────────────────────────
+// With qvts installed, a vs-search locate is redirected to it. But `taskFor` renders a natural-language task
+// that carried the ROOT and not the FILE, so `search_text q=X path=<one header>` — which answers instantly and
+// COMPLETE — was handed back as `qvts -p <depot root> --json "find X in code"`, a whole-tree scan replacing a
+// single-header read. The Bash and Glob paths already stay native for a scoped call for exactly this reason;
+// the MCP redirect never got the rule. A named FILE is exempt outright; a named DIR still delegates but must
+// carry its scope into the task.
+const orchScopeOk = await (async () => {
+  const hook = fileURLToPath(new URL("../hooks/orchestrator-redirect.js", import.meta.url));
+  const base = path.join(os.tmpdir(), `vts-eval-orch-${process.pid}`);
+  const dir = path.join(base, "Components");
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, "ActorComponent.h");
+  fs.writeFileSync(file, "bool bIsEditorOnly;\n");
+  const seen = path.join(base, "seen.json");
+  const run = (suffix, input) => {
+    try { fs.rmSync(seen, { force: true }); } catch { /* fresh */ }
+    const r = spawnSync(process.execPath, [hook], {
+      input: JSON.stringify({ tool_name: `mcp__plugin_vs-token-safer_vs-search__${suffix}`, tool_input: input }),
+      encoding: "utf8",
+      // The eval sets VTS_ORCHESTRATOR_AWARE=0 for hermeticity (so the maintainer's real qvts install cannot
+      // leak into results). orchestratorPresent() checks that kill switch FIRST, so the child must re-enable
+      // it or the redirect never engages and every assertion below trivially "passes" the wrong way.
+      env: { ...process.env, VTS_ORCHESTRATOR_AWARE: "1", VTS_ORCHESTRATOR: "1", VTS_ENFORCE: "1", VTS_ORCH_BLOCK: "1", VTS_ORCH_SEEN_FILE: seen },
+    });
+    return { status: r.status, out: (r.stderr || "") + (r.stdout || "") };
+  };
+  try {
+    const f = run("search_text", { q: "bIsEditorOnly", path: file });
+    const d = run("document_symbols", { path: file });
+    const g = run("search_text", { q: "bIsEditorOnly", path: dir });
+    const n = run("search_symbol", { q: "bIsEditorOnly" });
+    return (
+      f.status === 0 && !/qvts -p/.test(f.out) &&   // a named FILE passes through, silently
+      d.status === 0 && !/qvts -p/.test(d.out) &&
+      g.status === 2 && /under /.test(g.out) &&      // a named DIR delegates WITH its scope
+      n.status === 2                                  // a path-less locate still delegates
+    );
+  } catch {
+    return false;
+  } finally {
+    try { fs.rmSync(base, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+})();
+
 // ── auto-index bounds: an UNATTENDED build must be capped, liveness-deduped, and stoppable ────────────────
 // ensureAutoIndex starts `vts index` detached on any locate over an un-indexed tree. It had a FLOOR (only trees
 // big enough to be worth indexing) but no CEILING, so a UE-size depot got a tens-of-minutes, one-process-per-
@@ -2881,6 +2927,7 @@ const rows = [
   ["auto-index bounds: size ceiling refuses an unattended build on a huge tree, lock held by pid LIVENESS (not a TTL), stop/status are honest", autoIndexBoundsOk, "true", autoIndexBoundsOk],
   ["PowerShell search channel: Select-String/Get-ChildItem classified (aliases, abbreviated params, non-Windows paths), scripted-value/-NotMatch/prose shapes silent, hook WIRED to the tool, counted by discover", psearchOk, "true", psearchOk],
   ["widen-root hint: names a real enclosing PROJECT on an empty symbol miss, silent when outermost / when the parent is only a VCS container, toggle", widenHintOk, "true", widenHintOk],
+  ["orchestrator redirect never widens a scoped call: a named FILE passes through silently, a named DIR delegates WITH its scope, path-less still delegates", orchScopeOk, "true", orchScopeOk],
 ];
 console.log(`vs-token-safer eval — mock LSP backend\n`);
 let ok = true;

--- a/hooks/orchestrator-redirect.js
+++ b/hooks/orchestrator-redirect.js
@@ -68,6 +68,10 @@ function taskFor(suffix, ti) {
   const q = String(ti.q ?? ti.query ?? "").trim();
   const sym = String(ti.symbol ?? ti.name ?? q).trim();
   const p = String(ti.path ?? ti.file ?? "").trim();
+  // Carry a DIRECTORY scope into the task. A file target never reaches here (those are exempted from the
+  // redirect entirely), but a dir-scoped call still must not silently widen to the whole root — the same
+  // scope-loss the Bash path fixed by folding the grep's own file/dir operand into the delegated task.
+  const scope = p && !/\.[A-Za-z0-9]{1,6}$/.test(p) ? ` under ${p}` : "";
   switch (suffix) {
     case "search_symbol": return `where is symbol ${q || sym} declared`;
     case "def_search": return `where is ${sym || q} defined`;
@@ -77,14 +81,16 @@ function taskFor(suffix, ti) {
     case "document_symbols": return `outline / list the symbols declared in ${p || "this file"}`;
     case "concept_search": return q || sym;
     case "search_text":
-    default: return `find ${q || sym} in code`;
+    default: return `find ${q || sym}${scope || " in code"}`;
   }
 }
 
 const blockOn = () => !off(process.env.VTS_ORCH_BLOCK ?? "1");
 
 // One-time-per-query state so a post-delegation fallback retry isn't blocked again.
-const SEEN_FILE = path.join(os.homedir(), ".vs-token-safer", "orch-seen.json");
+// VTS_ORCH_SEEN_FILE overrides the one-shot dedupe store so a test can drive the block without touching the
+// user's real state (and without its result depending on what they searched five minutes ago).
+const SEEN_FILE = process.env.VTS_ORCH_SEEN_FILE || path.join(os.homedir(), ".vs-token-safer", "orch-seen.json");
 const TTL_MS = (() => { const n = Number(process.env.VTS_ORCH_TTL_MS); return Number.isFinite(n) && n > 0 ? n : 180000; })();
 function seenRecently(key) {
   let m = {};
@@ -142,6 +148,22 @@ process.stdin.on("end", () => {
   if (!orchestratorPresent()) process.exit(0);             // standalone vts → unchanged behavior
 
   const ti = j.tool_input || {};
+
+  // A call that NAMES AN EXISTING FILE is already scoped to that one file — the cheapest, most precise form of
+  // the query. Delegating it LOSES that scope: `taskFor` renders a natural-language task ("find X in code") that
+  // carries the root but not the file, so qvts re-runs it across the whole tree. Live: `search_text
+  // q="bIsEditorOnly" path=".../ActorComponent.h"` answered 4 matches instantly and COMPLETE, while the handed
+  // back command was `qvts -p "<depot root>" --json "find bIsEditorOnly in code"` — a whole-depot scan replacing
+  // a single-header read. This is the same rule the Bash and Glob paths already apply (a `find <subdir> -name X`
+  // and a subdir-scoped Glob stay native precisely because delegating would widen them). The token mandate is
+  // about keeping BULK output out of context, and a file-scoped, token-capped answer already does that.
+  const named = String(ti.path ?? ti.file ?? "").trim();
+  if (named) {
+    let isFile = false;
+    try { isFile = fs.statSync(named).isFile(); } catch { /* missing/unreadable → not a file, fall through */ }
+    if (isFile) process.exit(0); // already minimal and correctly scoped → let it through, silently
+  }
+
   const root = rootFor(ti);
   const task = taskFor(suffix, ti).replace(/"/g, "'");     // keep the handed-back command shell-safe
   const safeRoot = String(root).replace(/"/g, "'");


### PR DESCRIPTION
## Not an error — but it exposed one

The red `PreToolUse:mcp__...vs-search__search_text hook error` lines are the orchestrator redirect's **intended** one-shot block (exit 2); re-issuing the same call passes through, which is what the screenshot shows happening. That part works.

What it exposed: **the redirect widens a call that was already scoped.**

```
call:      search_text q="bIsEditorOnly" path=".../Engine/Classes/Components/ActorComponent.h"
handed to: qvts -p "<depot root>" --json "find bIsEditorOnly in code"
```

`rootFor` lifts the project root out of `path`, but `taskFor` renders the task **without the file**. The direct call answered 4 matches instantly and `COMPLETE — bounded scan, every match (4)`; the suggested replacement scans the whole depot.

The Bash path already lets a `find <subdir> -name X` run natively, and the Glob path already lets a subdir-scoped glob through, for precisely this reason. The MCP redirect never got the rule.

## Changes

- A call naming an **existing file** is exempt from the redirect outright (silent pass-through). It is already the cheapest, most precise form of the query, and the token mandate is about keeping *bulk* output out of context — a file-scoped, token-capped answer already does that.
- A call naming a **directory** still delegates, but carries `under <dir>` into the task so qvts searches there rather than the root.
- `VTS_ORCH_SEEN_FILE` overrides the one-shot dedupe store so a test can drive the block without touching the user's real state.

## Review points

- The file check is `fs.statSync(...).isFile()` — a *missing* path falls through and still delegates, which is right: a path that does not exist is not a scope.
- `document_symbols` and a positional `goto_definition`/`find_references` also name a file, so they are exempt too. That is intended — all three are inherently single-file and already capped.
- Guard 100 needs `VTS_ORCHESTRATOR_AWARE=1` in the spawned child: the eval sets that kill switch to `0` for hermeticity (so the maintainer's real qvts install cannot leak into results) and `orchestratorPresent()` checks it **first**. Without the override the redirect never engages and every assertion passes the wrong way — verified by watching the guard pass for the wrong reason before the fix.

## Verification

- `node eval/run.mjs` → `EVAL PASSED`; guard 100 verified **red** when the file exemption is removed, green after restore
- Hook driven end-to-end on the four shapes (file / file+document_symbols / dir / path-less)
- `npm run lint` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
