### PR TITLE
fix(roslyn): preflight the user-set launcher too

### DIFF
--- a/server/backends/index.js
+++ b/server/backends/index.js
@@ -172,7 +172,10 @@ const ROSLYN_DOTNET = ROSLYN_MS_DLL_FOUND ? findRoslynDotnetHost() : "dotnet";
 // So: dll found AND host can run it → MS engine; otherwise → csharp-ls with `--solution`, logged once.
 function roslynHostCanRun(dll, host) {
   if (!dll) return false;
-  if (env("VTS_ROSLYN_CMD")) return true;   // the user picked the launcher; trust it
+  // A user-set launcher is preflighted too — with THAT launcher. If it is a dotnet host it lists the
+  // runtimes and the MS engine proceeds; if it is csharp-ls (or a wrapper around it) `--list-runtimes`
+  // is not a thing it answers, so we correctly take the csharp-ls path with `--solution` instead of
+  // handing it MS-style flags (which it rejects with its usage text).
   const need = roslynRequiredMajor(dll);
   if (!need) return true;
   let out;
@@ -182,7 +185,7 @@ function roslynHostCanRun(dll, host) {
   if (!ok) console.error(`[vs-token-safer] Roslyn LSP dll needs .NET ${need}.x but "${host}" has no such runtime — falling back to csharp-ls (set VTS_ROSLYN_CMD/roslynCmd, or install the runtime, to use the MS engine).`);
   return ok;
 }
-const ROSLYN_MS_DLL = roslynHostCanRun(ROSLYN_MS_DLL_FOUND, ROSLYN_DOTNET) ? ROSLYN_MS_DLL_FOUND : null;
+const ROSLYN_MS_DLL = roslynHostCanRun(ROSLYN_MS_DLL_FOUND, cfgCmd("VTS_ROSLYN_CMD", "roslynCmd", ROSLYN_DOTNET)) ? ROSLYN_MS_DLL_FOUND : null;
 
 const exists = (root, ...names) => names.some((n) => {
   try { return fs.existsSync(path.join(root, n)); } catch { return false; }


### PR DESCRIPTION
## Summary
Follow-up to #252: the runtime preflight now runs with the configured launcher (`VTS_ROSLYN_CMD` / `roslynCmd`) instead of being skipped when one is set.

## Why
#252 trusted a user-set launcher and skipped the preflight — so `VTS_ROSLYN_CMD=<csharp-ls wrapper>` with the VS Code C# dll present still produced MS-style args → csharp-ls usage text → `COMPLETE (0)`. That is exactly the setup the Unity note in the README recommends. Preflighting with the launcher itself sorts both cases: a dotnet host answers `--list-runtimes`, csharp-ls doesn't.

Closes #— (follow-up to #252)

## How verified
- `node --check`, `npx eslint server/backends/index.js`: clean.
- `node eval/test-roslyn-runtime.mjs` → 6 cases ok; `node eval/run.mjs` → EVAL PASSED.
- Manual on the Unity tree from #252 with ONLY `VTS_ROSLYN_CMD=<wrapper>` set (MS dll present, no `VTS_ROSLYN_DLL`): `vts symbol --q <prop>` → `1 symbol(s)`. Before this change the same setup returned usage text / 0.

## Risk / blast radius
Roslyn backend only. Users on the MS engine with no launcher override: unchanged (preflight host is still the auto-detected dotnet). Users who set a dotnet host as launcher: preflight succeeds as before. Users who set csharp-ls as launcher: now correctly routed (previously broken).

## Checklist
- [x] Single, focused change
- [x] `node eval/run.mjs` prints EVAL PASSED (guard from #252 still covers the parser)
- [x] Token win kept
- [x] Docs unchanged (behavior now matches what the README already says)
- [ ] Version bump in the release commit after merge
- [x] No proprietary data or secrets
- [x] Generic / reusable
- [x] `node --check` passes; `claude plugin validate` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQuNpsCXvCjLKeijZh8rz2
